### PR TITLE
fix(primary-ip): updating the name resets auto-delete

### DIFF
--- a/internal/cmd/primaryip/update.go
+++ b/internal/cmd/primaryip/update.go
@@ -27,10 +27,12 @@ var updateCmd = base.UpdateCmd{
 		updOpts := hcloud.PrimaryIPUpdateOpts{
 			Name: flags["name"].String(),
 		}
-		autoDelete, _ := cmd.Flags().GetBool("auto-delete")
-		if primaryIP.AutoDelete != autoDelete {
-			updOpts.AutoDelete = hcloud.Bool(autoDelete)
+
+		if cmd.Flags().Changed("auto-delete") {
+			autoDelete, _ := cmd.Flags().GetBool("auto-delete")
+			updOpts.AutoDelete = hcloud.Ptr(autoDelete)
 		}
+
 		_, _, err := client.PrimaryIP().Update(ctx, primaryIP, updOpts)
 		if err != nil {
 			return err


### PR DESCRIPTION
Due to not correctly checking if the auto-delete flag was set, every time the update command was called and the auto-delete flag wasn't set, auto deletion was erroneously disabled.