### PR TITLE
chore: convert syscall.Stdin to int to fix build on Windows

### DIFF
--- a/internal/cmd/context/create.go
+++ b/internal/cmd/context/create.go
@@ -61,7 +61,9 @@ func runCreate(cli *state.State, _ *cobra.Command, args []string) error {
 	if token == "" {
 		for {
 			fmt.Printf("Token: ")
-			btoken, err := term.ReadPassword(syscall.Stdin)
+			// Conversion needed for compilation on Windows
+			//                               vvv
+			btoken, err := term.ReadPassword(int(syscall.Stdin))
 			fmt.Print("\n")
 			if err != nil {
 				return err


### PR DESCRIPTION
This fixes a bug that was introduced in #582 
Example pipeline in which the bug occured: https://github.com/hetznercloud/cli/actions/runs/6638017209/job/18033507784#step:4:57