### PR TITLE
fix(floating-ip): list command only returns first 50 entries

### DIFF
--- a/internal/cmd/floatingip/list.go
+++ b/internal/cmd/floatingip/list.go
@@ -25,7 +25,7 @@ var ListCmd = base.ListCmd{
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		floatingIPs, _, err := client.FloatingIP().List(ctx, opts)
+		floatingIPs, err := client.FloatingIP().AllWithOpts(ctx, opts)
 
 		var resources []interface{}
 		for _, n := range floatingIPs {


### PR DESCRIPTION
On the FloatingIPClient List was used instead of AllWithOpts, which resulted in "list" only returning the first 50 entries. (Same as #415)