### PR TITLE
feat: allow formatting a volume without automounting it

### DIFF
--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -35,7 +35,7 @@ var CreateCommand = base.Cmd{
 		cmd.MarkFlagRequired("size")
 
 		cmd.Flags().Bool("automount", false, "Automount volume after attach (server must be provided)")
-		cmd.Flags().String("format", "", "Format volume after creation (automount must be enabled)")
+		cmd.Flags().String("format", "", "Format volume after creation")
 
 		cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
 
@@ -76,9 +76,9 @@ var CreateCommand = base.Cmd{
 		}
 		if automount {
 			opts.Automount = &automount
-			if format != "" {
-				opts.Format = &format
-			}
+		}
+		if format != "" {
+			opts.Format = &format
 		}
 
 		result, _, err := client.Volume().Create(ctx, opts)

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -35,7 +35,9 @@ var CreateCommand = base.Cmd{
 		cmd.MarkFlagRequired("size")
 
 		cmd.Flags().Bool("automount", false, "Automount volume after attach (server must be provided)")
-		cmd.Flags().String("format", "", "Format volume after creation")
+
+		cmd.Flags().String("format", "", "Format volume after creation (ext4 or xfs)")
+		cmd.RegisterFlagCompletionFunc("format", cmpl.SuggestCandidates("ext4", "xfs"))
 
 		cmd.Flags().StringToString("label", nil, "User-defined labels ('key=value') (can be specified multiple times)")
 


### PR DESCRIPTION
* Fixes #529

### To Do
- [x] document supported volume formats (this can be done either hard-coded or fetched from somewhere, but that may require changing the REST API service, so I left that open for now)