### PR TITLE
Implement missing ssh-key update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## master
+
 * Add `hcloud ssh-key update` command
 
 ## v1.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## master
+* Add `hcloud ssh-key update` command
+
 ## v1.7.0
 
 * Add type filter flag `-t` / `--type` to `image list` command

--- a/cli/sshkey.go
+++ b/cli/sshkey.go
@@ -14,6 +14,7 @@ func newSSHKeyCommand(cli *CLI) *cobra.Command {
 	cmd.AddCommand(
 		newSSHKeyListCommand(cli),
 		newSSHKeyCreateCommand(cli),
+		newSSHKeyUpdateCommand(cli),
 		newSSHKeyDeleteCommand(cli),
 		newSSHKeyDescribeCommand(cli),
 		newSSHKeyAddLabelCommand(cli),

--- a/cli/sshkey_update.go
+++ b/cli/sshkey_update.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/spf13/cobra"
+)
+
+func newSSHKeyUpdateCommand(cli *CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "update [FLAGS] SSHKEY",
+		Short:                 "Update a SSH Key",
+		Args:                  cobra.ExactArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		PreRunE:               cli.ensureToken,
+		RunE:                  cli.wrap(runSSHKeyUpdate),
+	}
+
+	cmd.Flags().String("name", "", "SSH Key name")
+
+	return cmd
+}
+
+func runSSHKeyUpdate(cli *CLI, cmd *cobra.Command, args []string) error {
+	idOrName := args[0]
+	sshKey, _, err := cli.Client().SSHKey.Get(cli.Context, idOrName)
+	if err != nil {
+		return err
+	}
+	if sshKey == nil {
+		return fmt.Errorf("SSH key not found: %s", idOrName)
+	}
+
+	name, _ := cmd.Flags().GetString("name")
+	opts := hcloud.SSHKeyUpdateOpts{
+		Name: name,
+	}
+	if opts.Name == "" {
+		return errors.New("no updates")
+	}
+
+	_, _, err = cli.Client().SSHKey.Update(cli.Context, sshKey, opts)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("SSH Key %s updated\n", sshKey.Name)
+	return nil
+}

--- a/cli/sshkey_update.go
+++ b/cli/sshkey_update.go
@@ -46,6 +46,6 @@ func runSSHKeyUpdate(cli *CLI, cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("SSH Key %s updated\n", sshKey.Name)
+	fmt.Printf("SSH Key %d updated\n", sshKey.ID)
 	return nil
 }

--- a/cli/sshkey_update.go
+++ b/cli/sshkey_update.go
@@ -11,7 +11,7 @@ import (
 func newSSHKeyUpdateCommand(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "update [FLAGS] SSHKEY",
-		Short:                 "Update a SSH Key",
+		Short:                 "Update a SSH key",
 		Args:                  cobra.ExactArgs(1),
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
@@ -19,7 +19,7 @@ func newSSHKeyUpdateCommand(cli *CLI) *cobra.Command {
 		RunE:                  cli.wrap(runSSHKeyUpdate),
 	}
 
-	cmd.Flags().String("name", "", "SSH Key name")
+	cmd.Flags().String("name", "", "SSH key name")
 
 	return cmd
 }
@@ -46,6 +46,6 @@ func runSSHKeyUpdate(cli *CLI, cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("SSH Key %d updated\n", sshKey.ID)
+	fmt.Printf("SSH key %d updated\n", sshKey.ID)
 	return nil
 }


### PR DESCRIPTION
This PR adds the missing ssh-key update command. All other resources have the update command. 