### PR TITLE
Add command to request a VNC console

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -42,6 +42,7 @@ func newServerCommand(cli *CLI) *cobra.Command {
 		newServerDetachFromNetworkCommand(cli),
 		newServerChangeAliasIPsCommand(cli),
 		newServerIPCommand(cli),
+		newServerRequestConsoleCommand(cli),
 	)
 	return cmd
 }

--- a/cli/server_request_console.go
+++ b/cli/server_request_console.go
@@ -16,10 +16,12 @@ func newServerRequestConsoleCommand(cli *CLI) *cobra.Command {
 		PreRunE:               cli.ensureToken,
 		RunE:                  cli.wrap(runServerRequestConsole),
 	}
+	addOutputFlag(cmd, outputOptionJSON())
 	return cmd
 }
 
 func runServerRequestConsole(cli *CLI, cmd *cobra.Command, args []string) error {
+	outOpts := outputFlagsForCommand(cmd)
 	idOrName := args[0]
 	server, _, err := cli.Client().Server.Get(cli.Context, idOrName)
 	if err != nil {
@@ -36,6 +38,16 @@ func runServerRequestConsole(cli *CLI, cmd *cobra.Command, args []string) error 
 
 	if err := cli.ActionProgress(cli.Context, result.Action); err != nil {
 		return err
+	}
+
+	if outOpts.IsSet("json") {
+		return describeJSON(struct {
+			WSSURL   string
+			Password string
+		}{
+			WSSURL:   result.WSSURL,
+			Password: result.Password,
+		})
 	}
 
 	fmt.Printf("Console for server %d:\n", server.ID)

--- a/cli/server_request_console.go
+++ b/cli/server_request_console.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newServerRequestConsoleCommand(cli *CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "request-console [FLAGS] SERVER",
+		Short:                 "Request a WebSocket VNC console for a server",
+		Args:                  cobra.ExactArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		PreRunE:               cli.ensureToken,
+		RunE:                  cli.wrap(runServerRequestConsole),
+	}
+	return cmd
+}
+
+func runServerRequestConsole(cli *CLI, cmd *cobra.Command, args []string) error {
+	idOrName := args[0]
+	server, _, err := cli.Client().Server.Get(cli.Context, idOrName)
+	if err != nil {
+		return err
+	}
+	if server == nil {
+		return fmt.Errorf("server not found: %s", idOrName)
+	}
+
+	result, _, err := cli.Client().Server.RequestConsole(cli.Context, server)
+	if err != nil {
+		return err
+	}
+
+	if err := cli.ActionProgress(cli.Context, result.Action); err != nil {
+		return err
+	}
+
+	fmt.Printf("Console for server %d:\n", server.ID)
+	fmt.Printf("WebSocket URL: %s\n", result.WSSURL)
+	fmt.Printf("VNC Password: %s\n", result.Password)
+	return nil
+}


### PR DESCRIPTION
Add command to request a VNC console. Also includes a proxy translating WebSocket to a normal TCP socket using the `-l` flag. This allows a normal VNC viewer to connect to the console by connecting to localhost:5900.

This also updates the version of the hcloud library to make use of the console API added in https://github.com/hetznercloud/hcloud-go/pull/134

Preview:
![screenshot](https://user-images.githubusercontent.com/419104/83972835-f1685800-a8d1-11ea-8965-5510638b9341.png)