### PR TITLE
Add reverse dns commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## master
 
 * Add `hcloud ssh-key update` command
+* Add `hcloud server set-rdns` command
 
 ## v1.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Add `hcloud ssh-key update` command
 * Add `hcloud server set-rdns` command
+* Add `hcloud floating-ip set-rdns` command
 
 ## v1.7.0
 

--- a/cli/floatingip.go
+++ b/cli/floatingip.go
@@ -23,7 +23,7 @@ func newFloatingIPCommand(cli *CLI) *cobra.Command {
 		newFloatingIPDisableProtectionCommand(cli),
 		newFloatingIPAddLabelCommand(cli),
 		newFloatingIPRemoveLabelCommand(cli),
-		newFloatingIPSetRdnsCommand(cli),
+		newFloatingIPSetRDNSCommand(cli),
 	)
 	return cmd
 }

--- a/cli/floatingip.go
+++ b/cli/floatingip.go
@@ -23,6 +23,7 @@ func newFloatingIPCommand(cli *CLI) *cobra.Command {
 		newFloatingIPDisableProtectionCommand(cli),
 		newFloatingIPAddLabelCommand(cli),
 		newFloatingIPRemoveLabelCommand(cli),
+		newFloatingIPSetRdnsCommand(cli),
 	)
 	return cmd
 }

--- a/cli/floatingip_set_rdns.go
+++ b/cli/floatingip_set_rdns.go
@@ -8,26 +8,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newFloatingIPSetRdnsCommand(cli *CLI) *cobra.Command {
+func newFloatingIPSetRDNSCommand(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "set-rdns [FLAGS] FLOATINGIP",
-		Short:                 "Change reverse dns of a Floating IP",
+		Short:                 "Change reverse DNS of a Floating IP",
 		Args:                  cobra.ExactArgs(1),
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
 		PreRunE:               cli.ensureToken,
-		RunE:                  cli.wrap(runFloatingIPSetRdns),
+		RunE:                  cli.wrap(runFloatingIPSetRDNS),
 	}
 
-	cmd.Flags().StringP("hostname", "r", "", "Primary IP address for which the reverse DNS entry should be set")
+	cmd.Flags().StringP("hostname", "r", "", "Hostname to set as a reverse DNS PTR entry")
 	cmd.MarkFlagRequired("hostname")
 
-	cmd.Flags().StringP("ip", "i", "", "Hostname to set as a reverse DNS PTR entry")
-
+	cmd.Flags().StringP("ip", "i", "", "IP address for which the reverse DNS entry should be set")
 	return cmd
 }
 
-func runFloatingIPSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
+func runFloatingIPSetRDNS(cli *CLI, cmd *cobra.Command, args []string) error {
 	id, err := strconv.Atoi(args[0])
 	if err != nil {
 		return err
@@ -56,7 +55,7 @@ func runFloatingIPSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Reverse DNS from Floating IP %d was changed\n", floatingIP.ID)
+	fmt.Printf("Reverse DNS of Floating IP %d changed\n", floatingIP.ID)
 
 	return nil
 }

--- a/cli/floatingip_set_rdns.go
+++ b/cli/floatingip_set_rdns.go
@@ -38,7 +38,7 @@ func runFloatingIPSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if floatingIP == nil {
-		return fmt.Errorf("Floating IP not found: %s", id)
+		return fmt.Errorf("Floating IP not found: %d", id)
 	}
 
 	ip, _ := cmd.Flags().GetString("ip")

--- a/cli/floatingip_set_rdns.go
+++ b/cli/floatingip_set_rdns.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/spf13/cobra"
+)
+
+func newFloatingIPSetRdnsCommand(cli *CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "set-rdns [FLAGS] FLOATINGIP",
+		Short:                 "Change reverse dns of a Floating IP",
+		Args:                  cobra.ExactArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		PreRunE:               cli.ensureToken,
+		RunE:                  cli.wrap(runFloatingIPSetRdns),
+	}
+
+	cmd.Flags().StringP("hostname", "r", "", "Primary IP address for which the reverse DNS entry should be set")
+	cmd.MarkFlagRequired("hostname")
+
+	cmd.Flags().StringP("ip", "i", "", "Hostname to set as a reverse DNS PTR entry")
+
+	return cmd
+}
+
+func runFloatingIPSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
+	id, err := strconv.Atoi(args[0])
+	if err != nil {
+		return err
+	}
+
+	floatingIP, _, err := cli.Client().FloatingIP.GetByID(cli.Context, id)
+	if err != nil {
+		return err
+	}
+	if floatingIP == nil {
+		return fmt.Errorf("Floating IP not found: %s", id)
+	}
+
+	ip, _ := cmd.Flags().GetString("ip")
+	if ip == "" {
+		ip = floatingIP.IP.String()
+	}
+
+	hostname, _ := cmd.Flags().GetString("hostname")
+	action, _, err := cli.Client().FloatingIP.ChangeDNSPtr(cli.Context, floatingIP, ip, hcloud.String(hostname))
+	if err != nil {
+		return err
+	}
+
+	if err := cli.ActionProgress(cli.Context, action); err != nil {
+		return err
+	}
+
+	fmt.Printf("Reverse DNS from Floating IP %d was changed\n", floatingIP.ID)
+
+	return nil
+}

