### PR TITLE
feat(completion): read network zones from API

### DIFF
--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -36,7 +36,7 @@ func newCreateCommand(cli *state.State) *cobra.Command {
 	cmd.RegisterFlagCompletionFunc("location", cmpl.SuggestCandidatesF(cli.LocationNames))
 
 	cmd.Flags().String("network-zone", "", "Network Zone")
-	cmd.RegisterFlagCompletionFunc("network-zone", cmpl.SuggestCandidates("eu-central"))
+	cmd.RegisterFlagCompletionFunc("network-zone", cmpl.SuggestCandidatesF(cli.NetworkZoneNames))
 
 	cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
 

--- a/internal/cmd/network/add_subnet.go
+++ b/internal/cmd/network/add_subnet.go
@@ -27,7 +27,7 @@ func newAddSubnetCommand(cli *state.State) *cobra.Command {
 	cmd.MarkFlagRequired("type")
 
 	cmd.Flags().String("network-zone", "", "Name of network zone (required)")
-	cmd.RegisterFlagCompletionFunc("network-zone", cmpl.SuggestCandidates("eu-central", "us-east"))
+	cmd.RegisterFlagCompletionFunc("network-zone", cmpl.SuggestCandidatesF(cli.NetworkZoneNames))
 	cmd.MarkFlagRequired("network-zone")
 
 	cmd.Flags().IPNet("ip-range", net.IPNet{}, "Range to allocate IPs from")

--- a/internal/hcapi/location.go
+++ b/internal/hcapi/location.go
@@ -30,3 +30,26 @@ func (c *LocationClient) LocationNames() []string {
 	}
 	return names
 }
+
+// NetworkZoneNames obtains a list of available network zones. It returns nil if
+// network zone names could not be fetched.
+func (c *LocationClient) NetworkZoneNames() []string {
+	locs, err := c.All(context.Background())
+	if err != nil || len(locs) == 0 {
+		return nil
+	}
+	// Use map to get unique elements
+	namesMap := map[hcloud.NetworkZone]bool{}
+	for _, loc := range locs {
+		name := loc.NetworkZone
+		namesMap[name] = true
+	}
+
+	// Unique names from map to slice
+	names := make([]string, len(namesMap))
+	for name := range namesMap {
+		names = append(names, string(name))
+	}
+
+	return names
+}

--- a/internal/state/helpers.go
+++ b/internal/state/helpers.go
@@ -143,6 +143,14 @@ func (c *State) LocationNames() []string {
 	return c.locationClient.LocationNames()
 }
 
+func (c *State) NetworkZoneNames() []string {
+	if c.locationClient == nil {
+		client := c.Client()
+		c.locationClient = &hcapi.LocationClient{LocationClient: &client.Location}
+	}
+	return c.locationClient.NetworkZoneNames()
+}
+
 func (c *State) DataCenterNames() []string {
 	if c.dataCenterClient == nil {
 		client := c.Client()


### PR DESCRIPTION
We previously hard-coded the available network zones for autocompletion purposes. This makes it easy to forget to add them, or only update the list in one location (as you can see, it's currently missing us-east for the loadbalancer create call).

In this PR we replace the hardcoded list with an api call that retrieves all available network zones from the API. As there is no dedicated `GET /v1/network_zones` endpoint, we use the network zone referenced in the `GET /v1/locations` response.