### PR TITLE
fix: crash on server create with missing server type

### DIFF
--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -220,6 +220,10 @@ func createOptsFromFlags(
 	if err != nil {
 		return
 	}
+	if serverType == nil {
+		err = fmt.Errorf("server type not found: %s", serverTypeName)
+		return
+	}
 
 	// Select correct image based on server type architecture
 	image, _, err := client.Image().GetForArchitecture(ctx, imageIDorName, serverType.Architecture)


### PR DESCRIPTION
The cli would crash when trying to create a server with a server type that did not exist in the API.