### PR TITLE
fix(image): backup is suggested as type in update command

### DIFF
--- a/internal/cmd/image/update.go
+++ b/internal/cmd/image/update.go
@@ -22,7 +22,7 @@ var UpdateCmd = base.UpdateCmd{
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("description", "", "Image description")
 		cmd.Flags().String("type", "", "Image type")
-		cmd.RegisterFlagCompletionFunc("type", cmpl.SuggestCandidates("backup", "snapshot"))
+		cmd.RegisterFlagCompletionFunc("type", cmpl.SuggestCandidates("snapshot"))
 	},
 	Update: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
 		image := resource.(*hcloud.Image)


### PR DESCRIPTION
As described in the [API Docs](https://docs.hetzner.cloud/#images-update-an-image), the only allowed image type to update to is `snapshot`. The completions should reflect that.