### PR TITLE
Add `start-after-create` flag to server create cmd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## master
+
+* Add `--start-after-create` flag to `hcloud server create` command
+
 ## v1.8.0
 
 * Add `hcloud ssh-key update` command

--- a/cli/server_create.go
+++ b/cli/server_create.go
@@ -53,7 +53,7 @@ func newServerCreateCommand(cli *CLI) *cobra.Command {
 
 	cmd.Flags().String("user-data-from-file", "", "Read user data from specified file (use - to read from stdin)")
 
-	cmd.Flags().Bool("start-after-create", true, "Start Server right after creation. Defaults to true.")
+	cmd.Flags().Bool("start-after-create", true, "Start server right after creation (default: true)")
 
 	return cmd
 }

--- a/cli/server_create.go
+++ b/cli/server_create.go
@@ -53,6 +53,8 @@ func newServerCreateCommand(cli *CLI) *cobra.Command {
 
 	cmd.Flags().String("user-data-from-file", "", "Read user data from specified file (use - to read from stdin)")
 
+	cmd.Flags().Bool("start-after-create", true, "Start Server right after creation. Defaults to true.")
+
 	return cmd
 }
 
@@ -90,6 +92,7 @@ func optsFromFlags(cli *CLI, flags *pflag.FlagSet) (opts hcloud.ServerCreateOpts
 	location, _ := flags.GetString("location")
 	datacenter, _ := flags.GetString("datacenter")
 	userDataFile, _ := flags.GetString("user-data-from-file")
+	startAfterCreate, _ := flags.GetBool("start-after-create")
 	sshKeys, _ := flags.GetStringSlice("ssh-key")
 
 	opts = hcloud.ServerCreateOpts{
@@ -100,6 +103,7 @@ func optsFromFlags(cli *CLI, flags *pflag.FlagSet) (opts hcloud.ServerCreateOpts
 		Image: &hcloud.Image{
 			Name: image,
 		},
+		StartAfterCreate: &startAfterCreate,
 	}
 
 	if userDataFile != "" {


### PR DESCRIPTION
Reading the [hcloud documentation](https://docs.hetzner.cloud/#servers-create-a-server) I found out that there is a Boolean flag, that one can send, which enables you to choose if the server should start directly after creation.

This is a good feature to include if one wants to install alternate operating systems from the default vm images provided by Hetzner Cloud.