### PR TITLE
chore: update hcloud-go to v1.37.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/golang/mock v1.6.0
 	github.com/guptarohit/asciigraph v0.5.5
-	github.com/hetznercloud/hcloud-go v1.35.2
+	github.com/hetznercloud/hcloud-go v1.37.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rjeczalik/interfaces v0.1.1
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/guptarohit/asciigraph v0.5.5 h1:ccFnUF8xYIOUPPY3tmdvRyHqmn1MYI9iv1pLKX+/ZkQ=
 github.com/guptarohit/asciigraph v0.5.5/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
-github.com/hetznercloud/hcloud-go v1.35.2 h1:eEDtmDiI2plZ2UQmj4YpiYse5XbtpXOUBpAdIOLxzgE=
-github.com/hetznercloud/hcloud-go v1.35.2/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
+github.com/hetznercloud/hcloud-go v1.37.0 h1:Uwu7OKfZvar86LfJuzItStoO1AL7DVDCqWzRGzrvdEw=
+github.com/hetznercloud/hcloud-go v1.37.0/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/internal/hcapi2/mock/zz_primary_ip_client_mock.go
+++ b/internal/hcapi2/mock/zz_primary_ip_client_mock.go
@@ -50,6 +50,21 @@ func (mr *MockPrimaryIPClientMockRecorder) All(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockPrimaryIPClient)(nil).All), arg0)
 }
 
+// AllWithOpts mocks base method.
+func (m *MockPrimaryIPClient) AllWithOpts(arg0 context.Context, arg1 hcloud.PrimaryIPListOpts) ([]*hcloud.PrimaryIP, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllWithOpts", arg0, arg1)
+	ret0, _ := ret[0].([]*hcloud.PrimaryIP)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllWithOpts indicates an expected call of AllWithOpts.
+func (mr *MockPrimaryIPClientMockRecorder) AllWithOpts(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllWithOpts", reflect.TypeOf((*MockPrimaryIPClient)(nil).AllWithOpts), arg0, arg1)
+}
+
 // Assign mocks base method.
 func (m *MockPrimaryIPClient) Assign(arg0 context.Context, arg1 hcloud.PrimaryIPAssignOpts) (*hcloud.Action, *hcloud.Response, error) {
 	m.ctrl.T.Helper()

--- a/internal/hcapi2/mock/zz_server_client_mock.go
+++ b/internal/hcapi2/mock/zz_server_client_mock.go
@@ -224,6 +224,22 @@ func (mr *MockServerClientMockRecorder) Delete(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockServerClient)(nil).Delete), arg0, arg1)
 }
 
+// DeleteWithResult mocks base method.
+func (m *MockServerClient) DeleteWithResult(arg0 context.Context, arg1 *hcloud.Server) (*hcloud.ServerDeleteResult, *hcloud.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteWithResult", arg0, arg1)
+	ret0, _ := ret[0].(*hcloud.ServerDeleteResult)
+	ret1, _ := ret[1].(*hcloud.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DeleteWithResult indicates an expected call of DeleteWithResult.
+func (mr *MockServerClientMockRecorder) DeleteWithResult(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWithResult", reflect.TypeOf((*MockServerClient)(nil).DeleteWithResult), arg0, arg1)
+}
+
 // DetachFromNetwork mocks base method.
 func (m *MockServerClient) DetachFromNetwork(arg0 context.Context, arg1 *hcloud.Server, arg2 hcloud.ServerDetachFromNetworkOpts) (*hcloud.Action, *hcloud.Response, error) {
 	m.ctrl.T.Helper()

--- a/internal/hcapi2/zz_primary_ip_client_base.go
+++ b/internal/hcapi2/zz_primary_ip_client_base.go
@@ -10,6 +10,7 @@ import (
 // PrimaryIPClientBase is an interface generated for "github.com/hetznercloud/hcloud-go/hcloud.PrimaryIPClient".
 type PrimaryIPClientBase interface {
 	All(context.Context) ([]*hcloud.PrimaryIP, error)
+	AllWithOpts(context.Context, hcloud.PrimaryIPListOpts) ([]*hcloud.PrimaryIP, error)
 	Assign(context.Context, hcloud.PrimaryIPAssignOpts) (*hcloud.Action, *hcloud.Response, error)
 	ChangeDNSPtr(context.Context, hcloud.PrimaryIPChangeDNSPtrOpts) (*hcloud.Action, *hcloud.Response, error)
 	ChangeProtection(context.Context, hcloud.PrimaryIPChangeProtectionOpts) (*hcloud.Action, *hcloud.Response, error)

--- a/internal/hcapi2/zz_server_client_base.go
+++ b/internal/hcapi2/zz_server_client_base.go
@@ -21,6 +21,7 @@ type ServerClientBase interface {
 	Create(context.Context, hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, *hcloud.Response, error)
 	CreateImage(context.Context, *hcloud.Server, *hcloud.ServerCreateImageOpts) (hcloud.ServerCreateImageResult, *hcloud.Response, error)
 	Delete(context.Context, *hcloud.Server) (*hcloud.Response, error)
+	DeleteWithResult(context.Context, *hcloud.Server) (*hcloud.ServerDeleteResult, *hcloud.Response, error)
 	DetachFromNetwork(context.Context, *hcloud.Server, hcloud.ServerDetachFromNetworkOpts) (*hcloud.Action, *hcloud.Response, error)
 	DetachISO(context.Context, *hcloud.Server) (*hcloud.Action, *hcloud.Response, error)
 	DisableBackup(context.Context, *hcloud.Server) (*hcloud.Action, *hcloud.Response, error)


### PR DESCRIPTION
Rebased on #414 to fix the errors that occured when regenerating our mocks.