### PR TITLE
Remove leading newline in zsh completion

### DIFF
--- a/cli/completion.go
+++ b/cli/completion.go
@@ -319,8 +319,8 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 }
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
-	zshInitialization := `
-#compdef hcloud
+	zshInitialization := 
+`#compdef hcloud
 
 __hcloud_bash_source() {
 	alias shopt=':'

--- a/cli/completion.go
+++ b/cli/completion.go
@@ -319,8 +319,7 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 }
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
-	zshInitialization := 
-`#compdef hcloud
+	zshInitialization := `#compdef hcloud
 
 __hcloud_bash_source() {
 	alias shopt=':'


### PR DESCRIPTION
This fixes an issue with zsh completion.
A leading newline prevents zsh completion definitions from autoloading.
See https://github.com/hetznercloud/cli/issues/177 for details.