### PR TITLE
Add zsh tag

### DIFF
--- a/cli/completion.go
+++ b/cli/completion.go
@@ -297,6 +297,8 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	zshInitialization := `
+#compdef hcloud
+
 __hcloud_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand


### PR DESCRIPTION
For zsh to recognize completion file when put into placehttp://zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files, the file in question needs to
include a tag `#compdef name`, [see docs](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Autoloaded-files):

````
When compinit is run, it searches all such files accessible via
fpath/FPATH and reads the first line of each of them. This line
should contain one of the tags described below. Files whose first line
does not start with one of these tags are not considered to be part of
the completion system and will not be treated specially.
````

We stumbled upon this issue at [NixOS](https://github.com/NixOS/nixpkgs/pull/46001#issuecomment-418567160), though I would suspect more projects have this issue unless they do custom patching.