--- a/cli/server.go
+++ b/cli/server.go
@@ -37,6 +37,7 @@ func newServerCommand(cli *CLI) *cobra.Command {
 		newServerSSHCommand(cli),
 		newServerAddLabelCommand(cli),
 		newServerRemoveLabelCommand(cli),
+		newServerSetRdnsCommand(cli),
 	)
 	return cmd
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -37,7 +37,7 @@ func newServerCommand(cli *CLI) *cobra.Command {
 		newServerSSHCommand(cli),
 		newServerAddLabelCommand(cli),
 		newServerRemoveLabelCommand(cli),
-		newServerSetRdnsCommand(cli),
+		newServerSetRDNSCommand(cli),
 	)
 	return cmd
 }

--- a/cli/server_set_rdns.go
+++ b/cli/server_set_rdns.go
@@ -7,26 +7,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newServerSetRdnsCommand(cli *CLI) *cobra.Command {
+func newServerSetRDNSCommand(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "set-rdns [FLAGS] SERVER",
-		Short:                 "Change reverse dns of a server",
+		Short:                 "Change reverse DNS of a server",
 		Args:                  cobra.ExactArgs(1),
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
 		PreRunE:               cli.ensureToken,
-		RunE:                  cli.wrap(runServerSetRdns),
+		RunE:                  cli.wrap(runServerSetRDNS),
 	}
 
-	cmd.Flags().StringP("hostname", "r", "", "Primary IP address for which the reverse DNS entry should be set")
+	cmd.Flags().StringP("hostname", "r", "", "Hostname to set as a reverse DNS PTR entry")
 	cmd.MarkFlagRequired("hostname")
 
-	cmd.Flags().StringP("ip", "i", "", "Hostname to set as a reverse DNS PTR entry")
+	cmd.Flags().StringP("ip", "i", "", "IP address for which the reverse DNS entry should be set")
 
 	return cmd
 }
 
-func runServerSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
+func runServerSetRDNS(cli *CLI, cmd *cobra.Command, args []string) error {
 	idOrName := args[0]
 	server, _, err := cli.Client().Server.Get(cli.Context, idOrName)
 	if err != nil {
@@ -50,7 +50,7 @@ func runServerSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Reverse DNS from server %d was changed\n", server.ID)
+	fmt.Printf("Reverse DNS of server %d changed\n", server.ID)
 
 	return nil
 }

--- a/cli/server_set_rdns.go
+++ b/cli/server_set_rdns.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/spf13/cobra"
+)
+
+func newServerSetRdnsCommand(cli *CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "set-rdns [FLAGS] SERVER",
+		Short:                 "Change reverse dns of a server",
+		Args:                  cobra.ExactArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		PreRunE:               cli.ensureToken,
+		RunE:                  cli.wrap(runServerSetRdns),
+	}
+
+	cmd.Flags().StringP("hostname", "r", "", "Primary IP address for which the reverse DNS entry should be set")
+	cmd.MarkFlagRequired("hostname")
+
+	cmd.Flags().StringP("ip", "i", "", "Hostname to set as a reverse DNS PTR entry")
+
+	return cmd
+}
+
+func runServerSetRdns(cli *CLI, cmd *cobra.Command, args []string) error {
+	idOrName := args[0]
+	server, _, err := cli.Client().Server.Get(cli.Context, idOrName)
+	if err != nil {
+		return err
+	}
+	if server == nil {
+		return fmt.Errorf("server not found: %s", idOrName)
+	}
+	ip, _ := cmd.Flags().GetString("ip")
+	if ip == "" {
+		ip = server.PublicNet.IPv4.IP.String()
+	}
+
+	hostname, _ := cmd.Flags().GetString("hostname")
+	action, _, err := cli.Client().Server.ChangeDNSPtr(cli.Context, server, ip, hcloud.String(hostname))
+	if err != nil {
+		return err
+	}
+
+	if err := cli.ActionProgress(cli.Context, action); err != nil {
+		return err
+	}
+
+	fmt.Printf("Reverse DNS from server %d was changed\n", server.ID)
+
+	return nil
+}


### PR DESCRIPTION
#131 and #92 

This adds a new command set-rdns for `server` and `floating-ip`. You can now easily set reverse DNS entries. 

When you do not specify an IP, as default IP we will use the ipv4 from the serve. or the address from the floating IP