### PR TITLE
Add more optional output columns to resource list commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 * Deprecate and ignore the `--window` flag on `hcloud server enable-backup`
 * Add output columns `type|labels|volumes|protection` to `hcloud server list`
 * Add output columns `labels|protection` to `hcloud volume list`
-* Add output columns `labels|protection` to `hcloud image list`
+* Add output column `labels` to `hcloud image list`
 * Add output column `labels` to `hcloud floating-ip list`
 * Add output column `labels` to `hcloud ssh-key list`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 * Fix creating a volume when server is specified by its name
 * Deprecate and ignore the `--window` flag on `hcloud server enable-backup`
+* Add output columns `type|labels|volumes|protection` to `hcloud server list`
+* Add output columns `labels|protection` to `hcloud volume list`
+* Add output columns `labels|protection` to `hcloud image list`
+* Add output column `labels` to `hcloud floating-ip list`
+* Add output column `labels` to `hcloud ssh-key list`
 
 ## v1.9.1
 

--- a/cli/floatingip_list.go
+++ b/cli/floatingip_list.go
@@ -53,6 +53,10 @@ func init() {
 				protection = append(protection, "delete")
 			}
 			return strings.Join(protection, ", ")
+		})).
+		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
+			floatingIP := obj.(*hcloud.FloatingIP)
+			return parseLabelsToString(floatingIP.Labels)
 		}))
 }
 

--- a/cli/floatingip_list.go
+++ b/cli/floatingip_list.go
@@ -56,7 +56,7 @@ func init() {
 		})).
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			floatingIP := obj.(*hcloud.FloatingIP)
-			return parseLabelsToString(floatingIP.Labels)
+			return labelsToString(floatingIP.Labels)
 		}))
 }
 

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -66,7 +66,7 @@ func init() {
 		})).
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			image := obj.(*hcloud.Image)
-			return parseLabelsToString(image.Labels)
+			return labelsToString(image.Labels)
 		}))
 }
 

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -63,6 +63,10 @@ func init() {
 				protection = append(protection, "delete")
 			}
 			return strings.Join(protection, ", ")
+		})).
+		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
+			image := obj.(*hcloud.Image)
+			return parseLabelsToString(image.Labels)
 		}))
 }
 

--- a/cli/server_list.go
+++ b/cli/server_list.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
-	"github.com/hetznercloud/hcloud-go/hcloud"
-	"github.com/spf13/cobra"
 	"strconv"
 	"strings"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/spf13/cobra"
 )
 
 var serverListTableOutput *tableOutput

--- a/cli/server_list.go
+++ b/cli/server_list.go
@@ -31,7 +31,7 @@ func init() {
 		})).
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			server := obj.(*hcloud.Server)
-			return parseLabelsToString(server.Labels)
+			return labelsToString(server.Labels)
 		})).
 		AddFieldOutputFn("type", fieldOutputFn(func(obj interface{}) string {
 			server := obj.(*hcloud.Server)

--- a/cli/server_list.go
+++ b/cli/server_list.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
+	"strconv"
+	"strings"
 )
 
 var serverListTableOutput *tableOutput
@@ -25,6 +27,34 @@ func init() {
 		AddFieldOutputFn("location", fieldOutputFn(func(obj interface{}) string {
 			server := obj.(*hcloud.Server)
 			return server.Datacenter.Location.Name
+		})).
+		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
+			server := obj.(*hcloud.Server)
+			return parseLabelsToString(server.Labels)
+		})).
+		AddFieldOutputFn("type", fieldOutputFn(func(obj interface{}) string {
+			server := obj.(*hcloud.Server)
+			return server.ServerType.Name
+		})).
+		AddFieldOutputFn("volumes", fieldOutputFn(func(obj interface{}) string {
+			server := obj.(*hcloud.Server)
+			var volumes []string
+			for _, volume := range server.Volumes {
+				volumeID := strconv.Itoa(volume.ID)
+				volumes = append(volumes, volumeID)
+			}
+			return strings.Join(volumes, ", ")
+		})).
+		AddFieldOutputFn("protection", fieldOutputFn(func(obj interface{}) string {
+			server := obj.(*hcloud.Server)
+			var protection []string
+			if server.Protection.Delete {
+				protection = append(protection, "delete")
+			}
+			if server.Protection.Rebuild {
+				protection = append(protection, "rebuild")
+			}
+			return strings.Join(protection, ", ")
 		}))
 }
 

