### PR TITLE
fix: primary-ip list returns max 50 items

### DIFF
--- a/internal/cmd/primaryip/list.go
+++ b/internal/cmd/primaryip/list.go
@@ -24,7 +24,7 @@ var listCmd = base.ListCmd{
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		primaryips, _, err := client.PrimaryIP().List(ctx, opts)
+		primaryips, err := client.PrimaryIP().AllWithOpts(ctx, opts)
 
 		var resources []interface{}
 		for _, n := range primaryips {

--- a/internal/cmd/primaryip/list_test.go
+++ b/internal/cmd/primaryip/list_test.go
@@ -19,7 +19,7 @@ func TestList(t *testing.T) {
 
 	fx.ExpectEnsureToken()
 	fx.Client.PrimaryIPClient.EXPECT().
-		List(
+		AllWithOpts(
 			gomock.Any(),
 			hcloud.PrimaryIPListOpts{
 				ListOpts: hcloud.ListOpts{
@@ -38,7 +38,6 @@ func TestList(t *testing.T) {
 				IP:         net.ParseIP("127.0.0.1"),
 			},
 		},
-			&hcloud.Response{},
 			nil)
 
 	out, err := fx.Run(cmd, []string{"--selector", "foo=bar"})


### PR DESCRIPTION
Calls to `hcloud primary-ip list` would only return the first page of the results which by default is 50 items. By using `.AllWithOpts` instead of `.List`, hcloud-go automatically fetches all pages for us.