### PR TITLE
Switch bats to maintained bats-core (CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
         run: ./script/build.bash linux amd64 test-build; mv dist/hcloud* cmd/hcloud/hcloud
       - name: Run bats
         run: |
-          git clone --depth 1 https://github.com/sstephenson/bats.git
+          git clone --depth 1 https://github.com/bats-core/bats-core.git bats
           PATH="./cmd/hcloud:$PATH" bats/bin/bats test


### PR DESCRIPTION
sstephenson/bats is not maintained any longer [1].

it spilled errors when running tests. replacing it with
bats-core/bats-core worked out of the box.

[1]: https://github.com/sstephenson/bats/pull/269 etc.