### PR TITLE
Adding "loadbalancer" as an alias to the "load-balancer" command

### DIFF
--- a/internal/cmd/loadbalancer/load_balancer.go
+++ b/internal/cmd/loadbalancer/load_balancer.go
@@ -10,6 +10,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "load-balancer",
 		Short:                 "Manage Load Balancers",
+		Aliases:               []string{"loadbalancer"},
 		Args:                  cobra.NoArgs,
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
This commit allows for the additional use of `hcloud loadbalancer list` instead of `hcloud load-balancer list`. This is just a small quality of life update, to allow for both options.