### PR TITLE
Allow option --user-data-from-file multiple times on "server create".

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Add support for executing commands via `hcloud server ssh <server> <command>`
 * Make overriding context via `HCLOUD_CONTEXT` work
+* Add support for JSON and Go template output
+* Add support for multiple user data files
 
 ## v1.11.0
 


### PR DESCRIPTION
The option --user-data-from-file can now be used multiple times on a
"server create" command. If this option is specified more than once, all
files will be opened and put into a multipart MIME message which will
then be send to the API. The cloud-init can understand this MIME
message and unpack it.