### PR TITLE
test: capture stderr for tests

### DIFF
--- a/internal/cmd/all/list_test.go
+++ b/internal/cmd/all/list_test.go
@@ -173,7 +173,7 @@ func TestListAll(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `SERVERS
 ---
@@ -287,7 +287,7 @@ func TestListAllPaidJSON(t *testing.T) {
 		AllWithOpts(gomock.Any(), hcloud.VolumeListOpts{}).
 		Return([]*hcloud.Volume{}, nil)
 
-	out, err := fx.Run(cmd, []string{"--paid", "-o=json"})
+	out, _, err := fx.Run(cmd, []string{"--paid", "-o=json"})
 
 	expOut := "{\"floating_ips\":[],\"images\":[{\"id\":114690387,\"status\":\"available\",\"type\":\"system\"," +
 		"\"name\":\"debian-12\",\"description\":\"Debian 12\",\"image_size\":0,\"disk_size\":5,\"created\":" +

--- a/internal/cmd/certificate/create_test.go
+++ b/internal/cmd/certificate/create_test.go
@@ -40,7 +40,7 @@ func TestCreateManaged(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), &hcloud.Action{ID: 321})
 
-	out, err := fx.Run(cmd, []string{"--name", "test", "--type", "managed", "--domain", "example.com"})
+	out, _, err := fx.Run(cmd, []string{"--name", "test", "--type", "managed", "--domain", "example.com"})
 
 	expOut := "Certificate 123 created\n"
 
@@ -72,7 +72,7 @@ func TestCreateUploaded(t *testing.T) {
 			Type: hcloud.CertificateTypeUploaded,
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "test", "--key-file", "testdata/key.pem", "--cert-file", "testdata/cert.pem"})
+	out, _, err := fx.Run(cmd, []string{"--name", "test", "--key-file", "testdata/key.pem", "--cert-file", "testdata/cert.pem"})
 
 	expOut := "Certificate 123 created\n"
 

--- a/internal/cmd/certificate/delete_test.go
+++ b/internal/cmd/certificate/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), cert).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "certificate test deleted\n"
 

--- a/internal/cmd/certificate/describe_test.go
+++ b/internal/cmd/certificate/describe_test.go
@@ -57,7 +57,7 @@ func TestDescribe(t *testing.T) {
 		LoadBalancerName(int64(123)).
 		Return("test")
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:			123
 Name:			test

--- a/internal/cmd/certificate/labels_test.go
+++ b/internal/cmd/certificate/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to certificate 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from certificate 123\n"
 

--- a/internal/cmd/certificate/list_test.go
+++ b/internal/cmd/certificate/list_test.go
@@ -40,7 +40,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   TYPE      DOMAIN NAMES   NOT VALID AFTER                AGE
 123   test   managed   example.com    Wed Aug 20 12:00:00 UTC 2036   20m

--- a/internal/cmd/certificate/update_test.go
+++ b/internal/cmd/certificate/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "certificate 123 updated\n"
 

--- a/internal/cmd/datacenter/describe_test.go
+++ b/internal/cmd/datacenter/describe_test.go
@@ -30,7 +30,7 @@ func TestDescribe(t *testing.T) {
 			Description: "Falkenstein 1 virtual DC 14",
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := `ID:		4
 Name:		fsn1-dc14

--- a/internal/cmd/datacenter/list_test.go
+++ b/internal/cmd/datacenter/list_test.go
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID   NAME        DESCRIPTION                   LOCATION
 4    fsn1-dc14   Falkenstein 1 virtual DC 14   fsn1

--- a/internal/cmd/firewall/create_test.go
+++ b/internal/cmd/firewall/create_test.go
@@ -37,7 +37,7 @@ func TestCreate(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), []*hcloud.Action{{ID: 321}})
 
-	out, err := fx.Run(cmd, []string{"--name", "test"})
+	out, _, err := fx.Run(cmd, []string{"--name", "test"})
 
 	expOut := "Firewall 123 created\n"
 

--- a/internal/cmd/firewall/delete_test.go
+++ b/internal/cmd/firewall/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), firewall).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "firewall test deleted\n"
 

