### PR TITLE
refactor: export list commands and only pass flags to ListCmd.Fetch

### DIFF
--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -3,6 +3,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
@@ -16,7 +17,7 @@ import (
 type ListCmd struct {
 	ResourceNamePlural string // e.g. "servers"
 	DefaultColumns     []string
-	Fetch              func(context.Context, hcapi2.Client, *cobra.Command, hcloud.ListOpts, []string) ([]interface{}, error)
+	Fetch              func(context.Context, hcapi2.Client, *pflag.FlagSet, hcloud.ListOpts, []string) ([]interface{}, error)
 	AdditionalFlags    func(*cobra.Command)
 	OutputTable        func(client hcapi2.Client) *output.Table
 	JSONSchema         func([]interface{}) interface{}
@@ -62,7 +63,7 @@ func (lc *ListCmd) Run(ctx context.Context, client hcapi2.Client, cmd *cobra.Com
 	}
 	sorts, _ := cmd.Flags().GetStringSlice("sort")
 
-	resources, err := lc.Fetch(ctx, client, cmd, listOpts, sorts)
+	resources, err := lc.Fetch(ctx, client, cmd.Flags(), listOpts, sorts)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		labelCmds.AddCobraCommand(cli.Context, client, cli),

--- a/internal/cmd/certificate/list.go
+++ b/internal/cmd/certificate/list.go
@@ -2,24 +2,23 @@ package certificate
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/spf13/cobra"
-
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "certificates",
 	DefaultColumns:     []string{"id", "name", "type", "domain_names", "not_valid_after", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.CertificateListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/datacenter/datacenter.go
+++ b/internal/cmd/datacenter/datacenter.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/datacenter/list.go
+++ b/internal/cmd/datacenter/list.go
@@ -2,8 +2,7 @@ package datacenter
 
 import (
 	"context"
-
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
@@ -13,11 +12,11 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "datacenters",
 	DefaultColumns:     []string{"id", "name", "description", "location"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.DatacenterListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/firewall/firewall.go
+++ b/internal/cmd/firewall/firewall.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/firewall/list.go
+++ b/internal/cmd/firewall/list.go
@@ -3,20 +3,20 @@ package firewall
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "Firewalls",
 	DefaultColumns:     []string{"id", "name", "rules_count", "applied_to_count"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.FirewallListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/floatingip/floatingip.go
+++ b/internal/cmd/floatingip/floatingip.go
@@ -16,7 +16,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 	}
 	cmd.AddCommand(
 		updateCmd.CobraCommand(cli.Context, client, cli),
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		CreateCommand.CobraCommand(cli.Context, client, cli, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		AssignCommand.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/floatingip/list.go
+++ b/internal/cmd/floatingip/list.go
@@ -3,10 +3,9 @@ package floatingip
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
-
-	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
@@ -18,11 +17,11 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "Floating IPs",
 	DefaultColumns:     []string{"id", "type", "name", "description", "ip", "home", "server", "dns", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.FloatingIPListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/image/image.go
+++ b/internal/cmd/image/image.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/image/list.go
+++ b/internal/cmd/image/list.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "images",
 	DefaultColumns:     []string{"id", "type", "name", "description", "architecture", "image_size", "disk_size", "created", "deprecated"},
 	AdditionalFlags: func(cmd *cobra.Command) {
@@ -29,15 +30,15 @@ var listCmd = base.ListCmd{
 		cmd.Flags().StringSliceP("architecture", "a", []string{}, "Only show images of given architecture: x86|arm")
 		cmd.RegisterFlagCompletionFunc("architecture", cmpl.SuggestCandidates(string(hcloud.ArchitectureX86), string(hcloud.ArchitectureARM)))
 	},
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, flags *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.ImageListOpts{ListOpts: listOpts, IncludeDeprecated: true}
 
-		imageType, _ := cmd.Flags().GetString("type")
+		imageType, _ := flags.GetString("type")
 		if len(imageType) > 0 {
 			opts.Type = []hcloud.ImageType{hcloud.ImageType(imageType)}
 		}
 
-		architecture, _ := cmd.Flags().GetStringSlice("architecture")
+		architecture, _ := flags.GetStringSlice("architecture")
 		if len(architecture) > 0 {
 			for _, arch := range architecture {
 				opts.Architecture = append(opts.Architecture, hcloud.Architecture(arch))

--- a/internal/cmd/iso/iso.go
+++ b/internal/cmd/iso/iso.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/iso/list.go
+++ b/internal/cmd/iso/list.go
@@ -2,6 +2,7 @@ package iso
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 
@@ -14,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "isos",
 	DefaultColumns:     []string{"id", "name", "description", "type", "architecture"},
 	AdditionalFlags: func(cmd *cobra.Command) {
@@ -24,17 +25,17 @@ var listCmd = base.ListCmd{
 		cmd.Flags().Bool("include-architecture-wildcard", false, "Include ISOs with unknown architecture, only required if you want so show custom ISOs and still filter for architecture.")
 	},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, flags *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.ISOListOpts{ListOpts: listOpts}
 
-		architecture, _ := cmd.Flags().GetStringSlice("architecture")
+		architecture, _ := flags.GetStringSlice("architecture")
 		if len(architecture) > 0 {
 			for _, arch := range architecture {
 				opts.Architecture = append(opts.Architecture, hcloud.Architecture(arch))
 			}
 		}
 
-		includeArchitectureWildcard, _ := cmd.Flags().GetBool("include-architecture-wildcard")
+		includeArchitectureWildcard, _ := flags.GetBool("include-architecture-wildcard")
 		if includeArchitectureWildcard {
 			opts.IncludeWildcardArchitecture = includeArchitectureWildcard
 		}

--- a/internal/cmd/loadbalancer/list.go
+++ b/internal/cmd/loadbalancer/list.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
@@ -9,17 +10,15 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{
 	ResourceNamePlural: "Load Balancer",
 
 	DefaultColumns: []string{"id", "name", "health", "ipv4", "ipv6", "type", "location", "network_zone", "age"},
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.LoadBalancerListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/loadbalancertype/list.go
+++ b/internal/cmd/loadbalancertype/list.go
@@ -2,15 +2,14 @@ package loadbalancertype
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{
@@ -18,7 +17,7 @@ var ListCmd = base.ListCmd{
 
 	DefaultColumns: []string{"id", "name", "description", "max_services", "max_connections", "max_targets"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.LoadBalancerTypeListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/location/list.go
+++ b/internal/cmd/location/list.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
@@ -9,14 +10,13 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "locations",
 	DefaultColumns:     []string{"id", "name", "description", "network_zone", "country", "city"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.LocationListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/location/location.go
+++ b/internal/cmd/location/location.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		DescribeCmd.CobraCommand(cli.Context, client, cli),
 	)
 	return cmd

--- a/internal/cmd/network/list.go
+++ b/internal/cmd/network/list.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
@@ -12,14 +13,13 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
 )
 
 var ListCmd = base.ListCmd{
 	ResourceNamePlural: "networks",
 	DefaultColumns:     []string{"id", "name", "ip_range", "servers", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.NetworkListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/placementgroup/list.go
+++ b/internal/cmd/placementgroup/list.go
@@ -3,6 +3,7 @@ package placementgroup
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"time"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
@@ -11,14 +12,13 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
 )
 
 var ListCmd = base.ListCmd{
 	ResourceNamePlural: "placement groups",
 	DefaultColumns:     []string{"id", "name", "servers", "type", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.PlacementGroupListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/primaryip/list.go
+++ b/internal/cmd/primaryip/list.go
@@ -3,6 +3,7 @@ package primaryip
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
@@ -13,14 +14,13 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "Primary IPs",
 	DefaultColumns:     []string{"id", "type", "name", "ip", "assignee", "dns", "auto_delete", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.PrimaryIPListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/primaryip/list_test.go
+++ b/internal/cmd/primaryip/list_test.go
@@ -16,7 +16,7 @@ func TestList(t *testing.T) {
 	fx := testutil.NewFixture(t)
 	defer fx.Finish()
 
-	cmd := listCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer)
+	cmd := ListCmd.CobraCommand(context.Background(), fx.Client, fx.TokenEnsurer)
 
 	fx.ExpectEnsureToken()
 	fx.Client.PrimaryIPClient.EXPECT().

--- a/internal/cmd/primaryip/primaryip.go
+++ b/internal/cmd/primaryip/primaryip.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		describeCmd.CobraCommand(cli.Context, client, cli),
 		CreateCmd.CobraCommand(cli.Context, client, cli, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),

--- a/internal/cmd/server/list.go
+++ b/internal/cmd/server/list.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 	"strconv"
 	"strings"
 	"time"
@@ -12,10 +13,8 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{
@@ -23,7 +22,7 @@ var ListCmd = base.ListCmd{
 
 	DefaultColumns: []string{"id", "name", "status", "ipv4", "ipv6", "private_net", "datacenter", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.ServerListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/servertype/list.go
+++ b/internal/cmd/servertype/list.go
@@ -3,15 +3,14 @@ package servertype
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{
@@ -19,7 +18,7 @@ var ListCmd = base.ListCmd{
 
 	DefaultColumns: []string{"id", "name", "cores", "cpu_type", "architecture", "memory", "disk", "storage_type", "traffic"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.ServerTypeListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/sshkey/list.go
+++ b/internal/cmd/sshkey/list.go
@@ -2,6 +2,7 @@ package sshkey
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 	"time"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
@@ -10,14 +11,13 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "ssh keys",
 	DefaultColumns:     []string{"id", "name", "fingerprint", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.SSHKeyListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/sshkey/sshkey.go
+++ b/internal/cmd/sshkey/sshkey.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		newCreateCommand(cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli, cli),

--- a/internal/cmd/volume/list.go
+++ b/internal/cmd/volume/list.go
@@ -2,10 +2,9 @@ package volume
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 	"strings"
 	"time"
-
-	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
@@ -18,11 +17,11 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var listCmd = base.ListCmd{
+var ListCmd = base.ListCmd{
 	ResourceNamePlural: "volumes",
 	DefaultColumns:     []string{"id", "name", "size", "server", "location", "age"},
 
-	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(ctx context.Context, client hcapi2.Client, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
 		opts := hcloud.VolumeListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts

--- a/internal/cmd/volume/volume.go
+++ b/internal/cmd/volume/volume.go
@@ -15,7 +15,7 @@ func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {
 		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		listCmd.CobraCommand(cli.Context, client, cli),
+		ListCmd.CobraCommand(cli.Context, client, cli),
 		CreateCommand.CobraCommand(cli.Context, client, cli, cli),
 		updateCmd.CobraCommand(cli.Context, client, cli),
 		deleteCmd.CobraCommand(cli.Context, client, cli, cli),


### PR DESCRIPTION
In preparation for #545