### PR TITLE
ci: fix gitlab pipeline not running

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,8 @@
+include:
+  - project: cloud/integrations/ci
+    file:
+      - default.yml
+
 variables:
   COVERAGE_FILE: .testCoverage.txt
 


### PR DESCRIPTION
The CI pipeline is not running because of a missing tag.

I am moving the default GitLab pipeline config (job tags, job templates) to a shared repository.
