### PR TITLE
[TEST] fix(ci): use macos-12 to fix issues with notarization

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-cli:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 720
     steps:
       - name: Checkout


### PR DESCRIPTION
We are currently trying to find the cause for https://github.com/hetznercloud/cli/issues/427, and we think that updating to macOS 12 might use a newer toolchain for the signing that works.