### PR TITLE
internal/cmd: Remove redundant DescribeJSON from JSONSchema

### DIFF
--- a/internal/cmd/certificate/list.go
+++ b/internal/cmd/certificate/list.go
@@ -97,6 +97,6 @@ var listCmd = base.ListCmd{
 			certSchemas = append(certSchemas, certSchema)
 		}
 
-		return util.DescribeJSON(certSchemas)
+		return certSchemas
 	},
 }

--- a/internal/cmd/datacenter/list.go
+++ b/internal/cmd/datacenter/list.go
@@ -43,6 +43,6 @@ var listCmd = base.ListCmd{
 			certSchemas = append(certSchemas, util.DatacenterToSchema(*cert))
 		}
 
-		return util.DescribeJSON(certSchemas)
+		return certSchemas
 	},
 }

--- a/internal/cmd/server/list.go
+++ b/internal/cmd/server/list.go
@@ -172,6 +172,6 @@ var ListCmd = base.ListCmd{
 			}
 			serversSchema = append(serversSchema, serverSchema)
 		}
-		return util.DescribeJSON(serversSchema)
+		return serversSchema
 	},
 }


### PR DESCRIPTION
The certificate, datacenter and server list command returned a twice
encoded JSON object and therefore caused a `null` output at the end of
e.g. `hcloud server list -o json`

Signed-off-by: Tom Siewert <tom@siewert.io>