### PR TITLE
feat(primary-ip): add and remove labels

### DIFF
--- a/internal/cmd/primaryip/labels.go
+++ b/internal/cmd/primaryip/labels.go
@@ -1,0 +1,35 @@
+package primaryip
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+var labelCmds = base.LabelCmds{
+	ResourceNameSingular:   "primary-ip",
+	ShortDescriptionAdd:    "Add a label to a Primary IP",
+	ShortDescriptionRemove: "Remove a label from a Primary IP",
+	NameSuggestions:        func(c hcapi2.Client) func() []string { return c.PrimaryIP().Names },
+	LabelKeySuggestions:    func(c hcapi2.Client) func(idOrName string) []string { return c.PrimaryIP().LabelKeys },
+	FetchLabels: func(ctx context.Context, client hcapi2.Client, idOrName string) (map[string]string, int, error) {
+		primaryIP, _, err := client.PrimaryIP().Get(ctx, idOrName)
+		if err != nil {
+			return nil, 0, err
+		}
+		if primaryIP == nil {
+			return nil, 0, fmt.Errorf("primaryIP not found: %s", idOrName)
+		}
+		return primaryIP.Labels, primaryIP.ID, nil
+	},
+	SetLabels: func(ctx context.Context, client hcapi2.Client, id int, labels map[string]string) error {
+		opts := hcloud.PrimaryIPUpdateOpts{
+			Labels: &labels,
+		}
+		_, _, err := client.PrimaryIP().Update(ctx, &hcloud.PrimaryIP{ID: id}, opts)
+		return err
+	},
+}

--- a/internal/cmd/primaryip/primaryip.go
+++ b/internal/cmd/primaryip/primaryip.go
@@ -25,6 +25,8 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		ChangeDNSCmd.CobraCommand(cli.Context, client, cli, cli),
 		EnableProtectionCmd.CobraCommand(cli.Context, client, cli, cli),
 		DisableProtectionCmd.CobraCommand(cli.Context, client, cli, cli),
+		labelCmds.AddCobraCommand(cli.Context, client, cli),
+		labelCmds.RemoveCobraCommand(cli.Context, client, cli),
 	)
 	return cmd
 }


### PR DESCRIPTION
Adds subcommands to add and remove labels from primary-ip resources.