### PR TITLE
Load context from .hcloud-context file

### DIFF
--- a/cmd/hcloud/main.go
+++ b/cmd/hcloud/main.go
@@ -30,6 +30,7 @@ func main() {
 		}
 	}
 
+	c.ReadContextFile()
 	c.ReadEnv()
 
 	if err := c.RootCommand.Execute(); err != nil {


### PR DESCRIPTION
When `hcloud` is invoked and there is a file called `.hcloud-context` in the current working directory that contains the name of a context, that context is automatically activated.

However, similar functionality can be achieved by using third-party tools like [direnv](https://direnv.net) which set per-directory environment variables. By configuring the `HCLOUD_CONTEXT` variable, you basically end up with the same effect as `.hcloud-context`. As a bonus, you could also set `HCLOUD_CONFIG` and `HCLOUD_TOKEN`.

Features has been requested in #154.

## TODO

* [ ] Add changelog line