### PR TITLE
refactor: sort imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,10 @@
 ---
 linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/hetznercloud)
   exhaustive:
     default-signifies-exhaustive: true
   gomodguard:
@@ -52,7 +57,7 @@ linters:
     - exhaustive
     # - gocritic
     # - golint
-    # - goimports
+    - gci
     - gomodguard
     - gosec
     # - gosimple

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/certificate"
 	"github.com/hetznercloud/cli/internal/cmd/completion"
 	"github.com/hetznercloud/cli/internal/cmd/context"
@@ -24,7 +26,6 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/volume"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewRootCommand(state *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/base/cmd.go
+++ b/internal/cmd/base/cmd.go
@@ -3,10 +3,11 @@ package base
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 // Cmd allows defining commands for generic resource-based commands

--- a/internal/cmd/base/delete.go
+++ b/internal/cmd/base/delete.go
@@ -6,12 +6,13 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 // DeleteCmd allows defining commands for deleting a resource.

--- a/internal/cmd/base/describe.go
+++ b/internal/cmd/base/describe.go
@@ -8,13 +8,14 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 // DescribeCmd allows defining commands for describing a resource.

--- a/internal/cmd/base/labels.go
+++ b/internal/cmd/base/labels.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 // LabelCmds allows defining commands for adding labels to resources.

--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -3,6 +3,8 @@ package base
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/output"
@@ -10,7 +12,6 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 // ListCmd allows defining commands for listing resources

--- a/internal/cmd/base/set_rdns.go
+++ b/internal/cmd/base/set_rdns.go
@@ -7,12 +7,13 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 // SetRdnsCmd allows defining commands for setting the RDNS of a resource.

--- a/internal/cmd/base/update.go
+++ b/internal/cmd/base/update.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
@@ -13,7 +14,6 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 // UpdateCmd allows defining commands for updating a resource.