--- a/cli/sshkey_list.go
+++ b/cli/sshkey_list.go
@@ -12,7 +12,7 @@ func init() {
 		AddAllowedFields(hcloud.SSHKey{}).
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			sshKey := obj.(*hcloud.SSHKey)
-			return parseLabelsToString(sshKey.Labels)
+			return labelsToString(sshKey.Labels)
 		}))
 }
 

--- a/cli/sshkey_list.go
+++ b/cli/sshkey_list.go
@@ -9,7 +9,11 @@ var sshKeyListTableOutput *tableOutput
 
 func init() {
 	sshKeyListTableOutput = newTableOutput().
-		AddAllowedFields(hcloud.SSHKey{})
+		AddAllowedFields(hcloud.SSHKey{}).
+		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
+			sshKey := obj.(*hcloud.SSHKey)
+			return parseLabelsToString(sshKey.Labels)
+		}))
 }
 
 func newSSHKeyListCommand(cli *CLI) *cobra.Command {

--- a/cli/util.go
+++ b/cli/util.go
@@ -74,3 +74,15 @@ func addListOutputFlag(cmd *cobra.Command, columns []string) {
 func splitLabel(label string) []string {
 	return strings.SplitN(label, "=", 2)
 }
+
+func parseLabelsToString(labels map[string]string) string {
+	var labelsString []string
+	for key, value := range labels {
+		if value == "" {
+			labelsString = append(labelsString, fmt.Sprintf("%s", key))
+		} else {
+			labelsString = append(labelsString, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+	return strings.Join(labelsString, ", ")
+}

--- a/cli/util.go
+++ b/cli/util.go
@@ -75,11 +75,11 @@ func splitLabel(label string) []string {
 	return strings.SplitN(label, "=", 2)
 }
 
-func parseLabelsToString(labels map[string]string) string {
+func labelsToString(labels map[string]string) string {
 	var labelsString []string
 	for key, value := range labels {
 		if value == "" {
-			labelsString = append(labelsString, fmt.Sprintf("%s", key))
+			labelsString = append(labelsString, key)
 		} else {
 			labelsString = append(labelsString, fmt.Sprintf("%s=%s", key, value))
 		}

--- a/cli/volume_list.go
+++ b/cli/volume_list.go
@@ -40,7 +40,7 @@ func init() {
 		})).
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			volume := obj.(*hcloud.Volume)
-			return parseLabelsToString(volume.Labels)
+			return labelsToString(volume.Labels)
 		}))
 }
 

--- a/cli/volume_list.go
+++ b/cli/volume_list.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/dustin/go-humanize"
 	"github.com/hetznercloud/hcloud-go/hcloud"
@@ -28,6 +29,18 @@ func init() {
 		AddFieldOutputFn("location", fieldOutputFn(func(obj interface{}) string {
 			volume := obj.(*hcloud.Volume)
 			return volume.Location.Name
+		})).
+		AddFieldOutputFn("protection", fieldOutputFn(func(obj interface{}) string {
+			volume := obj.(*hcloud.Volume)
+			var protection []string
+			if volume.Protection.Delete {
+				protection = append(protection, "delete")
+			}
+			return strings.Join(protection, ", ")
+		})).
+		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
+			volume := obj.(*hcloud.Volume)
+			return parseLabelsToString(volume.Labels)
 		}))
 }
 


### PR DESCRIPTION
With this PR more optional output columns are added to the resource list commands.

`hcloud server list`
+ type
+ labels
+ volumes
+ protection

`hcloud volume list`
+ labels
+ protection

`hcloud image list`
+ labels
(protection already exists) 

`hcloud floating-ip list`
+ labels
(protection already exists) 

`hcloud ssh-key list`
+ labels


Issue: #145 