### PR TITLE
Add option to label servers, volumes, images, floating ips and ssh keys on creation

### DIFF
--- a/cli/floatingip_create.go
+++ b/cli/floatingip_create.go
@@ -35,6 +35,9 @@ func newFloatingIPCreateCommand(cli *CLI) *cobra.Command {
 	cmd.Flag("server").Annotations = map[string][]string{
 		cobra.BashCompCustom: {"__hcloud_server_names"},
 	}
+
+	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
+
 	return cmd
 }
 
@@ -59,10 +62,12 @@ func runFloatingIPCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 	description, _ := cmd.Flags().GetString("description")
 	homeLocation, _ := cmd.Flags().GetString("home-location")
 	serverNameOrID, _ := cmd.Flags().GetString("server")
+	labels, _ := cmd.Flags().GetStringToString("label")
 
 	opts := hcloud.FloatingIPCreateOpts{
 		Type:        hcloud.FloatingIPType(typ),
 		Description: &description,
+		Labels:      labels,
 	}
 	if name != "" {
 		opts.Name = &name

--- a/cli/network_create.go
+++ b/cli/network_create.go
@@ -25,15 +25,20 @@ func newNetworkCreateCommand(cli *CLI) *cobra.Command {
 	cmd.Flags().IPNet("ip-range", net.IPNet{}, "Network IP range")
 	cmd.MarkFlagRequired("ip-range")
 
+	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
+
 	return cmd
 }
 
 func runNetworkCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 	name, _ := cmd.Flags().GetString("name")
 	ipRange, _ := cmd.Flags().GetIPNet("ip-range")
+	labels, _ := cmd.Flags().GetStringToString("label")
+
 	opts := hcloud.NetworkCreateOpts{
 		Name:    name,
 		IPRange: &ipRange,
+		Labels:  labels,
 	}
 
 	network, _, err := cli.Client().Network.Create(cli.Context, opts)

--- a/cli/server_create.go
+++ b/cli/server_create.go
@@ -56,6 +56,8 @@ func newServerCreateCommand(cli *CLI) *cobra.Command {
 		cobra.BashCompCustom: {"__hcloud_sshkey_names"},
 	}
 
+	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
+
 	cmd.Flags().StringArray("user-data-from-file", []string{}, "Read user data from specified file (use - to read from stdin)")
 
 	cmd.Flags().Bool("start-after-create", true, "Start server right after creation (default: true)")
@@ -175,6 +177,7 @@ func optsFromFlags(cli *CLI, flags *pflag.FlagSet) (opts hcloud.ServerCreateOpts
 	userDataFiles, _ := flags.GetStringArray("user-data-from-file")
 	startAfterCreate, _ := flags.GetBool("start-after-create")
 	sshKeys, _ := flags.GetStringSlice("ssh-key")
+	labels, _ := flags.GetStringToString("label")
 	volumes, _ := flags.GetStringSlice("volume")
 	networks, _ := flags.GetStringSlice("network")
 	automount, _ := flags.GetBool("automount")
@@ -187,6 +190,7 @@ func optsFromFlags(cli *CLI, flags *pflag.FlagSet) (opts hcloud.ServerCreateOpts
 		Image: &hcloud.Image{
 			Name: image,
 		},
+		Labels:           labels,
 		StartAfterCreate: &startAfterCreate,
 		Automount:        &automount,
 	}

--- a/cli/server_create_image.go
+++ b/cli/server_create_image.go
@@ -24,6 +24,9 @@ func newServerCreateImageCommand(cli *CLI) *cobra.Command {
 	cmd.MarkFlagRequired("type")
 
 	cmd.Flags().String("description", "", "Image description")
+
+	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
+
 	return cmd
 }
 
@@ -53,9 +56,12 @@ func runServerCreateImage(cli *CLI, cmd *cobra.Command, args []string) error {
 
 	description, _ := cmd.Flags().GetString("description")
 
+	labels, _ := cmd.Flags().GetStringToString("label")
+
 	opts := &hcloud.ServerCreateImageOpts{
 		Type:        hcloud.ImageType(imageType),
 		Description: hcloud.String(description),
+		Labels:      labels,
 	}
 	result, _, err := cli.Client().Server.CreateImage(cli.Context, server, opts)
 	if err != nil {

--- a/cli/sshkey_create.go
+++ b/cli/sshkey_create.go
@@ -23,6 +23,7 @@ func newSSHKeyCreateCommand(cli *CLI) *cobra.Command {
 	cmd.Flags().String("name", "", "Key name")
 	cmd.Flags().String("public-key", "", "Public key")
 	cmd.Flags().String("public-key-from-file", "", "Path to file containing public key")
+	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
 	return cmd
 }
 
@@ -44,6 +45,7 @@ func runSSHKeyCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 	name, _ := cmd.Flags().GetString("name")
 	publicKey, _ := cmd.Flags().GetString("public-key")
 	publicKeyFile, _ := cmd.Flags().GetString("public-key-from-file")
+	labels, _ := cmd.Flags().GetStringToString("label")
 
 	if publicKeyFile != "" {
 		var (
@@ -64,6 +66,7 @@ func runSSHKeyCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 	opts := hcloud.SSHKeyCreateOpts{
 		Name:      name,
 		PublicKey: publicKey,
+		Labels:    labels,
 	}
 	sshKey, _, err := cli.Client().SSHKey.Create(cli.Context, opts)
 	if err != nil {

--- a/cli/volume_create.go
+++ b/cli/volume_create.go
@@ -36,6 +36,9 @@ func newVolumeCreateCommand(cli *CLI) *cobra.Command {
 
 	cmd.Flags().Bool("automount", false, "Automount volume after attach (server must be provided)")
 	cmd.Flags().String("format", "", "Format volume after creation (automount must be enabled)")
+
+	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
+
 	return cmd
 }
 
@@ -46,10 +49,12 @@ func runVolumeCreate(cli *CLI, cmd *cobra.Command, args []string) error {
 	location, _ := cmd.Flags().GetString("location")
 	automount, _ := cmd.Flags().GetBool("automount")
 	format, _ := cmd.Flags().GetString("format")
+	labels, _ := cmd.Flags().GetStringToString("label")
 
 	opts := hcloud.VolumeCreateOpts{
-		Name: name,
-		Size: size,
+		Name:   name,
+		Size:   size,
+		Labels: labels,
 	}
 
 	if location != "" {


### PR DESCRIPTION
This way, servers can be labeled at creation time.

Example usage:

```
hcloud server create \
	--image=$image \
	--datacenter=nbg1-dc3 \
	--type=cx21 \
	--label project=cloud --label stage=test \
	--name=db-replica-1
```