### PR TITLE
firewall: Require port for TCP and UDP and deny for ICMP

### DIFF
--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -65,6 +65,18 @@ func runAddRule(cli *state.State, cmd *cobra.Command, args []string) error {
 		rule.Port = hcloud.String(port)
 	}
 
+	switch rule.Protocol {
+	case hcloud.FirewallRuleProtocolTCP:
+	case hcloud.FirewallRuleProtocolUDP:
+		if port == "" {
+			return fmt.Errorf("port is required")
+		}
+	default:
+		if port != "" {
+			return fmt.Errorf("port is not allowed for this protocol")
+		}
+	}
+
 	switch d {
 	case hcloud.FirewallRuleDirectionOut:
 		rule.DestinationIPs = make([]net.IPNet, len(destinationIPs))

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -64,6 +64,19 @@ func runDeleteRule(cli *state.State, cmd *cobra.Command, args []string) error {
 	if port != "" {
 		rule.Port = hcloud.String(port)
 	}
+
+	switch rule.Protocol {
+	case hcloud.FirewallRuleProtocolTCP:
+	case hcloud.FirewallRuleProtocolUDP:
+		if port == "" {
+			return fmt.Errorf("port is required")
+		}
+	default:
+		if port != "" {
+			return fmt.Errorf("port is not allowed for this protocol")
+		}
+	}
+
 	switch d {
 	case hcloud.FirewallRuleDirectionOut:
 		rule.DestinationIPs = make([]net.IPNet, len(destinationIPs))


### PR DESCRIPTION
In the last few days I have seen some customers which have issues with creating firewall rules because they do not add the port(-range) when using TCP or UDP as protocol. The error message `invalid_input` is not immediately understandable that in this case the port is missing.