### PR TITLE
Print IP address after a server was created

### DIFF
--- a/cli/server_create.go
+++ b/cli/server_create.go
@@ -71,10 +71,15 @@ func runServerCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	fmt.Printf("Server created with ID: %d\n", result.Server.ID)
+
+	// Print the server's IPv4 address
+	fmt.Printf("IP address: %s\n", result.Server.PublicNet.IPv4.IP.String())
+
+	// Only print the root password if it's not empty,
+	// which is only the case if it wasn't created with an SSH key.
 	if result.RootPassword != "" {
-		fmt.Printf("Server %d created with root password: %s\n", result.Server.ID, result.RootPassword)
-	} else {
-		fmt.Printf("Server %d created\n", result.Server.ID)
+		fmt.Printf("Root password: %s\n", result.RootPassword)
 	}
 
 	return nil

--- a/cli/server_create.go
+++ b/cli/server_create.go
@@ -71,10 +71,8 @@ func runServerCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Server created with ID: %d\n", result.Server.ID)
-
-	// Print the server's IPv4 address
-	fmt.Printf("IP address: %s\n", result.Server.PublicNet.IPv4.IP.String())
+	fmt.Printf("Server %d created\n", result.Server.ID)
+	fmt.Printf("IPv4: %s\n", result.Server.PublicNet.IPv4.IP.String())
 
 	// Only print the root password if it's not empty,
 	// which is only the case if it wasn't created with an SSH key.


### PR DESCRIPTION
The previous output was one line with one (ID) or two (ID and root password) info,
so instead of adding another one to the line, or having two lines with potentially
different amount of info, I also changed the printed output after creating a server.
It's now one short line per info: ID, IP address, optional root password.

Example:

```bash
./hcloud server create --image "ubuntu-16.04" --name "test" --type "cx11"
  10s [====================================================================] 100%
Server created with ID: 920920
Root password: secret
IP address: 123.123.123.123
```

Let me know if you have any improvement suggestions

Closes #107