### PR TITLE
Use go 1.16 again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.16
       - name: Print Go Version
         run: go version
       - name: Import GPG key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17]
+        go-version: [1.16]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v2

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.16
       - name: Print Go Version
         run: go version
       - name: Decrypt Secrets

--- a/go.mod
+++ b/go.mod
@@ -17,21 +17,4 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 )
 
-require (
-	github.com/VividCortex/ewma v1.1.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.7.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/mattn/go-colorable v0.1.2 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/mattn/go-runewidth v0.0.7 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-	golang.org/x/tools v0.1.1 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)
-
-go 1.17
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hetznercloud/hcloud-go v1.30.0 h1:Q8Y+YHgum6XvyVfz2IFp2pLWtupEFbykl12D5TwdBig=
-github.com/hetznercloud/hcloud-go v1.30.0/go.mod h1:2C5uMtBiMoFr3m7lBFPf7wXTdh33CevmZpQIIDPGYJI=
 github.com/hetznercloud/hcloud-go v1.31.0 h1:p5Irqrki5KdoNe4usT5okvVlCTARlD/BRX92mf2ktxU=
 github.com/hetznercloud/hcloud-go v1.31.0/go.mod h1:Gevl2WnfGL4Z7Th6dB3BrPYWG3NpefmjkIXeToYGDJs=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=


### PR DESCRIPTION
goreleaser has currently a bug with go 1.17, that prevents build on darwin/arm64. Therefore we revert those changes

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>