### PR TITLE
Add pricing per location to load-balancer-type describe and server-type describe

### DIFF
--- a/cli/load_balancer_type_describe.go
+++ b/cli/load_balancer_type_describe.go
@@ -52,6 +52,13 @@ func loadBalancerTypeDescribeText(cli *CLI, loadBalancerType *hcloud.LoadBalance
 	fmt.Printf("Max Connections:\t\t%d\n", loadBalancerType.MaxConnections)
 	fmt.Printf("Max Targets:\t\t\t%d\n", loadBalancerType.MaxTargets)
 	fmt.Printf("Max assigned Certificates:\t%d\n", loadBalancerType.MaxAssignedCertificates)
+
+	fmt.Printf("Pricings per Location:\n")
+	for _, price := range loadBalancerType.Pricings {
+		fmt.Printf("  - Location:\t%s:\n", price.Location.Name)
+		fmt.Printf("    Hourly:\t€ %s\n", price.Hourly.Gross)
+		fmt.Printf("    Monthly:\t€ %s\n", price.Monthly.Gross)
+	}
 	return nil
 }
 

--- a/cli/servertypes_describe.go
+++ b/cli/servertypes_describe.go
@@ -53,6 +53,13 @@ func serverTypeDescribeText(cli *CLI, serverType *hcloud.ServerType) error {
 	fmt.Printf("Memory:\t\t%.1f GB\n", serverType.Memory)
 	fmt.Printf("Disk:\t\t%d GB\n", serverType.Disk)
 	fmt.Printf("Storage Type:\t%s\n", serverType.StorageType)
+
+	fmt.Printf("Pricings per Location:\n")
+	for _, price := range serverType.Pricings {
+		fmt.Printf("  - Location:\t%s:\n", price.Location.Name)
+		fmt.Printf("    Hourly:\t€ %s\n", price.Hourly.Gross)
+		fmt.Printf("    Monthly:\t€ %s\n", price.Monthly.Gross)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is a way to solve #241. Showing the prices in the list endpoint might be a bit difficult as there may be different prices per location, so this adds the data to the `describe` endpoint, where it might help most of our customers if they are using the CLI.

I'm not quite sure if this is the best solution, so @thcyron and @LD250 what do you think about it?