### PR TITLE
allow specifying default columns for each sub command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/certificate"
 	"github.com/hetznercloud/cli/internal/cmd/completion"
+	"github.com/hetznercloud/cli/internal/cmd/config"
 	"github.com/hetznercloud/cli/internal/cmd/context"
 	"github.com/hetznercloud/cli/internal/cmd/datacenter"
 	"github.com/hetznercloud/cli/internal/cmd/firewall"
@@ -45,6 +46,7 @@ func NewRootCommand(state *state.State, client hcapi2.Client) *cobra.Command {
 		version.NewCommand(state),
 		completion.NewCommand(state),
 		servertype.NewCommand(state, client),
+		config.NewCommand(state),
 		context.NewCommand(state),
 		datacenter.NewCommand(state, client),
 		location.NewCommand(state, client),

--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -55,6 +55,10 @@ func (lc *ListCmd) CobraCommand(
 
 	cmd.Flags().StringSliceP("sort", "s", sortingDefault, "Determine the sorting of the result")
 
+	if defaults != nil && len(defaults.DefaultColumns) > 0 {
+		lc.DefaultColumns = defaults.DefaultColumns
+	}
+
 	return cmd
 }
 

--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -24,7 +24,7 @@ type ListCmd struct {
 
 // CobraCommand creates a command that can be registered with cobra.
 func (lc *ListCmd) CobraCommand(
-	ctx context.Context, client hcapi2.Client, tokenEnsurer state.TokenEnsurer,
+	ctx context.Context, client hcapi2.Client, tokenEnsurer state.TokenEnsurer, defaults *state.SubcommandDefaults,
 ) *cobra.Command {
 	outputColumns := lc.OutputTable(client).Columns()
 
@@ -47,7 +47,14 @@ func (lc *ListCmd) CobraCommand(
 	if lc.AdditionalFlags != nil {
 		lc.AdditionalFlags(cmd)
 	}
-	cmd.Flags().StringSliceP("sort", "s", []string{"id:asc"}, "Determine the sorting of the result")
+
+	sortingDefault := []string{"id:asc"}
+	if defaults != nil && len(defaults.Sorting) > 0 {
+		sortingDefault = defaults.Sorting
+	}
+
+	cmd.Flags().StringSliceP("sort", "s", sortingDefault, "Determine the sorting of the result")
+
 	return cmd
 }
 

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		labelCmds.AddCobraCommand(cli.Context, client, cli),

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/hetznercloud/cli/internal/cmd/config/defaultcolumns"
 	"github.com/hetznercloud/cli/internal/cmd/config/sorting"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/spf13/cobra"
@@ -16,6 +17,7 @@ func NewCommand(cli *state.State) *cobra.Command {
 	}
 	cmd.AddCommand(
 		sorting.NewSortCommand(cli),
+		defaultcolumns.NewDefaultColumnsCommand(cli),
 	)
 	return cmd
 }

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"github.com/hetznercloud/cli/internal/cmd/config/sorting"
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "config [FLAGS]",
+		Short:                 "Manage config",
+		Args:                  cobra.NoArgs,
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+	}
+	cmd.AddCommand(
+		sorting.NewSortCommand(cli),
+	)
+	return cmd
+}

--- a/internal/cmd/config/defaultcolumns/columns.go
+++ b/internal/cmd/config/defaultcolumns/columns.go
@@ -1,0 +1,24 @@
+package defaultcolumns
+
+import (
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func NewDefaultColumnsCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "columns COMMAND",
+		Short:                 "Configure the default sorting order for a command",
+		Args:                  cobra.MinimumNArgs(2),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.AddCommand(
+		newSetCommand(cli),
+		newListCommand(cli),
+		newResetCommand(cli),
+	)
+
+	return cmd
+}

