### PR TITLE
ci: add renovate regex comment to version variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified with patch version
-          version: v1.54.2
+          version: v1.54.2 # renovate: datasource=github-releases depName=golangci/golangci-lint
           # In general linting is quite fast with warm caches, but a fresh run might take some time.
           args: --timeout 5m
 


### PR DESCRIPTION
Leverage the https://github.com/hetznercloud/.github/pull/16 regex manager to update the version variables.