### PR TITLE
Allow the created field to be within the list responses

### DIFF
--- a/cli/floatingip_list.go
+++ b/cli/floatingip_list.go
@@ -144,5 +144,9 @@ func describeFloatingIPListTableOutput(cli *CLI) *tableOutput {
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			floatingIP := obj.(*hcloud.FloatingIP)
 			return labelsToString(floatingIP.Labels)
+		})).
+		AddFieldOutputFn("created", fieldOutputFn(func(obj interface{}) string {
+			floatingIP := obj.(*hcloud.FloatingIP)
+			return datetime(floatingIP.Created)
 		}))
 }

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -144,5 +144,9 @@ func describeImageListTableOutput(cli *CLI) *tableOutput {
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			image := obj.(*hcloud.Image)
 			return labelsToString(image.Labels)
+		})).
+		AddFieldOutputFn("created", fieldOutputFn(func(obj interface{}) string {
+			image := obj.(*hcloud.Image)
+			return datetime(image.Created)
 		}))
 }

--- a/cli/network_list.go
+++ b/cli/network_list.go
@@ -127,5 +127,9 @@ func describeNetworkListTableOutput(cli *CLI) *tableOutput {
 				protection = append(protection, "delete")
 			}
 			return strings.Join(protection, ", ")
+		})).
+		AddFieldOutputFn("created", fieldOutputFn(func(obj interface{}) string {
+			network := obj.(*hcloud.Network)
+			return datetime(network.Created)
 		}))
 }

--- a/cli/server_list.go
+++ b/cli/server_list.go
@@ -193,5 +193,9 @@ func describeServerListTableOutput(cli *CLI) *tableOutput {
 				protection = append(protection, "rebuild")
 			}
 			return strings.Join(protection, ", ")
+		})).
+		AddFieldOutputFn("created", fieldOutputFn(func(obj interface{}) string {
+			server := obj.(*hcloud.Server)
+			return datetime(server.Created)
 		}))
 }

--- a/cli/sshkey_list.go
+++ b/cli/sshkey_list.go
@@ -14,6 +14,10 @@ func init() {
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			sshKey := obj.(*hcloud.SSHKey)
 			return labelsToString(sshKey.Labels)
+		})).
+		AddFieldOutputFn("created", fieldOutputFn(func(obj interface{}) string {
+			sshKey := obj.(*hcloud.SSHKey)
+			return datetime(sshKey.Created)
 		}))
 }
 

--- a/cli/volume_list.go
+++ b/cli/volume_list.go
@@ -120,5 +120,9 @@ func describeVolumeListTableOutput(cli *CLI) *tableOutput {
 		AddFieldOutputFn("labels", fieldOutputFn(func(obj interface{}) string {
 			volume := obj.(*hcloud.Volume)
 			return labelsToString(volume.Labels)
+		})).
+		AddFieldOutputFn("created", fieldOutputFn(func(obj interface{}) string {
+			volume := obj.(*hcloud.Volume)
+			return datetime(volume.Created)
 		}))
 }


### PR DESCRIPTION
This came out in the Hetzner Forum. A customer wanted to be able to see the creation date within the list response. It turned out that the created date is not available for this list. This MR changes this. 