### PR TITLE
fix(ci): race-condition in signing macos binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.12.3
-          args: release --rm-dist --skip-publish --skip-sign
+          version: latest
+          args: release --rm-dist --skip-publish --skip-sign --parallelism=2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,9 @@ builds:
     goarch:
       - amd64
     hooks:
-      post: gon -log-level DEBUG gon.hcl
+      post:
+        - cmd: gon -log-level DEBUG gon.hcl
+          output: true
   - id: "hcloud-macos-arm-build"
     main: ./cmd/hcloud/main.go
     binary: hcloud
@@ -44,8 +46,9 @@ builds:
     goarch:
       - arm64
     hooks:
-      post: gon -log-level DEBUG gon_arm64.hcl
-
+      post:
+        - cmd: gon -log-level DEBUG gon_arm64.hcl
+          output: true
 before:
   hooks:
     - go mod tidy

--- a/script/decrypt_secrets.sh
+++ b/script/decrypt_secrets.sh
@@ -3,6 +3,9 @@
 gpg --quiet --batch --yes --decrypt --passphrase="$SECRETS_PASSWORD" --output ./.github/secrets/hcloud_cli.p12 ./.github/secrets/hcloud_cli.p12.gpg
 
 security create-keychain -p "" build.keychain
+# Use long timeout for keychain to avoid issues where codesign fails because the keychain is locked
+# before it was used. Default timeout is 300s
+security set-keychain-settings -u -t 3600 ~/Library/Keychains/build.keychain
 security import ./.github/secrets/hcloud_cli.p12 -t agg -k ~/Library/Keychains/build.keychain -P "$CERT_PASSWORD" -A
 
 security list-keychains -s ~/Library/Keychains/build.keychain


### PR DESCRIPTION
By default the keychain that is used to sign macOS binaries is only unlocked for 300s. This caused the release process to fail, as building all binaries took longer than the 300s, and subsequent signing failed.

The new timeout is 3600s (1h), which should be enough to build anything we want. At the moment building all binaries takes ~8m, so we have a buffer of 52m or 650%.

Further changes made here:

- fix(ci): show logs of gon hooks

  This makes debugging any issues encountered in these steps easier.
- fix(ci): use similar goreleaser settings to tagged release builds

  In release builds we use `--parallelism=2` and the latest goreleaser version. We should use the same settings in our dev builds.