### PR TITLE
Remove Third-party packages Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ On macOS and Linux, you can install `hcloud` via [Homebrew](https://brew.sh/):
 
     brew install hcloud
 
+
 On Windows, you can install `hcloud` via [Scoop](https://scoop.sh/)
 
     scoop install hcloud

--- a/README.md
+++ b/README.md
@@ -11,31 +11,13 @@
 You can download pre-built binaries for Linux, FreeBSD, macOS, and Windows on
 the [releases page](https://github.com/hetznercloud/cli/releases).
 
-On macOS, you can install `hcloud` via [Homebrew](https://brew.sh/):
+On macOS and Linux, you can install `hcloud` via [Homebrew](https://brew.sh/):
 
     brew install hcloud
-
 
 On Windows, you can install `hcloud` via [Scoop](https://scoop.sh/)
 
     scoop install hcloud
-
-### Third-party packages
-
-There are unofficial packages maintained by third-party users. Please note
-that these packages aren’t supported nor maintained by Hetzner Cloud and
-may not always be up-to-date. Downloading the binary or building from source
-is still the recommended install method.
-
-| Operating System      | Command                                           |
-| --------------------- | ------------------------------------------------- |
-| Debian (>= bullseye)  | `apt install hcloud-cli`                          |
-| Ubuntu (>= 19.04)     | `apt install hcloud-cli`                          |
-| Arch Linux            | `pacman -Syu hcloud`                              |
-| Void Linux            | `xbps-install -Syu hcloud`                        |
-| Gentoo Linux          | `emerge hcloud`                                   |
-| Alpine Linux          | `apk add hcloud`                                  |
-| Fedora {35,36,37}     | `dnf install hcloud`                              |
 
 ### Build manually
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ On Windows, you can install `hcloud` via [Scoop](https://scoop.sh/)
 
     scoop install hcloud
 
+### Third-party packages
+
+There are unofficial packages maintained by third-party users. Please note
+that these packages aren’t supported nor maintained by Hetzner Cloud and
+may not always be up-to-date. Downloading the binary or building from source
+is still the recommended install method.
+
 ### Build manually
 
 If you have Go installed, you can build and install the latest version of


### PR DESCRIPTION
We should not recommend using third-party packages, as they might be fully outdated. We only "advertise" the official ways as of now.