### PR TITLE
Cant add elements to zero-length slice just by assigning them, fix with append

### DIFF
--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -81,7 +81,7 @@ func runAddRule(cli *state.State, cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("invalid CIDR on index %d : %s", i, err)
 			}
-			rule.DestinationIPs[i] = *n
+			rule.DestinationIPs = append(rule.DestinationIPs, *n)
 		}
 	case hcloud.FirewallRuleDirectionIn:
 		rule.SourceIPs = make([]net.IPNet, 0, len(sourceIPs))
@@ -90,7 +90,7 @@ func runAddRule(cli *state.State, cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("invalid CIDR on index %d : %s", i, err)
 			}
-			rule.SourceIPs[i] = *n
+			rule.SourceIPs = append(rule.SourceIPs, *n)
 		}
 	}
 


### PR DESCRIPTION
The slice `rule.SourceIPs` was defined with zero length. Either need to define slice with len(sourceIPs) like this: `rule.SourceIPs = make([]net.IPNet, len(sourceIPs))`
or to leave it zero-length and len(sourceIPs) capacity and use append() to add elements.
I choose the second approach because I have no time to check if <nil> elements can affect API interaction.
Fixes #302