### PR TITLE
feat(primary-ip): enable/disable-protection accept levels as arguments

### DIFF
--- a/internal/cmd/primaryip/enable_protection.go
+++ b/internal/cmd/primaryip/enable_protection.go
@@ -3,6 +3,7 @@ package primaryip
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 
@@ -16,11 +17,12 @@ import (
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "enable-protection PRIMARYIP",
+			Use:   "enable-protection PRIMARYIP [PROTECTIONLEVEL...]",
 			Short: "Enable Protection for a Primary IP",
-			Args:  cobra.ExactArgs(1),
+			Args:  cobra.MinimumNArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(
 				cmpl.SuggestCandidatesF(client.PrimaryIP().Names),
+				cmpl.SuggestCandidates("delete"),
 			),
 			TraverseChildren:      true,
 			DisableFlagsInUseLine: true,
@@ -37,9 +39,24 @@ var EnableProtectionCmd = base.Cmd{
 			return fmt.Errorf("Primary IP not found: %v", idOrName)
 		}
 
-		opts := hcloud.PrimaryIPChangeProtectionOpts{
-			ID:     primaryIP.ID,
-			Delete: true,
+		// This command used to have the "delete" protection level as the default.
+		// To avoid a breaking change, we now add it if no level is defined.
+		if len(args) < 2 {
+			args = append(args, "delete")
+		}
+
+		var unknown []string
+		opts := hcloud.PrimaryIPChangeProtectionOpts{ID: primaryIP.ID}
+		for _, arg := range args[1:] {
+			switch strings.ToLower(arg) {
+			case "delete":
+				opts.Delete = true
+			default:
+				unknown = append(unknown, arg)
+			}
+		}
+		if len(unknown) > 0 {
+			return fmt.Errorf("unknown protection level: %s", strings.Join(unknown, ", "))
 		}
 
 		action, _, err := client.PrimaryIP().ChangeProtection(ctx, opts)


### PR DESCRIPTION
This PR changes how enable/disable-protection works on primary IPs. You can now pass the protection level as an optional argument. This is to make it consistent with other enable/disable-protection commands.