### PR TITLE
Fix context list nil pointer when no active context was given.

### DIFF
--- a/cli/context_list.go
+++ b/cli/context_list.go
@@ -57,7 +57,7 @@ func runContextList(cli *CLI, cmd *cobra.Command, args []string) error {
 			Token:  context.Token,
 			Active: " ",
 		}
-		if cli.Config.ActiveContext.Name == context.Name {
+		if cli.Config.ActiveContext != nil && cli.Config.ActiveContext.Name == context.Name {
 			presentation.Active = "*"
 		}
 


### PR DESCRIPTION
Closes #248 

When you run `hcloud context delete <ActiveContextName>` we set `cli.Config.ActiveContext = nil` (https://github.com/hetznercloud/cli/blob/master/cli/context_delete.go#L28). This leads in the `hcloud context list` to the problem that `cli.Config.ActiveContext`can be nil, but we try to access the `Name` (https://github.com/hetznercloud/cli/blob/master/cli/context_list.go#L60)