### PR TITLE
fix(primary-ip): assignee-id was not correctly passed when creating the IP

### DIFF
--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -28,7 +28,7 @@ var CreateCmd = base.Cmd{
 		cmd.Flags().String("name", "", "Name (required)")
 		cmd.MarkFlagRequired("name")
 
-		cmd.Flags().String("assignee-id", "", "Assignee (usually a server) to assign Primary IP to")
+		cmd.Flags().Int("assignee-id", 0, "Assignee (usually a server) to assign Primary IP to")
 
 		cmd.Flags().String("datacenter", "", "Datacenter (ID or name)")
 		cmd.RegisterFlagCompletionFunc("datacenter", cmpl.SuggestCandidatesF(client.Datacenter().Names))


### PR DESCRIPTION
When creating a Primary IP and directly assigning it to a server, the id was not passed on to the API. This caused the API request to error:

```shell
➜ hcloud primary-ip create --type ipv4 --name test --assignee-id 1234
hcloud: invalid input in fields 'assignee_id', 'datacenter' (invalid_input)
```