### PR TITLE
ci: bump all actions to latest major version

### DIFF
--- a/.github/workflows/bot_stale.yml
+++ b/.github/workflows/bot_stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v1
+      - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been marked as stale because it has not had recent activity. The bot will close the issue if no further action occurs.'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,52 +11,43 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
+
       - name: Print Go Version
         run: go version
+
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_KEY }}
+          gpg_private_key: ${{ secrets.GPG_KEY }}
+
       - name: Decrypt Secrets
         env:
           SECRETS_PASSWORD: ${{ secrets.SECRETS_PASSWORD }}
         run: bash script/decrypt_secrets.sh
+
       - name: Install gon
         run: |
           wget https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip
           unzip gon_macos.zip
           mv gon /usr/local/bin/gon
           chmod +x /usr/local/bin/gon
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist --skip-publish --skip-sign --parallelism=2
+          args: release --clean --snapshot --skip-sign --parallelism=2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@v3
         with:
-          name: Upload macOS (amd64) Build Artifact
-          path: dist/hcloud-macos-build_darwin_amd64_v1/hcloud
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Upload macOS (arm64) Build Artifact
-          path: dist/hcloud-macos-arm-build_darwin_arm64/hcloud
-      - uses: actions/upload-artifact@v1
-        with:
-          name: Upload Windows AMD64 Build Artifact
-          path: dist/hcloud-build_windows_amd64_v1/hcloud.exe
-      - uses: actions/upload-artifact@v1
-        with:
-          name: Upload Linux AMD64 Build Artifact
-          path: dist/hcloud-build_linux_amd64_v1/hcloud
-      - uses: actions/upload-artifact@v1
-        with:
-          name: Upload FreeBSD AMD64 Build Artifact
-          path: dist/hcloud-build_freebsd_amd64_v1/hcloud
+          name: Preview Binaries
+          path: dist/hcloud-*/hcloud

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,23 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.18]
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+          go-version: 1.18
+
       - name: Get dependencies
         run: |
           go get -u golang.org/x/lint/golint
           go get -v -t -d ./...
+
       - name: Run go fmt
         run: diff -u <(echo -n) <(gofmt -d -s .)
+
       - name: Run tests
         run: |
           go test -v \

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -8,39 +8,41 @@ on:
 jobs:
   release-cli:
     runs-on: macos-latest
-    timeout-minutes: 720
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v3
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
+
       - name: Print Go Version
         run: go version
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY }}
+
       - name: Decrypt Secrets
         env:
           SECRETS_PASSWORD: ${{ secrets.SECRETS_PASSWORD }}
         run: bash script/decrypt_secrets.sh
+
       - name: Install gon
         run: |
           wget https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip
           unzip gon_macos.zip
           mv gon /usr/local/bin/gon
           chmod +x /usr/local/bin/gon
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
-        with:
-          gpg-private-key: ${{ secrets.GPG_KEY }}
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        timeout-minutes: 720
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist --skip-validate --parallelism=2
+          args: release --clean --skip-validate --parallelism=2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HC_APPLE_DEVELOPER_USER: ${{ secrets.HC_APPLE_DEVELOPER_USER }}


### PR DESCRIPTION
These actions were using Node 12, which will be shut down on 2023-05-18: https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

While I was in the files, I also streamlined to workflows so they are more similar to eachother and optimized the asset uploading for preview builds.