--- a/internal/cmd/firewall/describe_test.go
+++ b/internal/cmd/firewall/describe_test.go
@@ -59,7 +59,7 @@ func TestDescribe(t *testing.T) {
 		ServerName(int64(321)).
 		Return("myServer")
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Name:		test

--- a/internal/cmd/firewall/labels_test.go
+++ b/internal/cmd/firewall/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to firewall 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from firewall 123\n"
 

--- a/internal/cmd/firewall/list_test.go
+++ b/internal/cmd/firewall/list_test.go
@@ -39,7 +39,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   RULES COUNT   APPLIED TO COUNT
 123   test   5 Rules       2 Servers | 0 Label Selectors

--- a/internal/cmd/firewall/update_test.go
+++ b/internal/cmd/firewall/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Firewall 123 updated\n"
 

--- a/internal/cmd/floatingip/create_test.go
+++ b/internal/cmd/floatingip/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 			Action: nil,
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "myFloatingIP", "--type", "ipv4", "--home-location", "fsn1"})
+	out, _, err := fx.Run(cmd, []string{"--name", "myFloatingIP", "--type", "ipv4", "--home-location", "fsn1"})
 
 	expOut := `Floating IP 123 created
 IPv4: 192.168.2.1
@@ -92,7 +92,7 @@ func TestCreateProtection(t *testing.T) {
 		Return(&hcloud.Action{ID: 333}, nil, nil)
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), &hcloud.Action{ID: 333}).Return(nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "myFloatingIP", "--type", "ipv4", "--home-location", "fsn1", "--enable-protection", "delete"})
+	out, _, err := fx.Run(cmd, []string{"--name", "myFloatingIP", "--type", "ipv4", "--home-location", "fsn1", "--enable-protection", "delete"})
 
 	expOut := `Floating IP 123 created
 Resource protection enabled for floating IP 123

--- a/internal/cmd/floatingip/delete_test.go
+++ b/internal/cmd/floatingip/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), floatingIP).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "Floating IP test deleted\n"
 

--- a/internal/cmd/floatingip/describe_test.go
+++ b/internal/cmd/floatingip/describe_test.go
@@ -48,7 +48,7 @@ func TestDescribe(t *testing.T) {
 		ServerName(int64(321)).
 		Return("myServer")
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Type:		ipv4

--- a/internal/cmd/floatingip/labels_test.go
+++ b/internal/cmd/floatingip/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to Floating IP 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from Floating IP 123\n"
 

--- a/internal/cmd/floatingip/list_test.go
+++ b/internal/cmd/floatingip/list_test.go
@@ -41,7 +41,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    TYPE   NAME   DESCRIPTION   IP            HOME   SERVER   DNS   AGE
 123   ipv4   test   -             192.168.2.1   fsn1   -        -     10m

--- a/internal/cmd/floatingip/update_test.go
+++ b/internal/cmd/floatingip/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Floating IP 123 updated\n"
 
@@ -55,7 +55,7 @@ func TestUpdateDescription(t *testing.T) {
 			Description: "new-description",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--description", "new-description"})
+	out, _, err := fx.Run(cmd, []string{"123", "--description", "new-description"})
 
 	expOut := "Floating IP 123 updated\n"
 

--- a/internal/cmd/image/delete_test.go
+++ b/internal/cmd/image/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), image).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "image test deleted\n"
 

