### PR TITLE
Fix panic: runtime error: index out of range [0] with length 0 in firewall replace-rules

### DIFF
--- a/internal/cmd/firewall/replace_rules.go
+++ b/internal/cmd/firewall/replace_rules.go
@@ -69,7 +69,7 @@ func runFirewallReplaceRules(cli *state.State, cmd *cobra.Command, args []string
 		}
 		switch d {
 		case hcloud.FirewallRuleDirectionOut:
-			r.DestinationIPs = make([]net.IPNet, 0, len(rule.DestinationIPs))
+			r.DestinationIPs = make([]net.IPNet, len(rule.DestinationIPs))
 			for i, ip := range rule.DestinationIPs {
 				_, n, err := net.ParseCIDR(ip)
 				if err != nil {
@@ -78,7 +78,7 @@ func runFirewallReplaceRules(cli *state.State, cmd *cobra.Command, args []string
 				r.DestinationIPs[i] = *n
 			}
 		case hcloud.FirewallRuleDirectionIn:
-			r.SourceIPs = make([]net.IPNet, 0, len(rule.SourceIPs))
+			r.SourceIPs = make([]net.IPNet, len(rule.SourceIPs))
 			for i, ip := range rule.SourceIPs {
 				_, n, err := net.ParseCIDR(ip)
 				if err != nil {


### PR DESCRIPTION
Fixes #308
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>