### PR TITLE
fix(output): ID column could not be selected

### DIFF
--- a/internal/cmd/output/output.go
+++ b/internal/cmd/output/output.go
@@ -206,7 +206,8 @@ func (o *Table) AddAllowedFields(obj interface{}) *Table {
 			k != reflect.Float32 &&
 			k != reflect.Float64 &&
 			k != reflect.String &&
-			k != reflect.Int {
+			k != reflect.Int &&
+			k != reflect.Int64 {
 			// only allow simple values
 			// complex values need to be mapped via a FieldFn
 			continue


### PR DESCRIPTION
Because we changed the type of ID fields but did not update the code that reflects on the structs to also allow int64 fields.

Broken since #512