--- a/internal/cmd/config/defaultcolumns/list.go
+++ b/internal/cmd/config/defaultcolumns/list.go
@@ -1,0 +1,102 @@
+package defaultcolumns
+
+import (
+	"strings"
+
+	"github.com/hetznercloud/cli/internal/cmd/output"
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var listTableOutput *output.Table
+
+func init() {
+	listTableOutput = output.NewTable().
+		AddAllowedFields(ColumnsPresentation{})
+}
+
+type ColumnsPresentation struct {
+	Command string
+	Columns string
+}
+
+func newListCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "list [COMMAND]",
+		Short:                 "See the default sorting order for a command",
+		Args:                  cobra.MaximumNArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		RunE:                  cli.Wrap(runList),
+	}
+
+	return cmd
+}
+
+func runList(cli *state.State, cmd *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		return runListCommand(cli, cmd, args)
+	}
+
+	return runListAll(cli, cmd, args)
+}
+
+func runListAll(cli *state.State, cmd *cobra.Command, args []string) error {
+	outOpts := output.FlagsForCommand(cmd)
+
+	cols := []string{"command", "columns"}
+
+	tw := listTableOutput
+	if err := tw.ValidateColumns(cols); err != nil {
+		return err
+	}
+
+	if !outOpts.IsSet("noheader") {
+		tw.WriteHeader(cols)
+	}
+
+	for command, defaults := range cli.Config.SubcommandDefaults {
+		if defaults != nil {
+			presentation := ColumnsPresentation{
+				Command: command,
+				Columns: strings.Join(defaults.DefaultColumns, ", "),
+			}
+
+			tw.Write(cols, presentation)
+		}
+	}
+
+	tw.Flush()
+	return nil
+}
+
+func runListCommand(cli *state.State, cmd *cobra.Command, args []string) error {
+	outOpts := output.FlagsForCommand(cmd)
+
+	cols := []string{"command", "columns"}
+
+	command := args[0]
+
+	tw := listTableOutput
+	if err := tw.ValidateColumns(cols); err != nil {
+		return err
+	}
+
+	if !outOpts.IsSet("noheader") {
+		tw.WriteHeader(cols)
+	}
+
+	defaults := cli.Config.SubcommandDefaults[command]
+
+	if defaults != nil {
+		presentation := ColumnsPresentation{
+			Command: command,
+			Columns: strings.Join(defaults.DefaultColumns, ", "),
+		}
+
+		tw.Write(cols, presentation)
+	}
+
+	tw.Flush()
+	return nil
+}

