### PR TITLE
Add -g/--get option to "server describe" command.

### DIFF
--- a/cli/server_describe.go
+++ b/cli/server_describe.go
@@ -17,6 +17,7 @@ func newServerDescribeCommand(cli *CLI) *cobra.Command {
 		PreRunE:               cli.ensureToken,
 		RunE:                  cli.wrap(runServerDescribe),
 	}
+	cmd.Flags().StringP("get", "g", "", "Get parameter")
 	return cmd
 }
 
@@ -28,6 +29,18 @@ func runServerDescribe(cli *CLI, cmd *cobra.Command, args []string) error {
 	}
 	if server == nil {
 		return fmt.Errorf("server not found: %s", idOrName)
+	}
+
+	parameter, _ := cmd.Flags().GetString("get")
+	if parameter == "public_net.ipv4.ip" {
+		fmt.Printf("%s\n", server.PublicNet.IPv4.IP)
+		return nil
+	}
+
+	// more parameters can be added here
+
+	if parameter != "" {
+		return fmt.Errorf("unknown parameter: %s", parameter)
 	}
 
 	fmt.Printf("ID:\t\t%d\n", server.ID)


### PR DESCRIPTION
This allows getting parameters of a server in a way that's easy to use in scripts. The normal "server describe" command outputs the data in a human readable form, but in (shell) scripts it would be much easier to just have single parameters printed.

This pull request is preliminary, it only implements the `public_net.ipv4.ip` parameter, but I can extend this, if you think this is going in the right direction.

An alternative would be to implement this as a new command, something like "server get" or so.