### PR TITLE
docs(load-balancer): change description for protocol flag

### DIFF
--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -30,7 +30,7 @@ var UpdateServiceCommand = base.Cmd{
 
 		cmd.Flags().Int("destination-port", 0, "Destination port of the service on the targets")
 
-		cmd.Flags().String("protocol", "", "The protocol the health check is performed over")
+		cmd.Flags().String("protocol", "", "The protocol to use for load balancing traffic")
 		cmd.Flags().Bool("proxy-protocol", false, "Enable or disable (with --proxy-protocol=false) Proxy Protocol")
 		cmd.Flags().Bool("http-redirect-http", false, "Enable or disable redirect all traffic on port 80 to port 443")
 


### PR DESCRIPTION
This fixes the description for the `protocol` flag of the `load-balancer update-service` command. Before this change, the description was identical with the description of the `health-check-protocol` flag.