--- a/internal/cmd/config/defaultcolumns/reset.go
+++ b/internal/cmd/config/defaultcolumns/reset.go
@@ -1,0 +1,49 @@
+package defaultcolumns
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newResetCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "reset COMMAND",
+		Short:                 "Reset to the application default columns for a command",
+		Args:                  cobra.ExactArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		RunE:                  cli.Wrap(runReset),
+	}
+
+	return cmd
+}
+
+func runReset(cli *state.State, cmd *cobra.Command, args []string) error {
+	command := strings.TrimSpace(args[0])
+	if command == "" {
+		return errors.New("invalid command")
+	}
+
+	if cli.Config.SubcommandDefaults == nil {
+		return nil
+	}
+
+	defaults := cli.Config.SubcommandDefaults[command]
+	if defaults != nil {
+		defaults.DefaultColumns = nil
+	}
+
+	cli.Config.SubcommandDefaults[command] = defaults
+
+	if err := cli.WriteConfig(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Reset to the default display columns for command '%s list'\n", command)
+
+	return nil
+}

--- a/internal/cmd/config/defaultcolumns/set.go
+++ b/internal/cmd/config/defaultcolumns/set.go
@@ -1,0 +1,62 @@
+package defaultcolumns
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newSetCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "set COMMAND COLUMNS...",
+		Short:                 "Set which columns to show by default for a command",
+		Args:                  cobra.MinimumNArgs(2),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		RunE:                  cli.Wrap(runSet),
+	}
+
+	return cmd
+}
+
+func runSet(cli *state.State, cmd *cobra.Command, args []string) error {
+	command := strings.TrimSpace(args[0])
+	if command == "" {
+		return errors.New("invalid command")
+	}
+
+	if len(args[1:]) == 0 {
+		return errors.New("invalid columns")
+	}
+
+	columns := make([]string, len(args[1:]))
+	for index, columnName := range args[1:] {
+		columns[index] = strings.TrimSpace(columnName)
+	}
+
+	if cli.Config.SubcommandDefaults == nil {
+		cli.Config.SubcommandDefaults = make(map[string]*state.SubcommandDefaults)
+	}
+
+	defaults := cli.Config.SubcommandDefaults[command]
+	if defaults == nil {
+		defaults = &state.SubcommandDefaults{
+			DefaultColumns: columns,
+		}
+	} else {
+		defaults.DefaultColumns = columns
+	}
+
+	cli.Config.SubcommandDefaults[command] = defaults
+
+	if err := cli.WriteConfig(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Displaying columns '%s' for command '%s list'\n", strings.Join(columns, ", "), command)
+
+	return nil
+}

--- a/internal/cmd/config/sorting/list.go
+++ b/internal/cmd/config/sorting/list.go
@@ -1,0 +1,121 @@
+package sorting
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/hetznercloud/cli/internal/cmd/output"
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var listTableOutput *output.Table
+
+func init() {
+	listTableOutput = output.NewTable().
+		AddAllowedFields(SortPresentation{})
+}
+
+type SortPresentation struct {
+	Command string
+	Column  string
+	Order   string
+}
+
+func newListCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "list [COMMAND]",
+		Short:                 "See the default sorting order for a command",
+		Args:                  cobra.MaximumNArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		RunE:                  cli.Wrap(runList),
+	}
+
+	return cmd
+}
+
+func runList(cli *state.State, cmd *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		return runListCommand(cli, cmd, args)
+	}
+
+	return runListAll(cli, cmd, args)
+}
+
+func runListAll(cli *state.State, cmd *cobra.Command, args []string) error {
+	outOpts := output.FlagsForCommand(cmd)
+
+	cols := []string{"command", "column"}
+
+	tw := listTableOutput
+	if err := tw.ValidateColumns(cols); err != nil {
+		return err
+	}
+
+	if !outOpts.IsSet("noheader") {
+		tw.WriteHeader(cols)
+	}
+
+	for command, defaults := range cli.Config.SubcommandDefaults {
+		if defaults != nil {
+			presentation := SortPresentation{
+				Command: command,
+				Column:  strings.Join(defaults.Sorting, ", "),
+				Order:   "",
+			}
+
+			tw.Write(cols, presentation)
+		}
+	}
+
+	tw.Flush()
+	return nil
+}
+
+func runListCommand(cli *state.State, cmd *cobra.Command, args []string) error {
+	outOpts := output.FlagsForCommand(cmd)
+
+	cols := []string{"column", "order"}
+
+	command := args[0]
+
+	tw := listTableOutput
+	if err := tw.ValidateColumns(cols); err != nil {
+		return err
+	}
+
+	if !outOpts.IsSet("noheader") {
+		tw.WriteHeader(cols)
+	}
+
+	defaults := cli.Config.SubcommandDefaults[command]
+
+	if defaults != nil {
+		for _, column := range defaults.Sorting {
+			order := "asc"
+
+			// handle special case where colum-name includes the : to specify the order
+			if strings.Contains(column, ":") {
+				columnWithOrdering := strings.Split(column, ":")
+				if len(columnWithOrdering) != 2 {
+					return errors.New("Column sort syntax invalid")
+				}
+
+				column = columnWithOrdering[0]
+				order = columnWithOrdering[1]
+			}
+
+			presentation := SortPresentation{
+				Command: command,
+				Column:  column,
+				Order:   order,
+			}
+
+			tw.Write(cols, presentation)
+		}
+	}
+
+	tw.Flush()
+	return nil
+}