--- a/internal/cmd/image/describe_test.go
+++ b/internal/cmd/image/describe_test.go
@@ -46,7 +46,7 @@ func TestDescribe(t *testing.T) {
 		GetForArchitecture(gomock.Any(), "test", hcloud.ArchitectureX86).
 		Return(img, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Type:		system

--- a/internal/cmd/image/labels_test.go
+++ b/internal/cmd/image/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to image 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from image 123\n"
 

--- a/internal/cmd/image/list_test.go
+++ b/internal/cmd/image/list_test.go
@@ -42,7 +42,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    TYPE     NAME   DESCRIPTION   ARCHITECTURE   IMAGE SIZE   DISK SIZE   CREATED                        DEPRECATED
 123   system   test   -             x86            20.00 GB     15 GB       Wed Aug 20 12:00:00 UTC 2036   -

--- a/internal/cmd/image/update_test.go
+++ b/internal/cmd/image/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateDescription(t *testing.T) {
 			Description: hcloud.Ptr("new-description"),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--description", "new-description"})
+	out, _, err := fx.Run(cmd, []string{"123", "--description", "new-description"})
 
 	expOut := "Image 123 updated\n"
 
@@ -56,7 +56,7 @@ func TestUpdateType(t *testing.T) {
 			Type:        hcloud.ImageTypeSnapshot,
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--type", "snapshot"})
+	out, _, err := fx.Run(cmd, []string{"123", "--type", "snapshot"})
 
 	expOut := "Image 123 updated\n"
 

--- a/internal/cmd/iso/describe_test.go
+++ b/internal/cmd/iso/describe_test.go
@@ -31,7 +31,7 @@ func TestDescribe(t *testing.T) {
 			Architecture: hcloud.Ptr(hcloud.ArchitectureX86),
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := `ID:		123
 Name:		test

--- a/internal/cmd/iso/list_test.go
+++ b/internal/cmd/iso/list_test.go
@@ -39,7 +39,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   DESCRIPTION   TYPE     ARCHITECTURE
 123   test   Test ISO      public   x86

--- a/internal/cmd/loadbalancer/create_test.go
+++ b/internal/cmd/loadbalancer/create_test.go
@@ -49,7 +49,7 @@ func TestCreate(t *testing.T) {
 			},
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "myLoadBalancer", "--type", "lb11", "--location", "fsn1"})
+	out, _, err := fx.Run(cmd, []string{"--name", "myLoadBalancer", "--type", "lb11", "--location", "fsn1"})
 
 	expOut := `Load Balancer 123 created
 IPv4: 192.168.2.1
@@ -105,7 +105,7 @@ func TestCreateProtection(t *testing.T) {
 		Return(&hcloud.Action{ID: 333}, nil, nil)
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), &hcloud.Action{ID: 333}).Return(nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "myLoadBalancer", "--type", "lb11", "--location", "fsn1", "--enable-protection", "delete"})
+	out, _, err := fx.Run(cmd, []string{"--name", "myLoadBalancer", "--type", "lb11", "--location", "fsn1", "--enable-protection", "delete"})
 
 	expOut := `Load Balancer 123 created
 Resource protection enabled for Load Balancer 123

--- a/internal/cmd/loadbalancer/delete_test.go
+++ b/internal/cmd/loadbalancer/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), loadBalancer).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "Load Balancer test deleted\n"
 

--- a/internal/cmd/loadbalancer/describe_test.go
+++ b/internal/cmd/loadbalancer/describe_test.go
@@ -62,7 +62,7 @@ func TestDescribe(t *testing.T) {
 		Get(gomock.Any(), "test").
 		Return(lb, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:				123
 Name:				test

--- a/internal/cmd/loadbalancer/labels_test.go
+++ b/internal/cmd/loadbalancer/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to Load Balancer 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from Load Balancer 123\n"
 

--- a/internal/cmd/loadbalancer/update_test.go
+++ b/internal/cmd/loadbalancer/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Load Balancer 123 updated\n"
 

--- a/internal/cmd/loadbalancertype/describe_test.go
+++ b/internal/cmd/loadbalancertype/describe_test.go
@@ -33,7 +33,7 @@ func TestDescribe(t *testing.T) {
 			MaxAssignedCertificates: 10,
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"lb11"})
+	out, _, err := fx.Run(cmd, []string{"lb11"})
 
 	expOut := `ID:				123
 Name:				lb11

--- a/internal/cmd/loadbalancertype/list_test.go
+++ b/internal/cmd/loadbalancertype/list_test.go
@@ -39,7 +39,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   DESCRIPTION   MAX SERVICES   MAX CONNECTIONS   MAX TARGETS
 123   test   -             12             100               5

--- a/internal/cmd/location/describe_test.go
+++ b/internal/cmd/location/describe_test.go
@@ -35,7 +35,7 @@ func TestDescribe(t *testing.T) {
 			Longitude:   24.938379,
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"hel1"})
+	out, _, err := fx.Run(cmd, []string{"hel1"})
 
 	expOut := `ID:		3
 Name:		hel1

--- a/internal/cmd/location/list_test.go
+++ b/internal/cmd/location/list_test.go
@@ -39,7 +39,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID   NAME   DESCRIPTION   NETWORK ZONE   COUNTRY   CITY
 1    fsn1   -             eu-central     DE        Falkenstein

--- a/internal/cmd/network/create_test.go
+++ b/internal/cmd/network/create_test.go
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 			IPRange: ipRange,
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "myNetwork", "--ip-range", "10.0.0.0/24"})
+	out, _, err := fx.Run(cmd, []string{"--name", "myNetwork", "--ip-range", "10.0.0.0/24"})
 
 	expOut := "Network 123 created\n"
 
@@ -76,7 +76,7 @@ func TestCreateProtection(t *testing.T) {
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "myNetwork", "--ip-range", "10.0.0.0/24", "--enable-protection", "delete"})
+	out, _, err := fx.Run(cmd, []string{"--name", "myNetwork", "--ip-range", "10.0.0.0/24", "--enable-protection", "delete"})
 
 	expOut := `Network 123 created
 Resource protection enabled for network 123

--- a/internal/cmd/network/delete_test.go
+++ b/internal/cmd/network/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), network).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "Network test deleted\n"
 

