### PR TITLE
docs(load_balancer): word mistake in help output

### DIFF
--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -16,7 +16,7 @@ var AddServiceCommand = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
 			Use:                   "add-service LOADBALANCER FLAGS",
-			Short:                 "Add a service from a Load Balancer",
+			Short:                 "Add a service to a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),
 			TraverseChildren:      true,

--- a/internal/cmd/loadbalancer/remove_target.go
+++ b/internal/cmd/loadbalancer/remove_target.go
@@ -18,7 +18,7 @@ var RemoveTargetCommand = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
 			Use:                   "remove-target LOADBALANCER FLAGS",
-			Short:                 "Remove a target to a Load Balancer",
+			Short:                 "Remove a target from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),
 			TraverseChildren:      true,


### PR DESCRIPTION
Spotted a slight wording error while I was creating a load balancer. The help states `remove-target            Remove a target to a Load Balancer`. This should be `Remove a target from a Load Balancer` imo.