### PR TITLE
fix: improve unset version specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ If you have Go installed, you can build and install the latest version of
 
     go install github.com/hetznercloud/cli/cmd/hcloud@latest
 
+> Binaries built in this way do not have the correct version embedded. Use our
+prebuilt binaries or check out [`.goreleaser.yml`](.goreleaser.yml) to learn
+how to embed it yourself.
+
 ## Getting Started
 
 1.  Visit the Hetzner Cloud Console at [console.hetzner.cloud](https://console.hetzner.cloud/),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is set via compiler flags (see goreleaser config)
-var Version = "was not built properly"
+var Version = "unknown"


### PR DESCRIPTION
The text "not built properly" is factually wrong, as we do recommend building from source if no pre-built binary is available. By using "unknown" instead, we signify that the actual version is just that, unknown.

Closes #437 