### PR TITLE
fix: static resource list commands only return first 50 entries

### DIFF
--- a/internal/cmd/datacenter/list.go
+++ b/internal/cmd/datacenter/list.go
@@ -23,7 +23,7 @@ var ListCmd = base.ListCmd{
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		datacenters, _, err := client.Datacenter().List(ctx, opts)
+		datacenters, err := client.Datacenter().AllWithOpts(ctx, opts)
 		var resources []interface{}
 		for _, n := range datacenters {
 			resources = append(resources, n)

--- a/internal/cmd/loadbalancertype/list.go
+++ b/internal/cmd/loadbalancertype/list.go
@@ -24,7 +24,7 @@ var ListCmd = base.ListCmd{
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		loadBalancerTypes, _, err := client.LoadBalancerType().List(ctx, opts)
+		loadBalancerTypes, err := client.LoadBalancerType().AllWithOpts(ctx, opts)
 
 		var resources []interface{}
 		for _, r := range loadBalancerTypes {

--- a/internal/cmd/location/list.go
+++ b/internal/cmd/location/list.go
@@ -23,7 +23,7 @@ var ListCmd = base.ListCmd{
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		locations, _, err := client.Location().List(ctx, opts)
+		locations, err := client.Location().AllWithOpts(ctx, opts)
 
 		var resources []interface{}
 		for _, n := range locations {

--- a/internal/cmd/servertype/list.go
+++ b/internal/cmd/servertype/list.go
@@ -25,7 +25,7 @@ var ListCmd = base.ListCmd{
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		servers, _, err := client.ServerType().List(ctx, opts)
+		servers, err := client.ServerType().AllWithOpts(ctx, opts)
 
 		var resources []interface{}
 		for _, r := range servers {


### PR DESCRIPTION
The list commands for datacenters, load balancer types, locations and server types uses ``List()`` instead of ``AllWithOpts()`` to fetch resources. ``List()`` only returns a single page of resources at a time (50 entries in this case), while ``AllWithOpts()`` returns all of them. This does not make a difference at the moment, but could be a problem in the future.

Similar to #574