### PR TITLE
fix(server): wait for delete before returning

### DIFF
--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -20,7 +20,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		labelCmds.AddCobraCommand(cli.Context, client, cli),
 		labelCmds.RemoveCobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 	)
 

--- a/internal/cmd/certificate/delete.go
+++ b/internal/cmd/certificate/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Certificate().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		certificate := resource.(*hcloud.Certificate)
 		if _, err := client.Certificate().Delete(ctx, certificate); err != nil {
 			return err

--- a/internal/cmd/firewall/delete.go
+++ b/internal/cmd/firewall/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Firewall().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		firewall := resource.(*hcloud.Firewall)
 		if _, err := client.Firewall().Delete(ctx, firewall); err != nil {
 			return err

--- a/internal/cmd/firewall/firewall.go
+++ b/internal/cmd/firewall/firewall.go
@@ -20,7 +20,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		ReplaceRulesCommand.CobraCommand(cli.Context, client, cli, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		AddRuleCommand.CobraCommand(cli.Context, client, cli, cli),
 		DeleteRuleCommand.CobraCommand(cli.Context, client, cli, cli),
 		ApplyToResourceCommand.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/floatingip/delete.go
+++ b/internal/cmd/floatingip/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.FloatingIP().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		floatingIP := resource.(*hcloud.FloatingIP)
 		if _, err := client.FloatingIP().Delete(ctx, floatingIP); err != nil {
 			return err

--- a/internal/cmd/floatingip/floatingip.go
+++ b/internal/cmd/floatingip/floatingip.go
@@ -21,7 +21,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		AssignCommand.CobraCommand(cli.Context, client, cli, cli),
 		UnassignCommand.CobraCommand(cli.Context, client, cli, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		EnableProtectionCommand.CobraCommand(cli.Context, client, cli, cli),
 		DisableProtectionCommand.CobraCommand(cli.Context, client, cli, cli),
 		labelCmds.AddCobraCommand(cli.Context, client, cli),

--- a/internal/cmd/image/delete.go
+++ b/internal/cmd/image/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Image().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		image := resource.(*hcloud.Image)
 		if _, err := client.Image().Delete(ctx, image); err != nil {
 			return err

--- a/internal/cmd/image/image.go
+++ b/internal/cmd/image/image.go
@@ -16,7 +16,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	}
 	cmd.AddCommand(
 		listCmd.CobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		EnableProtectionCommand.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/loadbalancer/delete.go
+++ b/internal/cmd/loadbalancer/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
@@ -17,7 +18,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.LoadBalancer().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		loadBalancer := resource.(*hcloud.LoadBalancer)
 		if _, err := client.LoadBalancer().Delete(ctx, loadBalancer); err != nil {
 			return err

--- a/internal/cmd/loadbalancer/load_balancer.go
+++ b/internal/cmd/loadbalancer/load_balancer.go
@@ -19,7 +19,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		CreateCommand.CobraCommand(cli.Context, client, cli, cli),
 		ListCmd.CobraCommand(cli.Context, client, cli),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		labelCmds.AddCobraCommand(cli.Context, client, cli),
 		labelCmds.RemoveCobraCommand(cli.Context, client, cli),

--- a/internal/cmd/network/delete.go
+++ b/internal/cmd/network/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 
 	"github.com/spf13/cobra"
@@ -17,7 +18,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Network().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		network := resource.(*hcloud.Network)
 		if _, err := client.Network().Delete(ctx, network); err != nil {
 			return err

--- a/internal/cmd/network/network.go
+++ b/internal/cmd/network/network.go
@@ -19,7 +19,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		ChangeIPRangeCommand.CobraCommand(cli.Context, client, cli, cli),
 		AddRouteCommand.CobraCommand(cli.Context, client, cli, cli),
 		RemoveRouteCommand.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/placementgroup/delete.go
+++ b/internal/cmd/placementgroup/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var DeleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.PlacementGroup().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		placementGroup := resource.(*hcloud.PlacementGroup)
 		if _, err := client.PlacementGroup().Delete(ctx, placementGroup); err != nil {
 			return err

--- a/internal/cmd/placementgroup/delete_test.go
+++ b/internal/cmd/placementgroup/delete_test.go
@@ -19,7 +19,8 @@ func TestDelete(t *testing.T) {
 	cmd := placementgroup.DeleteCmd.CobraCommand(
 		context.Background(),
 		fx.Client,
-		fx.TokenEnsurer)
+		fx.TokenEnsurer,
+		fx.ActionWaiter)
 	fx.ExpectEnsureToken()
 
 	placementGroup := hcloud.PlacementGroup{

--- a/internal/cmd/placementgroup/placementgroup.go
+++ b/internal/cmd/placementgroup/placementgroup.go
@@ -19,7 +19,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		ListCmd.CobraCommand(cli.Context, client, cli),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 		UpdateCmd.CobraCommand(cli.Context, client, cli),
-		DeleteCmd.CobraCommand(cli.Context, client, cli),
+		DeleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		LabelCmds.AddCobraCommand(cli.Context, client, cli),
 		LabelCmds.RemoveCobraCommand(cli.Context, client, cli),
 	)

--- a/internal/cmd/primaryip/delete.go
+++ b/internal/cmd/primaryip/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.PrimaryIP().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		primaryIP := resource.(*hcloud.PrimaryIP)
 		if _, err := client.PrimaryIP().Delete(ctx, primaryIP); err != nil {
 			return err

--- a/internal/cmd/primaryip/delete_test.go
+++ b/internal/cmd/primaryip/delete_test.go
@@ -14,7 +14,7 @@ func TestDelete(t *testing.T) {
 	fx := testutil.NewFixture(t)
 	defer fx.Finish()
 
-	cmd := deleteCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer)
+	cmd := deleteCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer, fx.ActionWaiter)
 	primaryip := &hcloud.PrimaryIP{ID: 13}
 	fx.ExpectEnsureToken()
 	fx.Client.PrimaryIPClient.EXPECT().

--- a/internal/cmd/primaryip/primaryip.go
+++ b/internal/cmd/primaryip/primaryip.go
@@ -19,7 +19,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		CreateCmd.CobraCommand(cli.Context, client, cli, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		AssignCmd.CobraCommand(cli.Context, client, cli, cli),
 		UnAssignCmd.CobraCommand(cli.Context, client, cli, cli),
 		ChangeDNSCmd.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/server/delete.go
+++ b/internal/cmd/server/delete.go
@@ -18,11 +18,17 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Server().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, actionWaiter state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		server := resource.(*hcloud.Server)
-		if _, err := client.Server().Delete(ctx, server); err != nil {
+		result, _, err := client.Server().DeleteWithResult(ctx, server)
+		if err != nil {
 			return err
 		}
+
+		if err := actionWaiter.ActionProgress(ctx, result.Action); err != nil {
+			return err
+		}
+
 		return nil
 	},
 }

--- a/internal/cmd/server/delete.go
+++ b/internal/cmd/server/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 
 	"github.com/spf13/cobra"
@@ -17,7 +18,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Server().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		server := resource.(*hcloud.Server)
 		if _, err := client.Server().Delete(ctx, server); err != nil {
 			return err

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -18,7 +18,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		ListCmd.CobraCommand(cli.Context, client, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		CreateCmd.CobraCommand(cli.Context, client, cli, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		RebootCommand.CobraCommand(cli.Context, client, cli, cli),
 		PoweronCommand.CobraCommand(cli.Context, client, cli, cli),
 		PoweroffCommand.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/sshkey/delete.go
+++ b/internal/cmd/sshkey/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.SSHKey().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		sshKey := resource.(*hcloud.SSHKey)
 		if _, err := client.SSHKey().Delete(ctx, sshKey); err != nil {
 			return err

--- a/internal/cmd/sshkey/sshkey.go
+++ b/internal/cmd/sshkey/sshkey.go
@@ -18,7 +18,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		listCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		labelCmds.AddCobraCommand(cli.Context, client, cli),
 		labelCmds.RemoveCobraCommand(cli.Context, client, cli),

--- a/internal/cmd/volume/delete.go
+++ b/internal/cmd/volume/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,7 @@ var deleteCmd = base.DeleteCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Volume().Get(ctx, idOrName)
 	},
-	Delete: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
+	Delete: func(ctx context.Context, client hcapi2.Client, _ state.ActionWaiter, cmd *cobra.Command, resource interface{}) error {
 		volume := resource.(*hcloud.Volume)
 		if _, err := client.Volume().Delete(ctx, volume); err != nil {
 			return err

--- a/internal/cmd/volume/volume.go
+++ b/internal/cmd/volume/volume.go
@@ -18,7 +18,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		listCmd.CobraCommand(cli.Context, client, cli),
 		CreateCommand.CobraCommand(cli.Context, client, cli, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
-		deleteCmd.CobraCommand(cli.Context, client, cli),
+		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		AttachCommand.CobraCommand(cli.Context, client, cli, cli),
 		DetachCommand.CobraCommand(cli.Context, client, cli, cli),


### PR DESCRIPTION
The `hcloud server delete` command returned before the action was actually awaited. This caused a race condition when creating new servers with the same name.