### PR TITLE
Make image subcommand descriptions consistent

### DIFF
--- a/internal/cmd/image/delete.go
+++ b/internal/cmd/image/delete.go
@@ -12,7 +12,7 @@ import (
 
 var deleteCmd = base.DeleteCmd{
 	ResourceNameSingular: "image",
-	ShortDescription:     "Delete a image",
+	ShortDescription:     "Delete an image",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Image().Names },
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Image().Get(ctx, idOrName)

--- a/internal/cmd/image/list.go
+++ b/internal/cmd/image/list.go
@@ -20,7 +20,7 @@ import (
 )
 
 var listCmd = base.ListCmd{
-	ResourceNamePlural: "Images",
+	ResourceNamePlural: "images",
 	DefaultColumns:     []string{"id", "type", "name", "description", "architecture", "image_size", "disk_size", "created", "deprecated"},
 	AdditionalFlags: func(cmd *cobra.Command) {
 		cmd.Flags().StringP("type", "t", "", "Only show images of given type")

--- a/internal/cmd/image/update.go
+++ b/internal/cmd/image/update.go
@@ -13,7 +13,7 @@ import (
 
 var updateCmd = base.UpdateCmd{
 	ResourceNameSingular: "Image",
-	ShortDescription:     "Update a Image",
+	ShortDescription:     "Update an image",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Image().Names },
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.Image().Get(ctx, idOrName)


### PR DESCRIPTION
This makes the descriptions for the `delete`, `list`, and `update` sub-commands of the `image` command consistent in sentence-case English.

**Screenshots**

| Before | After |
| --- | --- |
| ![image](https://github.com/hetznercloud/cli/assets/28510368/b3c38519-3693-4ed8-8280-4f1aa1a7f585) | ![image](https://github.com/hetznercloud/cli/assets/28510368/56977cba-4a02-4d92-8df9-757409680598) |

**How to test**

1. Run `go run ./cmd/hcloud/ image help`
2. See the updated descriptions under **Available Commands**