### PR TITLE
ci: fix issue where release pipeline fails and no assets are produced

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.12.3
           args: release --rm-dist --skip-publish --skip-sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Newer versions of goreleaser cause the `gon+ hook to fail in the `codesigning` step, causing a timeout of the release pipeline. This in turn causes the GitHub release to not have any attached assets.

See #427 and #429.