--- a/internal/cmd/config/sorting/reset.go
+++ b/internal/cmd/config/sorting/reset.go
@@ -1,0 +1,49 @@
+package sorting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newResetCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "reset COMMAND",
+		Short:                 "Reset to the application default sorting order for a command",
+		Args:                  cobra.ExactArgs(1),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		RunE:                  cli.Wrap(runReset),
+	}
+
+	return cmd
+}
+
+func runReset(cli *state.State, cmd *cobra.Command, args []string) error {
+	command := strings.TrimSpace(args[0])
+	if command == "" {
+		return errors.New("invalid command")
+	}
+
+	if cli.Config.SubcommandDefaults == nil {
+		return nil
+	}
+
+	defaults := cli.Config.SubcommandDefaults[command]
+	if defaults != nil {
+		defaults.Sorting = nil
+	}
+
+	cli.Config.SubcommandDefaults[command] = defaults
+
+	if err := cli.WriteConfig(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Reset sorting to the default sorting order for command '%s list'\n", command)
+
+	return nil
+}

--- a/internal/cmd/config/sorting/set.go
+++ b/internal/cmd/config/sorting/set.go
@@ -1,0 +1,63 @@
+package sorting
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func newSetCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "set COMMAND COLUMNS...",
+		Short:                 "Set the default sorting order for a command",
+		Long:                  "Configure how the list subcommand of each command sorts it output. Append `:asc` or `:desc` to the column name control sorting (Default: `:asc`). You can also sort by multiple columns",
+		Args:                  cobra.MinimumNArgs(2),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		RunE:                  cli.Wrap(runSet),
+	}
+
+	return cmd
+}
+
+func runSet(cli *state.State, cmd *cobra.Command, args []string) error {
+	command := strings.TrimSpace(args[0])
+	if command == "" {
+		return errors.New("invalid command")
+	}
+
+	if len(args[1:]) == 0 {
+		return errors.New("invalid columns")
+	}
+
+	columns := make([]string, len(args[1:]))
+	for index, columnName := range args[1:] {
+		columns[index] = strings.TrimSpace(columnName)
+	}
+
+	if cli.Config.SubcommandDefaults == nil {
+		cli.Config.SubcommandDefaults = make(map[string]*state.SubcommandDefaults)
+	}
+
+	defaults := cli.Config.SubcommandDefaults[command]
+	if defaults == nil {
+		defaults = &state.SubcommandDefaults{
+			Sorting: columns,
+		}
+	} else {
+		defaults.Sorting = columns
+	}
+
+	cli.Config.SubcommandDefaults[command] = defaults
+
+	if err := cli.WriteConfig(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Sorting by columns '%s' by default for command '%s list'\n", strings.Join(columns, ", "), command)
+
+	return nil
+}

--- a/internal/cmd/config/sorting/sort.go
+++ b/internal/cmd/config/sorting/sort.go
@@ -1,0 +1,23 @@
+package sorting
+
+import (
+	"github.com/hetznercloud/cli/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func NewSortCommand(cli *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "sort COMMAND",
+		Short:                 "Configure the default sorting order for a command",
+		Args:                  cobra.MinimumNArgs(2),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.AddCommand(
+		newSetCommand(cli),
+		newListCommand(cli),
+	)
+
+	return cmd
+}

--- a/internal/cmd/datacenter/datacenter.go
+++ b/internal/cmd/datacenter/datacenter.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/firewall/firewall.go
+++ b/internal/cmd/firewall/firewall.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/floatingip/floatingip.go
+++ b/internal/cmd/floatingip/floatingip.go
@@ -16,7 +16,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	}
 	cmd.AddCommand(
 		updateCmd.CobraCommand(cli.Context, client, cli),
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		newCreateCommand(cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		newAssignCommand(cli),

--- a/internal/cmd/image/image.go
+++ b/internal/cmd/image/image.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		deleteCmd.CobraCommand(cli.Context, client, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/iso/iso.go
+++ b/internal/cmd/iso/iso.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/loadbalancer/load_balancer.go
+++ b/internal/cmd/loadbalancer/load_balancer.go
@@ -16,7 +16,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newCreateCommand(cli),
-		ListCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/loadbalancertype/load_balancer_type.go
+++ b/internal/cmd/loadbalancertype/load_balancer_type.go
@@ -16,7 +16,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	}
 	cmd.AddCommand(
 		describeCmd.CobraCommand(cli.Context, client, cli),
-		ListCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 	)
 	return cmd
 }

--- a/internal/cmd/location/location.go
+++ b/internal/cmd/location/location.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/network/list_test.go
+++ b/internal/cmd/network/list_test.go
@@ -17,7 +17,7 @@ func TestList(t *testing.T) {
 	fx := testutil.NewFixture(t)
 	defer fx.Finish()
 
-	cmd := network.ListCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer)
+	cmd := network.ListCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer, nil)
 
 	fx.ExpectEnsureToken()
 	fx.Client.NetworkClient.EXPECT().

