### PR TITLE
Adding a .devcontainer configuration for usage in GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+ARG GO_VERSION=1.19
+ARG ALPINE_VERSION=3.16
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}
+
+# CA certificates
+RUN apk add -q --update --progress --no-cache ca-certificates make curl gpg dirmngr bash sudo bat file tzdata git mandoc git-doc openssh-client zsh zsh-vcs vim libstdc++ github-cli
+
+ENV EDITOR=vim
+ENV LANG=en_US.UTF-8
+ENV TERM=xterm
+ENV GO111MODULE=on
+
+# install golang tools
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+RUN go install github.com/cweill/gotests/... && \
+    go install github.com/swaggo/swag/cmd/swag@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@latest && \
+    go install github.com/fatih/gomodifytags@latest && \
+    go install github.com/vektra/mockery/v2@latest && \
+    go install github.com/golang/mock/mockgen@v1.6.0 && \
+    go install golang.org/x/tools/gopls@latest && \
+    go install github.com/josharian/impl@latest && \
+    go install github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,83 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"go.toolsManagement.autoUpdate": false,
+		"go.toolsManagement.checkForUpdates": "off",
+		"go.gopath": "/go",
+		"go.lintOnSave": "package",
+		"go.vetOnSave": "package",
+		"go.formatTool": "goimports",
+		"go.useLanguageServer": true,
+		"go.autocompleteUnimportedPackages": true,
+		"go.gotoSymbol.includeImports": true,
+		"go.gotoSymbol.includeGoroot": true,
+		"go.editorContextMenuCommands": {
+			"toggleTestFile": true,
+			"addTags": true,
+			"removeTags": false,
+			"fillStruct": true,
+			"testAtCursor": true,
+			"testFile": false,
+			"testPackage": false,
+			"generateTestForFunction": true,
+			"generateTestForFile": false,
+			"generateTestForPackage": false,
+			"addImport": true,
+			"testCoverage": true,
+			"playground": true,
+			"debugTestAtCursor": true,
+			"benchmarkAtCursor": false
+		},
+		"go.enableCodeLens": {
+			"references": true,
+			"runtest": true
+		},
+		"codeQL.telemetry.enableTelemetry": false,
+		"codeQL.runningQueries.memory": 2048,
+		"codeQL.runningQueries.debug": true,
+		"git.autofetch": true,
+		"editor.experimental.stickyScroll.enabled": true,
+		"editor.guides.bracketPairs": true,
+		"editor.renderFinalNewline": true,
+		"editor.codeLens": true,
+		"editor.insertSpaces": true,
+		"editor.formatOnSave": true,
+		"editor.formatOnPaste": true,
+		"editor.snippetSuggestions": "none",
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": true,
+			"source.fixAll": true
+		},
+		"workbench.iconTheme": "vscode-icons",
+		"files.trimTrailingWhitespace": true
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go",
+		"ms-azuretools.vscode-docker",
+		"github.vscode-codeql",
+		"davidanson.vscode-markdownlint",
+		"shardulm94.trailing-spaces",
+		"github.vscode-pull-request-github",
+		"eamodio.gitlens",
+		"IBM.output-colorizer",
+        "bungcip.better-toml"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	//"postCreateCommand": "",
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	//"remoteUser": "vscode"
+}


### PR DESCRIPTION
Adding a .devcontainer configuration

**What this PR does / why we need it**:

If you never worked with Devcontainers before, here is a good article about it: [What the heck are devcontainers][1].
Another good one can be found here: [your open source project needs a devcontainer - here's why][2]

Tl;Dr:
Devcontainers are awesome and they help to define an isolated development environment which is standardised across all contributors setups and leverages the beauty of [GitHub Codespaces][3].

**Special notes for your reviewer**:

Just try it out once, before dismissing it.
Setting up your VScode to use the Devcontainer is easy:

1. Make sure you have the following plugin installed: [`ms-vscode-remote.remote-containers`][4]
2. Open VScode in the root-directory of the Repository
3. Click "Reopen in Container" once VScode shows you the popup, telling you that it detected a devcontainer configuration.

alternative is to use [GitHub Codespaces][3] from your browser.

**Documentation**:
https://www.aaron-powell.com/posts/2021-03-08-your-open-source-project-needs-a-dev-container-heres-why/ https://code.visualstudio.com/docs/remote/containers https://github.com/qdm12/godevcontainer
https://github.com/features/codespaces

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

[1]: https://cedi.dev/post/devcontainer-pt1/
[2]: https://www.aaron-powell.com/posts/2021-03-08-your-open-source-project-needs-a-dev-container-heres-why/
[3]: https://github.com/features/codespaces
[4]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers