### PR TITLE
Add Fedora to the list of third-party providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ is still the recommended install method.
 | Void Linux            | `xbps-install -Syu hcloud`                        |
 | Gentoo Linux          | `emerge hcloud`                                   |
 | Alpine Linux          | `apk add hcloud`                                  |
+| Fedora {35|36|37}     | `dnf install hcloud`                              |
 
 ### Build manually
 


### PR DESCRIPTION
I wanted to use `hcloud` on my Fedora box and I usually prefer to
install packages from distro repos - if they are reasonably recent so
even though Fedora was not listed as providing said package, I went
ahead and ran `dnf search hcloud` to, well, search for `hcloud`.
apparently, `hcloud` *is* indeed packaged[1] for Fedora.
it might help other users if they also learn about it here.

[1]: https://koji.fedoraproject.org/koji/packageinfo?packageID=35663

Signed-off-by: wULLSnpAXbWZGYDYyhWTKKspEQoaYxXyhoisqHfsettings <a_mirre@utb.cz>