--- a/internal/cmd/network/network.go
+++ b/internal/cmd/network/network.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		ListCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/placementgroup/list_test.go
+++ b/internal/cmd/placementgroup/list_test.go
@@ -19,7 +19,8 @@ func TestList(t *testing.T) {
 	cmd := placementgroup.ListCmd.CobraCommand(
 		context.Background(),
 		fx.Client,
-		fx.TokenEnsurer)
+		fx.TokenEnsurer,
+		nil)
 	fx.ExpectEnsureToken()
 
 	fx.Client.PlacementGroupClient.EXPECT().

--- a/internal/cmd/placementgroup/placementgroup.go
+++ b/internal/cmd/placementgroup/placementgroup.go
@@ -16,7 +16,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	}
 	cmd.AddCommand(
 		CreateCmd.CobraCommand(cli.Context, client, cli, cli),
-		ListCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 		UpdateCmd.CobraCommand(cli.Context, client, cli),
 		DeleteCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/primaryip/list_test.go
+++ b/internal/cmd/primaryip/list_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,107 @@ func TestList(t *testing.T) {
 
 	expOut := `ID    TYPE   NAME       IP          ASSIGNEE   DNS   AUTO DELETE   AGE
 123   ipv4   test-net   127.0.0.1   -          -     yes           10s
+`
+
+	assert.NoError(t, err)
+	assert.Equal(t, expOut, out)
+}
+
+func TestListSortingFlag(t *testing.T) {
+	fx := testutil.NewFixture(t)
+	defer fx.Finish()
+
+	cmd := listCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer, nil)
+
+	fx.ExpectEnsureToken()
+	fx.Client.PrimaryIPClient.EXPECT().
+		AllWithOpts(
+			gomock.Any(),
+			hcloud.PrimaryIPListOpts{
+				ListOpts: hcloud.ListOpts{
+					PerPage:       50,
+					LabelSelector: "foo=bar",
+				},
+				Sort: []string{"id:desc"},
+			},
+		).
+		Return([]*hcloud.PrimaryIP{
+			{
+				ID:         456,
+				Name:       "test-net2",
+				AutoDelete: true,
+				Type:       hcloud.PrimaryIPTypeIPv4,
+				IP:         net.ParseIP("127.0.0.2"),
+				Created:    time.Now().Add(-11 * time.Second),
+			},
+			{
+				ID:         123,
+				Name:       "test-net",
+				AutoDelete: true,
+				Type:       hcloud.PrimaryIPTypeIPv4,
+				IP:         net.ParseIP("127.0.0.1"),
+				Created:    time.Now().Add(-10 * time.Second),
+			},
+		},
+			nil)
+
+	out, err := fx.Run(cmd, []string{"--selector", "foo=bar", "-s=id:desc"})
+
+	expOut := `ID    TYPE   NAME        IP          ASSIGNEE   DNS   AUTO DELETE   AGE
+456   ipv4   test-net2   127.0.0.2   -          -     yes           11s
+123   ipv4   test-net    127.0.0.1   -          -     yes           10s
+`
+
+	assert.NoError(t, err)
+	assert.Equal(t, expOut, out)
+}
+
+func TestListSortingConfig(t *testing.T) {
+	fx := testutil.NewFixture(t)
+	defer fx.Finish()
+
+	subcommandDefaults := &state.SubcommandDefaults{
+		Sorting: []string{"id:desc"},
+	}
+	cmd := listCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer, subcommandDefaults)
+
+	fx.ExpectEnsureToken()
+	fx.Client.PrimaryIPClient.EXPECT().
+		AllWithOpts(
+			gomock.Any(),
+			hcloud.PrimaryIPListOpts{
+				ListOpts: hcloud.ListOpts{
+					PerPage:       50,
+					LabelSelector: "foo=bar",
+				},
+				Sort: []string{"id:desc"},
+			},
+		).
+		Return([]*hcloud.PrimaryIP{
+			{
+				ID:         456,
+				Name:       "test-net2",
+				AutoDelete: true,
+				Type:       hcloud.PrimaryIPTypeIPv4,
+				IP:         net.ParseIP("127.0.0.2"),
+				Created:    time.Now().Add(-11 * time.Second),
+			},
+			{
+				ID:         123,
+				Name:       "test-net",
+				AutoDelete: true,
+				Type:       hcloud.PrimaryIPTypeIPv4,
+				IP:         net.ParseIP("127.0.0.1"),
+				Created:    time.Now().Add(-10 * time.Second),
+			},
+		},
+			nil)
+
+	out, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
+
+	expOut := `ID    TYPE   NAME        IP          ASSIGNEE   DNS   AUTO DELETE   AGE
+456   ipv4   test-net2   127.0.0.2   -          -     yes           11s
+123   ipv4   test-net    127.0.0.1   -          -     yes           10s
 `
 
 	assert.NoError(t, err)

