### PR TITLE
firewall: Add empty slices for respective direction instead of nil-slices

### DIFF
--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -73,6 +73,7 @@ func runDeleteRule(cli *state.State, cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("destination ips error on index %d: %s", i, err)
 			}
 			rule.DestinationIPs[i] = *n
+			rule.SourceIPs = make([]net.IPNet, 0)
 		}
 	case hcloud.FirewallRuleDirectionIn:
 		rule.SourceIPs = make([]net.IPNet, len(sourceIPs))
@@ -81,6 +82,7 @@ func runDeleteRule(cli *state.State, cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("source ips error on index %d: %s", i, err)
 			}
+			rule.DestinationIPs = make([]net.IPNet, 0)
 			rule.SourceIPs[i] = *n
 		}
 	}


### PR DESCRIPTION
As reported in hetznercloud#320, firewall rules can not be deleted because they
would not exist even if they are shown in "firewall describe".
This behaviour was correct because reflect.DeepEqual also compares if a
slice is empty or nil.
The slices DestinationIPs and SourceIPs are empty slices in an existing
firewall rule. However, the temporary FirewallRule object had slices
that were nil.

To fix this problem, the simple solution is to create an empty IPNet slice
for the respective direction (DestinationIPs for the direction "in", and
SourceIPs for the direction "out").

Signed-off-by: Tom Siewert <tom.siewert@hetzner.com>
