### PR TITLE
fix: send debug output to stderr

### DIFF
--- a/internal/state/helpers.go
+++ b/internal/state/helpers.go
@@ -37,7 +37,7 @@ func (c *State) Client() *hcloud.Client {
 		}
 		if c.Debug {
 			if c.DebugFilePath == "" {
-				opts = append(opts, hcloud.WithDebugWriter(os.Stdout))
+				opts = append(opts, hcloud.WithDebugWriter(os.Stderr))
 			} else {
 				writer, _ := os.Create(c.DebugFilePath)
 				opts = append(opts, hcloud.WithDebugWriter(writer))


### PR DESCRIPTION
When enabling debug output (`HCLOUD_DEBUG=true`), this was being printed to stdout by default. If one was using the output of the command in a script, this would break that usage.

By outputting to stderr, we can make sure that the "normal" output still works as expected and can be used in subsequent steps.

For example:

```shell
export HCLOUD_DEBUG=true
IP=$(hcloud server ip hccm-dev-1)
ping $IP
```