### PR TITLE
rename command flag to be more explicit

### DIFF
--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -32,7 +32,7 @@ func newAddServiceCommand(cli *state.State) *cobra.Command {
 	cmd.Flags().String("http-cookie-name", "", "Sticky Sessions: Cookie Name we set")
 	cmd.Flags().Duration("http-cookie-lifetime", 0, "Sticky Sessions: Lifetime of the cookie")
 	cmd.Flags().IntSlice("http-certificates", []int{}, "ID of Certificates which are attached to this Load Balancer")
-	cmd.Flags().Bool("http-redirect-http", false, "Redirect all traffic on port 80 to port 443")
+	cmd.Flags().Bool("http-redirect-https", false, "Redirect all traffic on port 80 to port 443")
 
 	return cmd
 }
@@ -87,7 +87,7 @@ func runAddService(cli *state.State, cmd *cobra.Command, args []string) error {
 	httpCookieName, _ := cmd.Flags().GetString("http-cookie-name")
 	httpCookieLifetime, _ := cmd.Flags().GetDuration("http-cookie-lifetime")
 	httpCertificates, _ := cmd.Flags().GetIntSlice("http-certificates")
-	httpRedirect, _ := cmd.Flags().GetBool("http-redirect-http")
+	httpRedirect, _ := cmd.Flags().GetBool("http-redirect-https")
 
 	loadBalancer, _, err := cli.Client().LoadBalancer.Get(cli.Context, idOrName)
 	if err != nil {

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -29,7 +29,7 @@ func newUpdateServiceCommand(cli *state.State) *cobra.Command {
 
 	cmd.Flags().String("protocol", "", "The protocol the health check is performed over")
 	cmd.Flags().Bool("proxy-protocol", false, "Enable or disable (with --proxy-protocol=false) Proxy Protocol")
-	cmd.Flags().Bool("http-redirect-http", false, "Enable or disable redirect all traffic on port 80 to port 443")
+	cmd.Flags().Bool("http-redirect-https", false, "Enable or disable redirect all traffic on port 80 to port 443")
 
 	cmd.Flags().Bool("http-sticky-sessions", false, "Enable or disable (with --http-sticky-sessions=false) Sticky Sessions")
 	cmd.Flags().String("http-cookie-name", "", "Sticky Sessions: Cookie Name which will be set")
@@ -87,8 +87,8 @@ func runUpdateService(cli *state.State, cmd *cobra.Command, args []string) error
 		opts.Proxyprotocol = hcloud.Bool(proxyProtocol)
 	}
 	// HTTP
-	if cmd.Flag("http-redirect-http").Changed {
-		redirectHTTP, _ := cmd.Flags().GetBool("http-redirect-http")
+	if cmd.Flag("http-redirect-https").Changed {
+		redirectHTTP, _ := cmd.Flags().GetBool("http-redirect-https")
 		opts.HTTP.RedirectHTTP = hcloud.Bool(redirectHTTP)
 	}
 	if cmd.Flag("http-sticky-sessions").Changed {


### PR DESCRIPTION
the command flag `--http-redirect-http` is used to redirect traffic from port 80 to 443, so a more obvious name for the flag would be `--http-redirect-https` to be descriptive for what it does.