--- a/internal/cmd/primaryip/list_test.go
+++ b/internal/cmd/primaryip/list_test.go
@@ -16,7 +16,7 @@ func TestList(t *testing.T) {
 	fx := testutil.NewFixture(t)
 	defer fx.Finish()
 
-	cmd := listCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer)
+	cmd := listCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer, nil)
 
 	fx.ExpectEnsureToken()
 	fx.Client.PrimaryIPClient.EXPECT().

--- a/internal/cmd/primaryip/primaryip.go
+++ b/internal/cmd/primaryip/primaryip.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		CreateCmd.CobraCommand(cli.Context, client, cli, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		ListCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		CreateCmd.CobraCommand(cli.Context, client, cli, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/servertype/server_type.go
+++ b/internal/cmd/servertype/server_type.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		ListCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/sshkey/sshkey.go
+++ b/internal/cmd/sshkey/sshkey.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/volume/volume.go
+++ b/internal/cmd/volume/volume.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		listCmd.CobraCommand(cli.Context, client, cli, cli.Config.SubcommandDefaults[cmd.Use]),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/state/config.go
+++ b/internal/state/config.go
@@ -67,6 +67,7 @@ type RawConfigContext struct {
 
 type RAWSubcommandDefaults struct {
 	Sorting []string `toml:"sort,omitempty"`
+	Columns []string `toml:"columns,omitempty"`
 }
 
 func MarshalConfig(c *Config) ([]byte, error) {
@@ -90,6 +91,7 @@ func MarshalConfig(c *Config) ([]byte, error) {
 		for command, defaults := range c.SubcommandDefaults {
 			raw.SubcommandDefaults[command] = &RAWSubcommandDefaults{
 				Sorting: defaults.Sorting,
+				Columns: defaults.DefaultColumns,
 			}
 		}
 	}
@@ -122,7 +124,8 @@ func UnmarshalConfig(config *Config, data []byte) error {
 		config.SubcommandDefaults = make(map[string]*SubcommandDefaults)
 		for command, defaults := range raw.SubcommandDefaults {
 			config.SubcommandDefaults[command] = &SubcommandDefaults{
-				Sorting: defaults.Sorting,
+				Sorting:        defaults.Sorting,
+				DefaultColumns: defaults.Columns,
 			}
 		}
 	}


### PR DESCRIPTION
I am a heavy user of the hcloud-cli. However, I usually change the columns that are displayed and don't like the default and would prefer specifying the default columns used in the config file.
Note: This PR adds on top of the work of https://github.com/hetznercloud/cli/pull/421 and should not be merged
before https://github.com/hetznercloud/cli/pull/421.

Currently, I always type `hcloud server list -o 'columns=name,status,ipv6,private_net'` to only get the columns that I'm interested in

since the `-o` flag is part of the `list` subcommand and not the `hcloud` base command (like in many other software that makes use of the Cobra framework),
I cannot simply `alias hcloud-"hcloud -o 'columns='"` in my shell to default the columns.

This commit adds a `[defaults]` section to the config toml which allows to override the default sorting behavior for individual `hcloud` subcommands.

The following behavior is used to determine the displayed columns

| config file | flag    | result                      |
|-------------|---------|-----------------------------|
| not-set     | not-set | display default columns     |
| not-set     | set     | display -o flag columns     |
| set         | not-set | display config file columns |
| set         | set     | display -o flag columns     |