### PR TITLE
fix(primary-ip): list does now allow to output IP column

### DIFF
--- a/internal/cmd/floatingip/list.go
+++ b/internal/cmd/floatingip/list.go
@@ -65,6 +65,7 @@ var ListCmd = base.ListCmd{
 			})).
 			AddFieldFn("ip", output.FieldFn(func(obj interface{}) string {
 				floatingIP := obj.(*hcloud.FloatingIP)
+				// Format IPv6 correctly
 				if floatingIP.Network != nil {
 					return floatingIP.Network.String()
 				}

--- a/internal/cmd/primaryip/list.go
+++ b/internal/cmd/primaryip/list.go
@@ -38,6 +38,14 @@ var ListCmd = base.ListCmd{
 	OutputTable: func(client hcapi2.Client) *output.Table {
 		return output.NewTable().
 			AddAllowedFields(hcloud.PrimaryIP{}).
+			AddFieldFn("ip", output.FieldFn(func(obj interface{}) string {
+				primaryIP := obj.(*hcloud.PrimaryIP)
+				// Format IPv6 correctly
+				if primaryIP.Network != nil {
+					return primaryIP.Network.String()
+				}
+				return primaryIP.IP.String()
+			})).
 			AddFieldFn("dns", output.FieldFn(func(obj interface{}) string {
 				primaryIP := obj.(*hcloud.PrimaryIP)
 				var dns string


### PR DESCRIPTION
Since IP is a ``*hcloud.PrimaryIP``, ``AddAllowedFields()`` only adds columns for primitive types and a field function for IP was missing, you were not able to output the IP column using output flags.

Closes #591