### PR TITLE
fix(readme): correct messed-up columns ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ is still the recommended install method.
 | Void Linux            | `xbps-install -Syu hcloud`                        |
 | Gentoo Linux          | `emerge hcloud`                                   |
 | Alpine Linux          | `apk add hcloud`                                  |
-| Fedora {35|36|37}     | `dnf install hcloud`                              |
+| Fedora {35,36,37}     | `dnf install hcloud`                              |
 
 ### Build manually
 


### PR DESCRIPTION
...after adding Fedora to the list of third-party package sources.

this fixes an issue inadvertently introduced by my previous commit (see
https://github.com/hetznercloud/cli/pull/388): I used the pipe character
("|") to separate entries, and that didn't work well as markdown uses
that to delimit tables.

the result can be seen in the picture of the following comment:
  https://github.com/hetznercloud/cli/pull/388#issuecomment-1152895950

this time it's correct, no caveats.
my apologies, I missed it in the preview the first time.

Signed-off-by: wULLSnpAXbWZGYDYyhWTKKspEQoaYxXyhoisqHf <a_mirre@utb.cz>