--- a/internal/cmd/network/describe_test.go
+++ b/internal/cmd/network/describe_test.go
@@ -41,7 +41,7 @@ func TestDescribe(t *testing.T) {
 		Get(gomock.Any(), "test").
 		Return(network, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Name:		test

--- a/internal/cmd/network/labels_test.go
+++ b/internal/cmd/network/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to Network 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from Network 123\n"
 

--- a/internal/cmd/network/list_test.go
+++ b/internal/cmd/network/list_test.go
@@ -43,7 +43,7 @@ func TestList(t *testing.T) {
 		},
 			nil)
 
-	out, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
+	out, _, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
 
 	expOut := `ID    NAME       IP RANGE       SERVERS    AGE
 123   test-net   192.0.2.1/24   1 server   10s

--- a/internal/cmd/network/update_test.go
+++ b/internal/cmd/network/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Network 123 updated\n"
 

--- a/internal/cmd/placementgroup/create_test.go
+++ b/internal/cmd/placementgroup/create_test.go
@@ -45,7 +45,7 @@ func TestCreate(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), &hcloud.Action{ID: 321})
 
-	out, err := fx.Run(cmd, []string{"--name", placementGroup.Name, "--type", string(placementGroup.Type)})
+	out, _, err := fx.Run(cmd, []string{"--name", placementGroup.Name, "--type", string(placementGroup.Type)})
 
 	expOut := `Placement group 897 created
 `

--- a/internal/cmd/placementgroup/delete_test.go
+++ b/internal/cmd/placementgroup/delete_test.go
@@ -39,7 +39,7 @@ func TestDelete(t *testing.T) {
 	fx.Client.PlacementGroupClient.EXPECT().
 		Delete(gomock.Any(), &placementGroup)
 
-	_, err := fx.Run(cmd, []string{placementGroup.Name})
+	_, _, err := fx.Run(cmd, []string{placementGroup.Name})
 
 	assert.NoError(t, err)
 }

--- a/internal/cmd/placementgroup/describe_test.go
+++ b/internal/cmd/placementgroup/describe_test.go
@@ -47,7 +47,7 @@ func TestDescribe(t *testing.T) {
 		ServerName(int64(4712)).
 		Return("server2")
 
-	out, err := fx.Run(cmd, []string{placementGroup.Name})
+	out, _, err := fx.Run(cmd, []string{placementGroup.Name})
 
 	expOut := fmt.Sprintf(`ID:		897
 Name:		my Placement Group

--- a/internal/cmd/placementgroup/labels_test.go
+++ b/internal/cmd/placementgroup/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to placement group 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from placement group 123\n"
 

--- a/internal/cmd/placementgroup/list_test.go
+++ b/internal/cmd/placementgroup/list_test.go
@@ -45,7 +45,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
+	out, _, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
 
 	expOut := `ID    NAME                 SERVERS     TYPE     AGE
 897   my Placement Group   2 servers   spread   10s

--- a/internal/cmd/placementgroup/update_test.go
+++ b/internal/cmd/placementgroup/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "placement group 123 updated\n"
 

--- a/internal/cmd/primaryip/assign_test.go
+++ b/internal/cmd/primaryip/assign_test.go
@@ -56,7 +56,7 @@ func TestAssign(t *testing.T) {
 
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), action).Return(nil)
 
-	out, err := fx.Run(cmd, []string{"13", "--server", "15"})
+	out, _, err := fx.Run(cmd, []string{"13", "--server", "15"})
 
 	expOut := "Primary IP 13 assigned to server 15\n"
 

--- a/internal/cmd/primaryip/changedns_test.go
+++ b/internal/cmd/primaryip/changedns_test.go
@@ -45,7 +45,7 @@ func TestChangeDNS(t *testing.T) {
 
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), action).Return(nil)
 
-	out, err := fx.Run(cmd, []string{"--hostname=server.your-host.de", "--ip=192.168.0.1", "13"})
+	out, _, err := fx.Run(cmd, []string{"--hostname=server.your-host.de", "--ip=192.168.0.1", "13"})
 
 	expOut := "Primary IP 13 DNS pointer: server.your-host.de associated to 192.168.0.1\n"
 

--- a/internal/cmd/primaryip/create_test.go
+++ b/internal/cmd/primaryip/create_test.go
@@ -44,7 +44,7 @@ func TestCreate(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), &hcloud.Action{ID: 321})
 
-	out, err := fx.Run(cmd, []string{"--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14"})
+	out, _, err := fx.Run(cmd, []string{"--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14"})
 
 	expOut := `Primary IP 1 created
 IPv4: 192.168.2.1

--- a/internal/cmd/primaryip/delete_test.go
+++ b/internal/cmd/primaryip/delete_test.go
@@ -38,7 +38,7 @@ func TestDelete(t *testing.T) {
 			nil,
 		)
 
-	out, err := fx.Run(cmd, []string{"13"})
+	out, _, err := fx.Run(cmd, []string{"13"})
 
 	expOut := "Primary IP 13 deleted\n"
 

--- a/internal/cmd/primaryip/describe_test.go
+++ b/internal/cmd/primaryip/describe_test.go
@@ -41,7 +41,7 @@ func TestDescribe(t *testing.T) {
 		Get(gomock.Any(), "10").
 		Return(primaryIP, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"10"})
+	out, _, err := fx.Run(cmd, []string{"10"})
 
 	expOut := fmt.Sprintf(`ID:		10
 Name:		test-net

--- a/internal/cmd/primaryip/disable_protection_test.go
+++ b/internal/cmd/primaryip/disable_protection_test.go
@@ -44,7 +44,7 @@ func TestEnable(t *testing.T) {
 		)
 
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), action).Return(nil)
-	out, err := fx.Run(cmd, []string{"13"})
+	out, _, err := fx.Run(cmd, []string{"13"})
 
 	expOut := "Resource protection disabled for primary IP 13\n"
 

--- a/internal/cmd/primaryip/enable_protection_test.go
+++ b/internal/cmd/primaryip/enable_protection_test.go
@@ -44,7 +44,7 @@ func TestEnableProtection(t *testing.T) {
 		)
 
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), action).Return(nil)
-	out, err := fx.Run(cmd, []string{"13"})
+	out, _, err := fx.Run(cmd, []string{"13"})
 
 	expOut := "Resource protection enabled for primary IP 13\n"
 

--- a/internal/cmd/primaryip/labels_test.go
+++ b/internal/cmd/primaryip/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			}),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to primary-ip 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: hcloud.Ptr(make(map[string]string)),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from primary-ip 123\n"
 

--- a/internal/cmd/primaryip/list_test.go
+++ b/internal/cmd/primaryip/list_test.go
@@ -43,7 +43,7 @@ func TestList(t *testing.T) {
 		},
 			nil)
 
-	out, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
+	out, _, err := fx.Run(cmd, []string{"--selector", "foo=bar"})
 
 	expOut := `ID    TYPE   NAME       IP          ASSIGNEE   DNS   AUTO DELETE   AGE
 123   ipv4   test-net   127.0.0.1   -          -     yes           10s

--- a/internal/cmd/primaryip/unassign_test.go
+++ b/internal/cmd/primaryip/unassign_test.go
@@ -41,7 +41,7 @@ func TestUnAssign(t *testing.T) {
 
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), action).Return(nil)
 
-	out, err := fx.Run(cmd, []string{"13"})
+	out, _, err := fx.Run(cmd, []string{"13"})
 
 	expOut := "Primary IP 13 was unassigned successfully\n"
 

--- a/internal/cmd/primaryip/update_test.go
+++ b/internal/cmd/primaryip/update_test.go
@@ -30,7 +30,7 @@ func TestUpdateName(t *testing.T) {
 			AutoDelete: nil,
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Primary IP 123 updated\n"
 
@@ -56,7 +56,7 @@ func TestUpdateAutoDelete(t *testing.T) {
 			AutoDelete: hcloud.Ptr(false),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--auto-delete=false"})
+	out, _, err := fx.Run(cmd, []string{"123", "--auto-delete=false"})
 
 	expOut := "Primary IP 123 updated\n"
 

--- a/internal/cmd/server/add_to_placement_group_test.go
+++ b/internal/cmd/server/add_to_placement_group_test.go
@@ -44,7 +44,7 @@ func TestAddToPlacementGroup(t *testing.T) {
 		AddToPlacementGroup(gomock.Any(), &server, &placementGroup)
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), nil)
 
-	out, err := fx.Run(cmd, []string{"-g", placementGroup.Name, server.Name})
+	out, _, err := fx.Run(cmd, []string{"-g", placementGroup.Name, server.Name})
 
 	expOut := `Server 42 added to placement group my Placement Group
 `

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) {
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
 
 	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
-	out, err := fx.Run(cmd, args)
+	out, _, err := fx.Run(cmd, args)
 
 	assert.NoError(t, err)
 	expOut := `Server 1234 created
@@ -145,7 +145,7 @@ func TestCreateProtectionBackup(t *testing.T) {
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), &hcloud.Action{ID: 42}).Return(nil)
 
 	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04", "--enable-protection", "rebuild,delete", "--enable-backup"}
-	out, err := fx.Run(cmd, args)
+	out, _, err := fx.Run(cmd, args)
 
 	assert.NoError(t, err)
 	expOut := `Server 1234 created

--- a/internal/cmd/server/delete_test.go
+++ b/internal/cmd/server/delete_test.go
@@ -38,7 +38,7 @@ func TestDelete(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), &hcloud.Action{ID: 321})
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "Server test deleted\n"
 

--- a/internal/cmd/server/describe_test.go
+++ b/internal/cmd/server/describe_test.go
@@ -78,7 +78,7 @@ func TestDescribe(t *testing.T) {
 		Get(gomock.Any(), "test").
 		Return(srv, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Name:		test

--- a/internal/cmd/server/labels_test.go
+++ b/internal/cmd/server/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to server 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from server 123\n"
 

--- a/internal/cmd/server/list_test.go
+++ b/internal/cmd/server/list_test.go
@@ -45,7 +45,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   STATUS    IPV4          IPV6   PRIVATE NET   DATACENTER   AGE
 123   test   running   192.168.2.1   -      -             fsn1-dc14    20s

--- a/internal/cmd/server/remove_from_placement_group_test.go
+++ b/internal/cmd/server/remove_from_placement_group_test.go
@@ -35,7 +35,7 @@ func TestRemoveFromPlacementGroup(t *testing.T) {
 		RemoveFromPlacementGroup(gomock.Any(), &server)
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), nil)
 
-	out, err := fx.Run(cmd, []string{server.Name})
+	out, _, err := fx.Run(cmd, []string{server.Name})
 
 	expOut := `Server 42 removed from placement group
 `

--- a/internal/cmd/server/shutdown_test.go
+++ b/internal/cmd/server/shutdown_test.go
@@ -39,7 +39,7 @@ func TestShutdown(t *testing.T) {
 		Shutdown(gomock.Any(), &server)
 	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), nil)
 
-	out, err := fx.Run(cmd, []string{server.Name})
+	out, _, err := fx.Run(cmd, []string{server.Name})
 
 	expOut := "Sent shutdown signal to server 42\n"
 
@@ -81,7 +81,7 @@ func TestShutdownWait(t *testing.T) {
 		Return(&server, nil, nil).
 		Return(&hcloud.Server{ID: server.ID, Name: server.Name, Status: hcloud.ServerStatusOff}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{server.Name, "--wait"})
+	out, _, err := fx.Run(cmd, []string{server.Name, "--wait"})
 
 	expOut := "Sent shutdown signal to server 42\nWaiting for server to shut down ... done\nServer 42 shut down\n"
 

--- a/internal/cmd/server/update_test.go
+++ b/internal/cmd/server/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Server 123 updated\n"
 

--- a/internal/cmd/servertype/describe_test.go
+++ b/internal/cmd/servertype/describe_test.go
@@ -34,7 +34,7 @@ func TestDescribe(t *testing.T) {
 			StorageType: hcloud.StorageTypeLocal,
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"cax11"})
+	out, _, err := fx.Run(cmd, []string{"cax11"})
 
 	expOut := `ID:			45
 Name:			cax11

--- a/internal/cmd/servertype/list_test.go
+++ b/internal/cmd/servertype/list_test.go
@@ -44,7 +44,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   CORES   CPU TYPE   ARCHITECTURE   MEMORY   DISK    STORAGE TYPE   TRAFFIC
 123   test   2       shared     arm            8.0 GB   80 GB   local          20 TB

--- a/internal/cmd/sshkey/create_test.go
+++ b/internal/cmd/sshkey/create_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 			PublicKey: "test",
 		}, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"--name", "test", "--public-key", "test"})
+	out, _, err := fx.Run(cmd, []string{"--name", "test", "--public-key", "test"})
 
 	expOut := "SSH key 123 created\n"
 

--- a/internal/cmd/sshkey/delete_test.go
+++ b/internal/cmd/sshkey/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), sshKey).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "SSH Key test deleted\n"
 

--- a/internal/cmd/sshkey/describe_test.go
+++ b/internal/cmd/sshkey/describe_test.go
@@ -39,7 +39,7 @@ func TestDescribe(t *testing.T) {
 		Get(gomock.Any(), "test").
 		Return(key, nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Name:		test

--- a/internal/cmd/sshkey/labels_test.go
+++ b/internal/cmd/sshkey/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to SSH Key 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from SSH Key 123\n"
 

--- a/internal/cmd/sshkey/list_test.go
+++ b/internal/cmd/sshkey/list_test.go
@@ -37,7 +37,7 @@ func TestList(t *testing.T) {
 			},
 		}, nil)
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   FINGERPRINT   AGE
 123   test   -             1h

--- a/internal/cmd/sshkey/update_test.go
+++ b/internal/cmd/sshkey/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "SSHKey 123 updated\n"
 

--- a/internal/cmd/volume/create_test.go
+++ b/internal/cmd/volume/create_test.go
@@ -44,7 +44,7 @@ func TestCreate(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
 
-	out, err := fx.Run(cmd, []string{"--name", "test", "--size", "20", "--location", "fsn1"})
+	out, _, err := fx.Run(cmd, []string{"--name", "test", "--size", "20", "--location", "fsn1"})
 
 	expOut := "Volume 123 created\n"
 
@@ -94,7 +94,7 @@ func TestCreateProtection(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), &hcloud.Action{ID: 123})
 
-	out, err := fx.Run(cmd, []string{"--name", "test", "--size", "20", "--location", "fsn1", "--enable-protection", "delete"})
+	out, _, err := fx.Run(cmd, []string{"--name", "test", "--size", "20", "--location", "fsn1", "--enable-protection", "delete"})
 
 	expOut := `Volume 123 created
 Resource protection enabled for volume 123

--- a/internal/cmd/volume/delete_test.go
+++ b/internal/cmd/volume/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 		Delete(gomock.Any(), volume).
 		Return(nil, nil)
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := "Volume test deleted\n"
 

--- a/internal/cmd/volume/describe_test.go
+++ b/internal/cmd/volume/describe_test.go
@@ -52,7 +52,7 @@ func TestDescribe(t *testing.T) {
 		ServerName(int64(321)).
 		Return("myServer")
 
-	out, err := fx.Run(cmd, []string{"test"})
+	out, _, err := fx.Run(cmd, []string{"test"})
 
 	expOut := fmt.Sprintf(`ID:		123
 Name:		test

--- a/internal/cmd/volume/labels_test.go
+++ b/internal/cmd/volume/labels_test.go
@@ -31,7 +31,7 @@ func TestLabelAdd(t *testing.T) {
 			},
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key=value"})
+	out, _, err := fx.Run(cmd, []string{"123", "key=value"})
 
 	expOut := "Label key added to Volume 123\n"
 
@@ -62,7 +62,7 @@ func TestLabelRemove(t *testing.T) {
 			Labels: make(map[string]string),
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "key"})
+	out, _, err := fx.Run(cmd, []string{"123", "key"})
 
 	expOut := "Label key removed from Volume 123\n"
 

--- a/internal/cmd/volume/list_test.go
+++ b/internal/cmd/volume/list_test.go
@@ -43,7 +43,7 @@ func TestList(t *testing.T) {
 		ServerName(int64(321)).
 		Return("myServer")
 
-	out, err := fx.Run(cmd, []string{})
+	out, _, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   SIZE    SERVER     LOCATION   AGE
 123   test   50 GB   myServer   fsn1       1h

--- a/internal/cmd/volume/update_test.go
+++ b/internal/cmd/volume/update_test.go
@@ -29,7 +29,7 @@ func TestUpdateName(t *testing.T) {
 			Name: "new-name",
 		})
 
-	out, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
+	out, _, err := fx.Run(cmd, []string{"123", "--name", "new-name"})
 
 	expOut := "Volume 123 updated\n"
 

--- a/internal/testutil/fixture.go
+++ b/internal/testutil/fixture.go
@@ -37,9 +37,9 @@ func (f *Fixture) ExpectEnsureToken() {
 
 // Run runs the given cobra command with the given arguments and returns stdout output and a
 // potential error.
-func (f *Fixture) Run(cmd *cobra.Command, args []string) (string, error) {
+func (f *Fixture) Run(cmd *cobra.Command, args []string) (string, string, error) {
 	cmd.SetArgs(args)
-	return CaptureStdout(cmd.Execute)
+	return CaptureOutStreams(cmd.Execute)
 }
 
 // Finish must be called after the test is finished, preferably via `defer` directly after

--- a/internal/testutil/testing.go
+++ b/internal/testutil/testing.go
@@ -7,46 +7,58 @@ import (
 	"os"
 )
 
-// CaptureStdout redirects stdout while running fn and returns the output as a string.
+// CaptureOutStreams redirects stdout & stderr while running fn and returns the outputs as a string.
 // If there's an error during capture, it returns the error, otherwise it returns the error
 // returned by fn.
-func CaptureStdout(fn func() error) (string, error) {
-	r, w, err := os.Pipe()
+func CaptureOutStreams(fn func() error) (string, string, error) {
+	outR, outW, err := os.Pipe()
 	if err != nil {
-		return "", fmt.Errorf("capture stdout: %v", err)
+		return "", "", fmt.Errorf("capture stdout: %v", err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		return "", "", fmt.Errorf("capture stderr: %v", err)
 	}
 
-	origOut := os.Stdout
+	origOut, origErr := os.Stdout, os.Stderr
 	defer func() {
 		os.Stdout = origOut
+		os.Stderr = origErr
 	}()
+	os.Stdout, os.Stderr = outW, errW
 
-	buf := &bytes.Buffer{}
-	os.Stdout = w
+	outBuf, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
 
-	copyDone := make(chan struct{})
-	var copyErr error
+	var copyErr = make(chan error)
 	go func() {
-		defer close(copyDone)
+		defer close(copyErr)
 
-		copied, err := io.Copy(buf, r)
+		copied, err := io.Copy(outBuf, outR)
 		if err != nil {
-			copyErr = fmt.Errorf("capture stdout: %v, copied: %d\n", err, copied)
+			copyErr <- fmt.Errorf("capture stdout: %v, copied: %d", err, copied)
+			return
+		}
+
+		copied, err = io.Copy(errBuf, errR)
+		if err != nil {
+			copyErr <- fmt.Errorf("capture stderr: %v, copied: %d", err, copied)
 			return
 		}
 	}()
 
 	err = fn()
 
-	if copyErr != nil {
-		return "", copyErr
+	if err := outW.Close(); err != nil {
+		return "", "", fmt.Errorf("capture stdout close pipe writer: %v", err)
 	}
 
-	if err := w.Close(); err != nil {
-		return "", fmt.Errorf("capture stdout close pipe reader: %v", err)
+	if err := errW.Close(); err != nil {
+		return "", "", fmt.Errorf("capture stderr close pipe writer: %v", err)
 	}
 
-	<-copyDone
+	if err := <-copyErr; err != nil {
+		return "", "", err
+	}
 
-	return buf.String(), err
+	return outBuf.String(), errBuf.String(), err
 }


### PR DESCRIPTION
In the future this will be useful for testing "-o=json" on resource creation, because the actual JSON and status messages will be printed to stdout/stderr respectively.