### PR TITLE
Improve hcloud server ssh command to use IPv6 automatically if no IPv…

### DIFF
--- a/internal/cmd/server/ssh.go
+++ b/internal/cmd/server/ssh.go
@@ -45,17 +45,13 @@ func runSSH(cli *state.State, cmd *cobra.Command, args []string) error {
 	port, _ := cmd.Flags().GetInt("port")
 
 	ipAddress := server.PublicNet.IPv4.IP
-	if useIPv6 {
+	if server.PublicNet.IPv4.IsUnspecified() || useIPv6 {
 		if server.PublicNet.IPv6.IsUnspecified() {
-			return fmt.Errorf("server %s does not have a assigned primary ipv6", idOrName)
+			return fmt.Errorf("server %s does not have a assigned primary ipv4 or ipv6", idOrName)
 		}
 		ipAddress = server.PublicNet.IPv6.Network.IP
 		// increment last byte to get the ::1 IP, which is routed
 		ipAddress[15]++
-	} else {
-		if server.PublicNet.IPv4.IsUnspecified() {
-			return fmt.Errorf("server %s does not have a assigned primary ipv4", idOrName)
-		}
 	}
 
 	sshArgs := []string{"-l", user, "-p", strconv.Itoa(port), ipAddress.String()}


### PR DESCRIPTION
…4 is available.


Improvement as described in https://github.com/hetznercloud/cli/issues/395#issuecomment-1188639874
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>