--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -1,9 +1,10 @@
 package certificate
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/certificate/create.go
+++ b/internal/cmd/certificate/create.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func newCreateCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/certificate/delete.go
+++ b/internal/cmd/certificate/delete.go
@@ -3,11 +3,12 @@ package certificate
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/certificate/describe.go
+++ b/internal/cmd/certificate/describe.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/dustin/go-humanize"
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/certificate/list.go
+++ b/internal/cmd/certificate/list.go
@@ -2,9 +2,10 @@ package certificate
 
 import (
 	"context"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"

--- a/internal/cmd/certificate/update.go
+++ b/internal/cmd/certificate/update.go
@@ -3,12 +3,12 @@ package certificate
 import (
 	"context"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/cmpl/suggestions_test.go
+++ b/internal/cmd/cmpl/suggestions_test.go
@@ -3,9 +3,10 @@ package cmpl_test
 import (
 	"testing"
 
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 )
 
 func TestSuggestCandidates(t *testing.T) {

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hetznercloud/cli/internal/state"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/state"
 )
 
 // const (

--- a/internal/cmd/context/active.go
+++ b/internal/cmd/context/active.go
@@ -3,8 +3,9 @@ package context
 import (
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/state"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/state"
 )
 
 func newActiveCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/context/context.go
+++ b/internal/cmd/context/context.go
@@ -1,8 +1,9 @@
 package context
 
 import (
-	"github.com/hetznercloud/cli/internal/state"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/state"
 )
 
 func NewCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/context/create.go
+++ b/internal/cmd/context/create.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/hetznercloud/cli/internal/state"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/hetznercloud/cli/internal/state"
 )
 
 func newCreateCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/context/delete.go
+++ b/internal/cmd/context/delete.go
@@ -3,9 +3,10 @@ package context
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func newDeleteCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/context/list.go
+++ b/internal/cmd/context/list.go
@@ -1,10 +1,11 @@
 package context
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var listTableOutput *output.Table

--- a/internal/cmd/context/use.go
+++ b/internal/cmd/context/use.go
@@ -3,9 +3,10 @@ package context
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func newUseCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/datacenter/datacenter.go
+++ b/internal/cmd/datacenter/datacenter.go
@@ -1,9 +1,10 @@
 package datacenter
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/datacenter/describe.go
+++ b/internal/cmd/datacenter/describe.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var describeCmd = base.DescribeCmd{

--- a/internal/cmd/datacenter/list.go
+++ b/internal/cmd/datacenter/list.go
@@ -2,6 +2,7 @@ package datacenter
 
 import (
 	"context"
+
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"

--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 var AddRuleCommand = base.Cmd{

--- a/internal/cmd/firewall/apply_to_resource.go
+++ b/internal/cmd/firewall/apply_to_resource.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 var ApplyToResourceCommand = base.Cmd{

--- a/internal/cmd/firewall/create.go
+++ b/internal/cmd/firewall/create.go
@@ -7,12 +7,12 @@ import (
 	"net"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 func newCreateCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/firewall/delete.go
+++ b/internal/cmd/firewall/delete.go
@@ -3,11 +3,12 @@ package firewall
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -6,13 +6,13 @@ import (
 	"net"
 	"reflect"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 var DeleteRuleCommand = base.Cmd{

--- a/internal/cmd/firewall/describe.go
+++ b/internal/cmd/firewall/describe.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/dustin/go-humanize"
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"

--- a/internal/cmd/firewall/firewall.go
+++ b/internal/cmd/firewall/firewall.go
@@ -1,9 +1,10 @@
 package firewall
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/firewall/list.go
+++ b/internal/cmd/firewall/list.go
@@ -3,6 +3,7 @@ package firewall
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"

--- a/internal/cmd/firewall/remove_from_resource.go
+++ b/internal/cmd/firewall/remove_from_resource.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var RemoveFromResourceCommand = base.Cmd{

--- a/internal/cmd/firewall/replace_rules.go
+++ b/internal/cmd/firewall/replace_rules.go
@@ -8,14 +8,14 @@ import (
 	"net"
 	"os"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 	"github.com/spf13/cobra"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ReplaceRulesCommand = base.Cmd{

--- a/internal/cmd/firewall/update.go
+++ b/internal/cmd/firewall/update.go
@@ -3,12 +3,12 @@ package firewall
 import (
 	"context"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/floatingip/assign.go
+++ b/internal/cmd/floatingip/assign.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var AssignCommand = base.Cmd{

--- a/internal/cmd/floatingip/create.go
+++ b/internal/cmd/floatingip/create.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var CreateCommand = base.Cmd{

--- a/internal/cmd/floatingip/delete.go
+++ b/internal/cmd/floatingip/delete.go
@@ -3,11 +3,12 @@ package floatingip
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/floatingip/describe.go
+++ b/internal/cmd/floatingip/describe.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/dustin/go-humanize"
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/floatingip/disable_protection.go
+++ b/internal/cmd/floatingip/disable_protection.go
@@ -3,11 +3,13 @@ package floatingip
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableProtectionCommand = base.Cmd{

--- a/internal/cmd/floatingip/enable_protection.go
+++ b/internal/cmd/floatingip/enable_protection.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.FloatingIPChangeProtectionOpts, error) {

--- a/internal/cmd/floatingip/floatingip.go
+++ b/internal/cmd/floatingip/floatingip.go
@@ -1,9 +1,10 @@
 package floatingip
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/floatingip/list.go
+++ b/internal/cmd/floatingip/list.go
@@ -3,18 +3,17 @@ package floatingip
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/spf13/pflag"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{

--- a/internal/cmd/floatingip/set_rdns.go
+++ b/internal/cmd/floatingip/set_rdns.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var setRDNSCmd = base.SetRdnsCmd{

--- a/internal/cmd/floatingip/unassign.go
+++ b/internal/cmd/floatingip/unassign.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var UnassignCommand = base.Cmd{

--- a/internal/cmd/floatingip/update.go
+++ b/internal/cmd/floatingip/update.go
@@ -3,11 +3,12 @@ package floatingip
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/image/delete.go
+++ b/internal/cmd/image/delete.go
@@ -3,11 +3,12 @@ package image
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/image/describe.go
+++ b/internal/cmd/image/describe.go
@@ -6,12 +6,13 @@ import (
 	"os"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var describeCmd = base.DescribeCmd{

--- a/internal/cmd/image/disable_protection.go
+++ b/internal/cmd/image/disable_protection.go
@@ -3,13 +3,15 @@ package image
 import (
 	"context"
 	"errors"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"strconv"
 )
 
 var DisableProtectionCommand = base.Cmd{

--- a/internal/cmd/image/enable_protection.go
+++ b/internal/cmd/image/enable_protection.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.ImageChangeProtectionOpts, error) {

--- a/internal/cmd/image/image.go
+++ b/internal/cmd/image/image.go
@@ -1,9 +1,10 @@
 package image
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/image/list.go
+++ b/internal/cmd/image/list.go
@@ -3,21 +3,20 @@ package image
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-
-	humanize "github.com/dustin/go-humanize"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{

--- a/internal/cmd/image/update.go
+++ b/internal/cmd/image/update.go
@@ -3,12 +3,13 @@ package image
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/iso/describe.go
+++ b/internal/cmd/iso/describe.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/iso/iso.go
+++ b/internal/cmd/iso/iso.go
@@ -1,9 +1,10 @@
 package iso
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/iso/list.go
+++ b/internal/cmd/iso/list.go
@@ -2,17 +2,17 @@ package iso
 
 import (
 	"context"
+
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
-
 	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-	"github.com/spf13/cobra"
 )
 
 var ListCmd = base.ListCmd{

--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AddServiceCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/add_target.go
+++ b/internal/cmd/loadbalancer/add_target.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AddTargetCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/attach_to_network.go
+++ b/internal/cmd/loadbalancer/attach_to_network.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AttachToNetworkCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/change_algorithm.go
+++ b/internal/cmd/loadbalancer/change_algorithm.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ChangeAlgorithmCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/change_type.go
+++ b/internal/cmd/loadbalancer/change_type.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ChangeTypeCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var CreateCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/delete_service.go
+++ b/internal/cmd/loadbalancer/delete_service.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DeleteServiceCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/describe.go
+++ b/internal/cmd/loadbalancer/describe.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-
 	humanize "github.com/dustin/go-humanize"
-	"github.com/hetznercloud/cli/internal/cmd/util"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 // DescribeCmd defines a command for describing a LoadBalancer.

--- a/internal/cmd/loadbalancer/detach_from_network.go
+++ b/internal/cmd/loadbalancer/detach_from_network.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-
-	"github.com/spf13/cobra"
 )
 
 var DetachFromNetworkCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/disable_protection.go
+++ b/internal/cmd/loadbalancer/disable_protection.go
@@ -3,11 +3,13 @@ package loadbalancer
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableProtectionCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/disable_public_interface.go
+++ b/internal/cmd/loadbalancer/disable_public_interface.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisablePublicInterfaceCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/enable_protection.go
+++ b/internal/cmd/loadbalancer/enable_protection.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.LoadBalancerChangeProtectionOpts, error) {

--- a/internal/cmd/loadbalancer/enable_public_interface.go
+++ b/internal/cmd/loadbalancer/enable_public_interface.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var EnablePublicInterfaceCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/list.go
+++ b/internal/cmd/loadbalancer/list.go
@@ -2,9 +2,10 @@ package loadbalancer
 
 import (
 	"context"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"

--- a/internal/cmd/loadbalancer/list_test.go
+++ b/internal/cmd/loadbalancer/list_test.go
@@ -3,8 +3,9 @@ package loadbalancer
 import (
 	"testing"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func TestLoadBalancerHealth(t *testing.T) {

--- a/internal/cmd/loadbalancer/load_balancer.go
+++ b/internal/cmd/loadbalancer/load_balancer.go
@@ -1,9 +1,10 @@
 package loadbalancer
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/loadbalancer/metrics.go
+++ b/internal/cmd/loadbalancer/metrics.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/guptarohit/asciigraph"
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/output"
@@ -16,7 +18,6 @@ import (
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var MetricsCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/remove_target.go
+++ b/internal/cmd/loadbalancer/remove_target.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var RemoveTargetCommand = base.Cmd{

--- a/internal/cmd/loadbalancer/set_rdns.go
+++ b/internal/cmd/loadbalancer/set_rdns.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var setRDNSCmd = base.SetRdnsCmd{

--- a/internal/cmd/loadbalancer/update.go
+++ b/internal/cmd/loadbalancer/update.go
@@ -3,11 +3,12 @@ package loadbalancer
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var UpdateServiceCommand = base.Cmd{

--- a/internal/cmd/loadbalancertype/describe.go
+++ b/internal/cmd/loadbalancertype/describe.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/spf13/cobra"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/loadbalancertype/list.go
+++ b/internal/cmd/loadbalancertype/list.go
@@ -2,6 +2,7 @@ package loadbalancertype
 
 import (
 	"context"
+
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"

--- a/internal/cmd/loadbalancertype/load_balancer_type.go
+++ b/internal/cmd/loadbalancertype/load_balancer_type.go
@@ -1,9 +1,10 @@
 package loadbalancertype
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/location/describe_test.go
+++ b/internal/cmd/location/describe_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/location"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDescribe(t *testing.T) {

--- a/internal/cmd/location/list.go
+++ b/internal/cmd/location/list.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"context"
+
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"

--- a/internal/cmd/location/location.go
+++ b/internal/cmd/location/location.go
@@ -1,9 +1,10 @@
 package location
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/network/add_route.go
+++ b/internal/cmd/network/add_route.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AddRouteCommand = base.Cmd{

--- a/internal/cmd/network/add_subnet.go
+++ b/internal/cmd/network/add_subnet.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AddSubnetCommand = base.Cmd{

--- a/internal/cmd/network/change_ip_range.go
+++ b/internal/cmd/network/change_ip_range.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ChangeIPRangeCommand = base.Cmd{

--- a/internal/cmd/network/create.go
+++ b/internal/cmd/network/create.go
@@ -1,13 +1,14 @@
 package network
 
 import (
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
-	"github.com/hetznercloud/cli/internal/hcapi2"
 	"net"
 
+	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func newCreateCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/network/delete.go
+++ b/internal/cmd/network/delete.go
@@ -3,12 +3,12 @@ package network
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/network/describe.go
+++ b/internal/cmd/network/describe.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-
 	humanize "github.com/dustin/go-humanize"
-	"github.com/hetznercloud/cli/internal/cmd/util"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 // DescribeCmd defines a command for describing a network.

--- a/internal/cmd/network/disable_protection.go
+++ b/internal/cmd/network/disable_protection.go
@@ -3,11 +3,13 @@ package network
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableProtectionCommand = base.Cmd{

--- a/internal/cmd/network/enable_protection.go
+++ b/internal/cmd/network/enable_protection.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.NetworkChangeProtectionOpts, error) {

--- a/internal/cmd/network/expose-routes-to-vswitch.go
+++ b/internal/cmd/network/expose-routes-to-vswitch.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ExposeRoutesToVSwitchCommand = base.Cmd{

--- a/internal/cmd/network/list.go
+++ b/internal/cmd/network/list.go
@@ -3,9 +3,10 @@ package network
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"

--- a/internal/cmd/network/list_test.go
+++ b/internal/cmd/network/list_test.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/network"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestList(t *testing.T) {

--- a/internal/cmd/network/network.go
+++ b/internal/cmd/network/network.go
@@ -1,9 +1,10 @@
 package network
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/network/remove_route.go
+++ b/internal/cmd/network/remove_route.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var RemoveRouteCommand = base.Cmd{

--- a/internal/cmd/network/remove_subnet.go
+++ b/internal/cmd/network/remove_subnet.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var RemoveSubnetCommand = base.Cmd{

--- a/internal/cmd/network/update.go
+++ b/internal/cmd/network/update.go
@@ -3,11 +3,12 @@ package network
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/output/output.go
+++ b/internal/cmd/output/output.go
@@ -11,9 +11,10 @@ import (
 	"unicode"
 
 	"github.com/fatih/structs"
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
-	"github.com/spf13/cobra"
 )
 
 const flagName = "output"

--- a/internal/cmd/placementgroup/create.go
+++ b/internal/cmd/placementgroup/create.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var CreateCmd = base.Cmd{

--- a/internal/cmd/placementgroup/create_test.go
+++ b/internal/cmd/placementgroup/create_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/placementgroup"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreate(t *testing.T) {

--- a/internal/cmd/placementgroup/delete.go
+++ b/internal/cmd/placementgroup/delete.go
@@ -3,11 +3,12 @@ package placementgroup
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var DeleteCmd = base.DeleteCmd{

--- a/internal/cmd/placementgroup/delete_test.go
+++ b/internal/cmd/placementgroup/delete_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/placementgroup"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDelete(t *testing.T) {

--- a/internal/cmd/placementgroup/describe.go
+++ b/internal/cmd/placementgroup/describe.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var DescribeCmd = base.DescribeCmd{

--- a/internal/cmd/placementgroup/describe_test.go
+++ b/internal/cmd/placementgroup/describe_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/placementgroup"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDescribe(t *testing.T) {

--- a/internal/cmd/placementgroup/labels_test.go
+++ b/internal/cmd/placementgroup/labels_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/placementgroup"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAddLabel(t *testing.T) {

--- a/internal/cmd/placementgroup/list.go
+++ b/internal/cmd/placementgroup/list.go
@@ -3,8 +3,9 @@ package placementgroup
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/pflag"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"

--- a/internal/cmd/placementgroup/list_test.go
+++ b/internal/cmd/placementgroup/list_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/placementgroup"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestList(t *testing.T) {

--- a/internal/cmd/placementgroup/placementgroup.go
+++ b/internal/cmd/placementgroup/placementgroup.go
@@ -1,9 +1,10 @@
 package placementgroup
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/placementgroup/update.go
+++ b/internal/cmd/placementgroup/update.go
@@ -3,12 +3,12 @@ package placementgroup
 import (
 	"context"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var UpdateCmd = base.UpdateCmd{

--- a/internal/cmd/placementgroup/update_test.go
+++ b/internal/cmd/placementgroup/update_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/placementgroup"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateName(t *testing.T) {

--- a/internal/cmd/primaryip/assign.go
+++ b/internal/cmd/primaryip/assign.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AssignCmd = base.Cmd{

--- a/internal/cmd/primaryip/assign_test.go
+++ b/internal/cmd/primaryip/assign_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAssign(t *testing.T) {

--- a/internal/cmd/primaryip/changedns.go
+++ b/internal/cmd/primaryip/changedns.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ChangeDNSCmd = base.Cmd{

--- a/internal/cmd/primaryip/changedns_test.go
+++ b/internal/cmd/primaryip/changedns_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestChangeDNS(t *testing.T) {

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -3,12 +3,14 @@ package primaryip
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var CreateCmd = base.Cmd{

--- a/internal/cmd/primaryip/create_test.go
+++ b/internal/cmd/primaryip/create_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreate(t *testing.T) {

--- a/internal/cmd/primaryip/delete.go
+++ b/internal/cmd/primaryip/delete.go
@@ -3,11 +3,12 @@ package primaryip
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/primaryip/delete_test.go
+++ b/internal/cmd/primaryip/delete_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDelete(t *testing.T) {

--- a/internal/cmd/primaryip/describe.go
+++ b/internal/cmd/primaryip/describe.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/dustin/go-humanize"
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/primaryip/describe_test.go
+++ b/internal/cmd/primaryip/describe_test.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDescribe(t *testing.T) {

--- a/internal/cmd/primaryip/disable_protecion_test.go
+++ b/internal/cmd/primaryip/disable_protecion_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEnable(t *testing.T) {

--- a/internal/cmd/primaryip/disable_protection.go
+++ b/internal/cmd/primaryip/disable_protection.go
@@ -3,12 +3,13 @@ package primaryip
 import (
 	"context"
 	"fmt"
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+
+	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableProtectionCmd = base.Cmd{

--- a/internal/cmd/primaryip/enable_protecion_test.go
+++ b/internal/cmd/primaryip/enable_protecion_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEnableProtection(t *testing.T) {

--- a/internal/cmd/primaryip/enable_protection.go
+++ b/internal/cmd/primaryip/enable_protection.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.PrimaryIPChangeProtectionOpts, error) {

--- a/internal/cmd/primaryip/list.go
+++ b/internal/cmd/primaryip/list.go
@@ -3,17 +3,17 @@ package primaryip
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{

--- a/internal/cmd/primaryip/list_test.go
+++ b/internal/cmd/primaryip/list_test.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestList(t *testing.T) {

--- a/internal/cmd/primaryip/primaryip.go
+++ b/internal/cmd/primaryip/primaryip.go
@@ -1,9 +1,10 @@
 package primaryip
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/primaryip/unassign.go
+++ b/internal/cmd/primaryip/unassign.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var UnAssignCmd = base.Cmd{

--- a/internal/cmd/primaryip/unassign_test.go
+++ b/internal/cmd/primaryip/unassign_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUnAssign(t *testing.T) {

--- a/internal/cmd/primaryip/update.go
+++ b/internal/cmd/primaryip/update.go
@@ -3,11 +3,12 @@ package primaryip
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/primaryip/update_test.go
+++ b/internal/cmd/primaryip/update_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdate(t *testing.T) {

--- a/internal/cmd/server/add_to_placement_group.go
+++ b/internal/cmd/server/add_to_placement_group.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var AddToPlacementGroupCommand = base.Cmd{

--- a/internal/cmd/server/add_to_placement_group_test.go
+++ b/internal/cmd/server/add_to_placement_group_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/server"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAddToPlacementGroup(t *testing.T) {

--- a/internal/cmd/server/attach_iso.go
+++ b/internal/cmd/server/attach_iso.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var AttachISOCommand = base.Cmd{

--- a/internal/cmd/server/attach_to_network.go
+++ b/internal/cmd/server/attach_to_network.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AttachToNetworkCommand = base.Cmd{

--- a/internal/cmd/server/change_alias_ips.go
+++ b/internal/cmd/server/change_alias_ips.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ChangeAliasIPsCommand = base.Cmd{

--- a/internal/cmd/server/change_type.go
+++ b/internal/cmd/server/change_type.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var ChangeTypeCommand = base.Cmd{

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -12,14 +12,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/crypto/ssh"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"golang.org/x/crypto/ssh"
 )
 
 // CreateCmd defines a command for creating a server.

--- a/internal/cmd/server/create_image.go
+++ b/internal/cmd/server/create_image.go
@@ -3,11 +3,12 @@ package server
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func newCreateImageCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/server"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreate(t *testing.T) {

--- a/internal/cmd/server/delete.go
+++ b/internal/cmd/server/delete.go
@@ -3,12 +3,12 @@ package server
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/server/describe.go
+++ b/internal/cmd/server/describe.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var describeCmd = base.DescribeCmd{

--- a/internal/cmd/server/detach_from_network.go
+++ b/internal/cmd/server/detach_from_network.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-
-	"github.com/spf13/cobra"
 )
 
 var DetachFromNetworkCommand = base.Cmd{

--- a/internal/cmd/server/detach_iso.go
+++ b/internal/cmd/server/detach_iso.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DetachISOCommand = base.Cmd{

--- a/internal/cmd/server/disable_backup.go
+++ b/internal/cmd/server/disable_backup.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableBackupCommand = base.Cmd{

--- a/internal/cmd/server/disable_protection.go
+++ b/internal/cmd/server/disable_protection.go
@@ -3,11 +3,13 @@ package server
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableProtectionCommand = base.Cmd{

--- a/internal/cmd/server/disable_rescue.go
+++ b/internal/cmd/server/disable_rescue.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableRescueCommand = base.Cmd{

--- a/internal/cmd/server/enable_backup.go
+++ b/internal/cmd/server/enable_backup.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var EnableBackupCommand = base.Cmd{

--- a/internal/cmd/server/enable_protection.go
+++ b/internal/cmd/server/enable_protection.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.ServerChangeProtectionOpts, error) {

--- a/internal/cmd/server/enable_rescue.go
+++ b/internal/cmd/server/enable_rescue.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var EnableRescueCommand = base.Cmd{

--- a/internal/cmd/server/ip.go
+++ b/internal/cmd/server/ip.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var IPCommand = base.Cmd{

--- a/internal/cmd/server/list.go
+++ b/internal/cmd/server/list.go
@@ -3,12 +3,13 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/pflag"
 	"strconv"
 	"strings"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"

--- a/internal/cmd/server/metrics.go
+++ b/internal/cmd/server/metrics.go
@@ -9,15 +9,15 @@ import (
 	"time"
 
 	"github.com/guptarohit/asciigraph"
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/spf13/cobra"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var MetricsCommand = base.Cmd{

--- a/internal/cmd/server/poweroff.go
+++ b/internal/cmd/server/poweroff.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var PoweroffCommand = base.Cmd{

--- a/internal/cmd/server/poweron.go
+++ b/internal/cmd/server/poweron.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var PoweronCommand = base.Cmd{

--- a/internal/cmd/server/reboot.go
+++ b/internal/cmd/server/reboot.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var RebootCommand = base.Cmd{

--- a/internal/cmd/server/rebuild.go
+++ b/internal/cmd/server/rebuild.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var RebuildCommand = base.Cmd{

--- a/internal/cmd/server/remove_from_placement_group.go
+++ b/internal/cmd/server/remove_from_placement_group.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var RemoveFromPlacementGroup = base.Cmd{

--- a/internal/cmd/server/remove_from_placement_group_test.go
+++ b/internal/cmd/server/remove_from_placement_group_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/cmd/server"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoveFromPlacementGroup(t *testing.T) {

--- a/internal/cmd/server/request_console.go
+++ b/internal/cmd/server/request_console.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var RequestConsoleCommand = base.Cmd{

--- a/internal/cmd/server/reset.go
+++ b/internal/cmd/server/reset.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var ResetCommand = base.Cmd{

--- a/internal/cmd/server/reset_password.go
+++ b/internal/cmd/server/reset_password.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var ResetPasswordCommand = base.Cmd{

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -1,9 +1,10 @@
 package server
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/server/set_rdns.go
+++ b/internal/cmd/server/set_rdns.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"net"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var setRDNSCmd = base.SetRdnsCmd{

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 var ShutdownCommand = base.Cmd{

--- a/internal/cmd/server/shutdown_test.go
+++ b/internal/cmd/server/shutdown_test.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
+	"testing"
+
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestShutdown(t *testing.T) {

--- a/internal/cmd/server/ssh.go
+++ b/internal/cmd/server/ssh.go
@@ -8,11 +8,12 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var SSHCommand = base.Cmd{

--- a/internal/cmd/server/update.go
+++ b/internal/cmd/server/update.go
@@ -3,11 +3,12 @@ package server
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/servertype/describe.go
+++ b/internal/cmd/servertype/describe.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
-	"github.com/spf13/cobra"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/servertype/list.go
+++ b/internal/cmd/servertype/list.go
@@ -3,6 +3,7 @@ package servertype
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"

--- a/internal/cmd/servertype/server_type.go
+++ b/internal/cmd/servertype/server_type.go
@@ -1,9 +1,10 @@
 package servertype
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/sshkey/create.go
+++ b/internal/cmd/sshkey/create.go
@@ -6,10 +6,11 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func newCreateCommand(cli *state.State) *cobra.Command {

--- a/internal/cmd/sshkey/delete.go
+++ b/internal/cmd/sshkey/delete.go
@@ -3,11 +3,12 @@ package sshkey
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/sshkey/describe.go
+++ b/internal/cmd/sshkey/describe.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/dustin/go-humanize"
-
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/sshkey/list.go
+++ b/internal/cmd/sshkey/list.go
@@ -2,8 +2,9 @@ package sshkey
 
 import (
 	"context"
-	"github.com/spf13/pflag"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"

--- a/internal/cmd/sshkey/sshkey.go
+++ b/internal/cmd/sshkey/sshkey.go
@@ -1,9 +1,10 @@
 package sshkey
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/cmd/sshkey/update.go
+++ b/internal/cmd/sshkey/update.go
@@ -3,11 +3,12 @@ package sshkey
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/util/deprecation.go
+++ b/internal/cmd/util/deprecation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dustin/go-humanize"
+
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/util/util.go
+++ b/internal/cmd/util/util.go
@@ -9,11 +9,11 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 func YesNo(b bool) string {

--- a/internal/cmd/volume/attach.go
+++ b/internal/cmd/volume/attach.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var AttachCommand = base.Cmd{

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var CreateCommand = base.Cmd{

--- a/internal/cmd/volume/delete.go
+++ b/internal/cmd/volume/delete.go
@@ -3,11 +3,12 @@ package volume
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 var deleteCmd = base.DeleteCmd{

--- a/internal/cmd/volume/describe.go
+++ b/internal/cmd/volume/describe.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
-
-	humanize "github.com/dustin/go-humanize"
 	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/cmd/volume/detach.go
+++ b/internal/cmd/volume/detach.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DetachCommand = base.Cmd{

--- a/internal/cmd/volume/disable_protection.go
+++ b/internal/cmd/volume/disable_protection.go
@@ -3,11 +3,13 @@ package volume
 import (
 	"context"
 	"fmt"
+
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 var DisableProtectionCommand = base.Cmd{

--- a/internal/cmd/volume/enable_protection.go
+++ b/internal/cmd/volume/enable_protection.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
 )
 
 func getChangeProtectionOpts(enable bool, flags []string) (hcloud.VolumeChangeProtectionOpts, error) {

--- a/internal/cmd/volume/list.go
+++ b/internal/cmd/volume/list.go
@@ -2,19 +2,18 @@ package volume
 
 import (
 	"context"
-	"github.com/spf13/pflag"
 	"strings"
 	"time"
 
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
+	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/pflag"
 
+	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
 	"github.com/hetznercloud/cli/internal/cmd/util"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
-
-	humanize "github.com/dustin/go-humanize"
+	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 var ListCmd = base.ListCmd{

--- a/internal/cmd/volume/resize.go
+++ b/internal/cmd/volume/resize.go
@@ -3,12 +3,13 @@ package volume
 import (
 	"context"
 	"fmt"
-	"github.com/hetznercloud/cli/internal/cmd/base"
-	"github.com/hetznercloud/cli/internal/hcapi2"
 
-	"github.com/hetznercloud/cli/internal/cmd/cmpl"
-	"github.com/hetznercloud/cli/internal/state"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
 )
 
 var ResizeCommand = base.Cmd{

--- a/internal/cmd/volume/update.go
+++ b/internal/cmd/volume/update.go
@@ -3,11 +3,12 @@ package volume
 import (
 	"context"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var updateCmd = base.UpdateCmd{

--- a/internal/cmd/volume/volume.go
+++ b/internal/cmd/volume/volume.go
@@ -1,9 +1,10 @@
 package volume
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 func NewCommand(cli *state.State, client hcapi2.Client) *cobra.Command {

--- a/internal/hcapi2/mock/client.go
+++ b/internal/hcapi2/mock/client.go
@@ -2,6 +2,7 @@ package hcapi2_mock
 
 import (
 	"github.com/golang/mock/gomock"
+
 	"github.com/hetznercloud/cli/internal/hcapi2"
 )
 

--- a/internal/state/command_helpers.go
+++ b/internal/state/command_helpers.go
@@ -3,8 +3,9 @@ package state
 import (
 	"context"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 //go:generate mockgen -package state -destination command_helper_mocks.go . ActionWaiter,TokenEnsurer

--- a/internal/state/helpers.go
+++ b/internal/state/helpers.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/hetznercloud/cli/internal/version"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 const (

--- a/internal/testutil/fixture.go
+++ b/internal/testutil/fixture.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+
 	hcapi2_mock "github.com/hetznercloud/cli/internal/hcapi2/mock"
 	"github.com/hetznercloud/cli/internal/state"
-	"github.com/spf13/cobra"
 )
 
 // Fixture provides affordances for testing CLI commands.


### PR DESCRIPTION
Also added gci to .golangci.yml to keep imports consistent in the future.