### PR TITLE
refactor: use Cobra print functions where possible

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -62,5 +63,6 @@ func NewRootCommand(state *state.State, client hcapi2.Client) *cobra.Command {
 		primaryip.NewCommand(state, client),
 	)
 	cmd.PersistentFlags().Duration("poll-interval", 500*time.Millisecond, "Interval at which to poll information, for example action progress")
+	cmd.SetOut(os.Stdout)
 	return cmd
 }

--- a/internal/cmd/all/list.go
+++ b/internal/cmd/all/list.go
@@ -3,7 +3,6 @@ package all
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -158,7 +157,7 @@ Listed resources are:
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%s\n", jsonBytes)
+			cmd.Printf("%s\n", jsonBytes)
 			return nil
 		}
 
@@ -171,14 +170,14 @@ Listed resources are:
 				continue
 			}
 
-			fmt.Print(strings.ToUpper(lc.ResourceNamePlural) + "\n---\n")
+			cmd.Print(strings.ToUpper(lc.ResourceNamePlural) + "\n---\n")
 			for _, resource := range resources[i] {
 				table.Write(cols, resource)
 			}
 			if err := table.Flush(); err != nil {
 				return err
 			}
-			fmt.Println()
+			cmd.Println()
 		}
 
 		return nil

--- a/internal/cmd/base/delete.go
+++ b/internal/cmd/base/delete.go
@@ -65,6 +65,6 @@ func (dc *DeleteCmd) Run(ctx context.Context, client hcapi2.Client, actionWaiter
 	if err := dc.Delete(ctx, client, actionWaiter, cmd, resource); err != nil {
 		return fmt.Errorf("deleting %s %s failed: %s", dc.ResourceNameSingular, idOrName, err)
 	}
-	fmt.Printf("%s %v deleted\n", dc.ResourceNameSingular, idOrName)
+	cmd.Printf("%s %v deleted\n", dc.ResourceNameSingular, idOrName)
 	return nil
 }

--- a/internal/cmd/base/labels.go
+++ b/internal/cmd/base/labels.go
@@ -71,7 +71,7 @@ func (lc *LabelCmds) RunAdd(ctx context.Context, client hcapi2.Client, cmd *cobr
 		return err
 	}
 
-	fmt.Printf("Label %s added to %s %d\n", key, lc.ResourceNameSingular, id)
+	cmd.Printf("Label %s added to %s %d\n", key, lc.ResourceNameSingular, id)
 	return nil
 }
 
@@ -137,9 +137,9 @@ func (lc *LabelCmds) RunRemove(ctx context.Context, client hcapi2.Client, cmd *c
 	}
 
 	if all {
-		fmt.Printf("All labels removed from %s %d\n", lc.ResourceNameSingular, id)
+		cmd.Printf("All labels removed from %s %d\n", lc.ResourceNameSingular, id)
 	} else {
-		fmt.Printf("Label %s removed from %s %d\n", args[1], lc.ResourceNameSingular, id)
+		cmd.Printf("Label %s removed from %s %d\n", args[1], lc.ResourceNameSingular, id)
 	}
 
 	return nil

--- a/internal/cmd/base/set_rdns.go
+++ b/internal/cmd/base/set_rdns.go
@@ -81,7 +81,7 @@ func (rc *SetRdnsCmd) Run(ctx context.Context, client hcapi2.Client, cmd *cobra.
 		return err
 	}
 
-	fmt.Printf("Reverse DNS of %s %s changed\n", rc.ResourceNameSingular, idOrName)
+	cmd.Printf("Reverse DNS of %s %s changed\n", rc.ResourceNameSingular, idOrName)
 
 	return nil
 }

--- a/internal/cmd/base/update.go
+++ b/internal/cmd/base/update.go
@@ -74,6 +74,6 @@ func (uc *UpdateCmd) Run(ctx context.Context, client hcapi2.Client, cmd *cobra.C
 		return fmt.Errorf("updating %s %s failed: %s", uc.ResourceNameSingular, idOrName, err)
 	}
 
-	fmt.Printf("%s %v updated\n", uc.ResourceNameSingular, idOrName)
+	cmd.Printf("%s %v updated\n", uc.ResourceNameSingular, idOrName)
 	return nil
 }

--- a/internal/cmd/certificate/create.go
+++ b/internal/cmd/certificate/create.go
@@ -96,7 +96,7 @@ func createUploaded(ctx context.Context, client hcapi2.Client, cmd *cobra.Comman
 	if cert, _, err = client.Certificate().Create(ctx, createOpts); err != nil {
 		return err
 	}
-	fmt.Printf("Certificate %d created\n", cert.ID)
+	cmd.Printf("Certificate %d created\n", cert.ID)
 	return nil
 }
 
@@ -129,6 +129,6 @@ func createManaged(ctx context.Context, client hcapi2.Client, waiter state.Actio
 	if err := waiter.ActionProgress(ctx, res.Action); err != nil {
 		return err
 	}
-	fmt.Printf("Certificate %d created\n", res.Certificate.ID)
+	cmd.Printf("Certificate %d created\n", res.Certificate.ID)
 	return nil
 }

--- a/internal/cmd/certificate/describe.go
+++ b/internal/cmd/certificate/describe.go
@@ -2,7 +2,6 @@ package certificate
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -24,47 +23,47 @@ var DescribeCmd = base.DescribeCmd{
 	},
 	PrintText: func(_ context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		cert := resource.(*hcloud.Certificate)
-		fmt.Printf("ID:\t\t\t%d\n", cert.ID)
-		fmt.Printf("Name:\t\t\t%s\n", cert.Name)
-		fmt.Printf("Type:\t\t\t%s\n", cert.Type)
-		fmt.Printf("Fingerprint:\t\t%s\n", cert.Fingerprint)
-		fmt.Printf("Created:\t\t%s (%s)\n", util.Datetime(cert.Created), humanize.Time(cert.Created))
-		fmt.Printf("Not valid before:\t%s (%s)\n", util.Datetime(cert.NotValidBefore), humanize.Time(cert.NotValidBefore))
-		fmt.Printf("Not valid after:\t%s (%s)\n", util.Datetime(cert.NotValidAfter), humanize.Time(cert.NotValidAfter))
+		cmd.Printf("ID:\t\t\t%d\n", cert.ID)
+		cmd.Printf("Name:\t\t\t%s\n", cert.Name)
+		cmd.Printf("Type:\t\t\t%s\n", cert.Type)
+		cmd.Printf("Fingerprint:\t\t%s\n", cert.Fingerprint)
+		cmd.Printf("Created:\t\t%s (%s)\n", util.Datetime(cert.Created), humanize.Time(cert.Created))
+		cmd.Printf("Not valid before:\t%s (%s)\n", util.Datetime(cert.NotValidBefore), humanize.Time(cert.NotValidBefore))
+		cmd.Printf("Not valid after:\t%s (%s)\n", util.Datetime(cert.NotValidAfter), humanize.Time(cert.NotValidAfter))
 		if cert.Status != nil {
-			fmt.Printf("Status:\n")
-			fmt.Printf("  Issuance:\t%s\n", cert.Status.Issuance)
-			fmt.Printf("  Renewal:\t%s\n", cert.Status.Renewal)
+			cmd.Printf("Status:\n")
+			cmd.Printf("  Issuance:\t%s\n", cert.Status.Issuance)
+			cmd.Printf("  Renewal:\t%s\n", cert.Status.Renewal)
 			if cert.Status.IsFailed() {
-				fmt.Printf("  Failure reason: %s\n", cert.Status.Error.Message)
+				cmd.Printf("  Failure reason: %s\n", cert.Status.Error.Message)
 			}
 		}
-		fmt.Printf("Domain names:\n")
+		cmd.Printf("Domain names:\n")
 		for _, domainName := range cert.DomainNames {
-			fmt.Printf("  - %s\n", domainName)
+			cmd.Printf("  - %s\n", domainName)
 		}
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(cert.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range cert.Labels {
-				fmt.Printf("  %s:\t%s\n", key, value)
+				cmd.Printf("  %s:\t%s\n", key, value)
 			}
 		}
-		fmt.Println("Used By:")
+		cmd.Println("Used By:")
 		if len(cert.UsedBy) == 0 {
-			fmt.Println("  Certificate unused")
+			cmd.Println("  Certificate unused")
 		} else {
 			for _, ub := range cert.UsedBy {
-				fmt.Printf("  - Type: %s\n", ub.Type)
+				cmd.Printf("  - Type: %s\n", ub.Type)
 				// Currently certificates can be only attached to load balancers.
 				// If we ever get something that is not a load balancer fall back
 				// to printing the ID.
 				if ub.Type != hcloud.CertificateUsedByRefTypeLoadBalancer {
-					fmt.Printf("  - ID: %d\n", ub.ID)
+					cmd.Printf("  - ID: %d\n", ub.ID)
 					continue
 				}
-				fmt.Printf("  - Name: %s\n", client.LoadBalancer().LoadBalancerName(ub.ID))
+				cmd.Printf("  - Name: %s\n", client.LoadBalancer().LoadBalancerName(ub.ID))
 			}
 		}
 		return nil

--- a/internal/cmd/context/active.go
+++ b/internal/cmd/context/active.go
@@ -26,7 +26,7 @@ func runActive(cli *state.State, cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintln(os.Stderr, "Warning: HCLOUD_TOKEN is set. The active context will have no effect.")
 	}
 	if cli.Config.ActiveContext != nil {
-		fmt.Println(cli.Config.ActiveContext.Name)
+		cmd.Println(cli.Config.ActiveContext.Name)
 	}
 	return nil
 }

--- a/internal/cmd/context/create.go
+++ b/internal/cmd/context/create.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"syscall"
@@ -27,7 +26,7 @@ func newCreateCommand(cli *state.State) *cobra.Command {
 	return cmd
 }
 
-func runCreate(cli *state.State, _ *cobra.Command, args []string) error {
+func runCreate(cli *state.State, cmd *cobra.Command, args []string) error {
 	if !state.StdoutIsTerminal() {
 		return errors.New("context create is an interactive command")
 	}
@@ -47,9 +46,9 @@ func runCreate(cli *state.State, _ *cobra.Command, args []string) error {
 	envToken := os.Getenv("HCLOUD_TOKEN")
 	if envToken != "" {
 		if len(envToken) != 64 {
-			fmt.Println("Warning: HCLOUD_TOKEN is set, but token is invalid (must be exactly 64 characters long)")
+			cmd.Println("Warning: HCLOUD_TOKEN is set, but token is invalid (must be exactly 64 characters long)")
 		} else {
-			fmt.Print("The HCLOUD_TOKEN environment variable is set. Do you want to use the token from HCLOUD_TOKEN for the new context? (Y/n): ")
+			cmd.Print("The HCLOUD_TOKEN environment variable is set. Do you want to use the token from HCLOUD_TOKEN for the new context? (Y/n): ")
 			scanner := bufio.NewScanner(os.Stdin)
 			scanner.Scan()
 			if s := strings.ToLower(scanner.Text()); s == "" || s == "y" || s == "yes" {
@@ -60,11 +59,11 @@ func runCreate(cli *state.State, _ *cobra.Command, args []string) error {
 
 	if token == "" {
 		for {
-			fmt.Printf("Token: ")
+			cmd.Printf("Token: ")
 			// Conversion needed for compilation on Windows
 			//                               vvv
 			btoken, err := term.ReadPassword(int(syscall.Stdin))
-			fmt.Print("\n")
+			cmd.Print("\n")
 			if err != nil {
 				return err
 			}
@@ -73,7 +72,7 @@ func runCreate(cli *state.State, _ *cobra.Command, args []string) error {
 				continue
 			}
 			if len(token) != 64 {
-				fmt.Print("Entered token is invalid (must be exactly 64 characters long)\n")
+				cmd.Print("Entered token is invalid (must be exactly 64 characters long)\n")
 				continue
 			}
 			break
@@ -89,7 +88,7 @@ func runCreate(cli *state.State, _ *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Context %s created and activated\n", name)
+	cmd.Printf("Context %s created and activated\n", name)
 
 	return nil
 }

--- a/internal/cmd/datacenter/describe.go
+++ b/internal/cmd/datacenter/describe.go
@@ -2,7 +2,6 @@ package datacenter
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -23,37 +22,37 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		datacenter := resource.(*hcloud.Datacenter)
 
-		fmt.Printf("ID:\t\t%d\n", datacenter.ID)
-		fmt.Printf("Name:\t\t%s\n", datacenter.Name)
-		fmt.Printf("Description:\t%s\n", datacenter.Description)
-		fmt.Printf("Location:\n")
-		fmt.Printf("  Name:\t\t%s\n", datacenter.Location.Name)
-		fmt.Printf("  Description:\t%s\n", datacenter.Location.Description)
-		fmt.Printf("  Country:\t%s\n", datacenter.Location.Country)
-		fmt.Printf("  City:\t\t%s\n", datacenter.Location.City)
-		fmt.Printf("  Latitude:\t%f\n", datacenter.Location.Latitude)
-		fmt.Printf("  Longitude:\t%f\n", datacenter.Location.Longitude)
-		fmt.Printf("Server Types:\n")
+		cmd.Printf("ID:\t\t%d\n", datacenter.ID)
+		cmd.Printf("Name:\t\t%s\n", datacenter.Name)
+		cmd.Printf("Description:\t%s\n", datacenter.Description)
+		cmd.Printf("Location:\n")
+		cmd.Printf("  Name:\t\t%s\n", datacenter.Location.Name)
+		cmd.Printf("  Description:\t%s\n", datacenter.Location.Description)
+		cmd.Printf("  Country:\t%s\n", datacenter.Location.Country)
+		cmd.Printf("  City:\t\t%s\n", datacenter.Location.City)
+		cmd.Printf("  Latitude:\t%f\n", datacenter.Location.Latitude)
+		cmd.Printf("  Longitude:\t%f\n", datacenter.Location.Longitude)
+		cmd.Printf("Server Types:\n")
 
 		printServerTypes := func(list []*hcloud.ServerType) {
 			for _, t := range list {
-				fmt.Printf("  - ID:\t\t %d\n", t.ID)
-				fmt.Printf("    Name:\t %s\n", client.ServerType().ServerTypeName(t.ID))
-				fmt.Printf("    Description: %s\n", client.ServerType().ServerTypeDescription(t.ID))
+				cmd.Printf("  - ID:\t\t %d\n", t.ID)
+				cmd.Printf("    Name:\t %s\n", client.ServerType().ServerTypeName(t.ID))
+				cmd.Printf("    Description: %s\n", client.ServerType().ServerTypeDescription(t.ID))
 			}
 		}
 
-		fmt.Printf("  Available:\n")
+		cmd.Printf("  Available:\n")
 		if len(datacenter.ServerTypes.Available) > 0 {
 			printServerTypes(datacenter.ServerTypes.Available)
 		} else {
-			fmt.Printf("    No available server types\n")
+			cmd.Printf("    No available server types\n")
 		}
-		fmt.Printf("  Supported:\n")
+		cmd.Printf("  Supported:\n")
 		if len(datacenter.ServerTypes.Supported) > 0 {
 			printServerTypes(datacenter.ServerTypes.Supported)
 		} else {
-			fmt.Printf("    No supported server types\n")
+			cmd.Printf("    No supported server types\n")
 		}
 
 		return nil

--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -117,7 +117,7 @@ var AddRuleCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)
+		cmd.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)
 
 		return nil
 	},

--- a/internal/cmd/firewall/apply_to_resource.go
+++ b/internal/cmd/firewall/apply_to_resource.go
@@ -86,7 +86,7 @@ var ApplyToResourceCmd = base.Cmd{
 		if err := waiter.WaitForActions(ctx, actions); err != nil {
 			return err
 		}
-		fmt.Printf("Firewall %d applied\n", firewall.ID)
+		cmd.Printf("Firewall %d applied\n", firewall.ID)
 
 		return nil
 	},

--- a/internal/cmd/firewall/create.go
+++ b/internal/cmd/firewall/create.go
@@ -87,7 +87,7 @@ var CreateCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Firewall %d created\n", result.Firewall.ID)
+		cmd.Printf("Firewall %d created\n", result.Firewall.ID)
 
 		return nil
 	},

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -124,7 +124,7 @@ var DeleteRuleCmd = base.Cmd{
 		if err := waiter.WaitForActions(ctx, actions); err != nil {
 			return err
 		}
-		fmt.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)
+		cmd.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)
 
 		return nil
 	},

--- a/internal/cmd/firewall/describe.go
+++ b/internal/cmd/firewall/describe.go
@@ -2,7 +2,6 @@ package firewall
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/dustin/go-humanize"
@@ -26,60 +25,60 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(_ context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		firewall := resource.(*hcloud.Firewall)
 
-		fmt.Printf("ID:\t\t%d\n", firewall.ID)
-		fmt.Printf("Name:\t\t%s\n", firewall.Name)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(firewall.Created), humanize.Time(firewall.Created))
+		cmd.Printf("ID:\t\t%d\n", firewall.ID)
+		cmd.Printf("Name:\t\t%s\n", firewall.Name)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(firewall.Created), humanize.Time(firewall.Created))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(firewall.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range firewall.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 
-		fmt.Print("Rules:\n")
+		cmd.Print("Rules:\n")
 		if len(firewall.Rules) == 0 {
-			fmt.Print("  No rules\n")
+			cmd.Print("  No rules\n")
 		} else {
 			for _, rule := range firewall.Rules {
-				fmt.Printf("  - Direction:\t\t%s\n", rule.Direction)
+				cmd.Printf("  - Direction:\t\t%s\n", rule.Direction)
 				if rule.Description != nil {
-					fmt.Printf("    Description:\t%s\n", *rule.Description)
+					cmd.Printf("    Description:\t%s\n", *rule.Description)
 				}
-				fmt.Printf("    Protocol:\t\t%s\n", rule.Protocol)
+				cmd.Printf("    Protocol:\t\t%s\n", rule.Protocol)
 				if rule.Port != nil {
-					fmt.Printf("    Port:\t\t%s\n", *rule.Port)
+					cmd.Printf("    Port:\t\t%s\n", *rule.Port)
 				}
 
 				var ips []net.IPNet
 				switch rule.Direction {
 				case hcloud.FirewallRuleDirectionIn:
-					fmt.Print("    Source IPs:\n")
+					cmd.Print("    Source IPs:\n")
 					ips = rule.SourceIPs
 				case hcloud.FirewallRuleDirectionOut:
-					fmt.Print("    Destination IPs:\n")
+					cmd.Print("    Destination IPs:\n")
 					ips = rule.DestinationIPs
 				}
 
 				for _, cidr := range ips {
-					fmt.Printf("     \t\t\t%s\n", cidr.String())
+					cmd.Printf("     \t\t\t%s\n", cidr.String())
 				}
 			}
 		}
-		fmt.Print("Applied To:\n")
+		cmd.Print("Applied To:\n")
 		if len(firewall.AppliedTo) == 0 {
-			fmt.Print("  Not applied\n")
+			cmd.Print("  Not applied\n")
 		} else {
 			for _, resource := range firewall.AppliedTo {
-				fmt.Printf("  - Type:\t\t%s\n", resource.Type)
+				cmd.Printf("  - Type:\t\t%s\n", resource.Type)
 				switch resource.Type {
 				case hcloud.FirewallResourceTypeServer:
-					fmt.Printf("    Server ID:\t\t%d\n", resource.Server.ID)
-					fmt.Printf("    Server Name:\t%s\n", client.Server().ServerName(resource.Server.ID))
+					cmd.Printf("    Server ID:\t\t%d\n", resource.Server.ID)
+					cmd.Printf("    Server Name:\t%s\n", client.Server().ServerName(resource.Server.ID))
 				case hcloud.FirewallResourceTypeLabelSelector:
-					fmt.Printf("    Label Selector:\t%s\n", resource.LabelSelector.Selector)
+					cmd.Printf("    Label Selector:\t%s\n", resource.LabelSelector.Selector)
 				}
 			}
 		}

--- a/internal/cmd/firewall/remove_from_resource.go
+++ b/internal/cmd/firewall/remove_from_resource.go
@@ -85,7 +85,7 @@ var RemoveFromResourceCmd = base.Cmd{
 		if err := waiter.WaitForActions(ctx, actions); err != nil {
 			return err
 		}
-		fmt.Printf("Firewall %d applied\n", firewall.ID)
+		cmd.Printf("Firewall %d applied\n", firewall.ID)
 
 		return nil
 	},

--- a/internal/cmd/firewall/replace_rules.go
+++ b/internal/cmd/firewall/replace_rules.go
@@ -98,7 +98,7 @@ var ReplaceRulesCmd = base.Cmd{
 		if err := waiter.WaitForActions(ctx, actions); err != nil {
 			return err
 		}
-		fmt.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)
+		cmd.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)
 
 		return nil
 	},

--- a/internal/cmd/floatingip/assign.go
+++ b/internal/cmd/floatingip/assign.go
@@ -54,7 +54,7 @@ var AssignCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Floating IP %d assigned to server %d\n", floatingIP.ID, server.ID)
+		cmd.Printf("Floating IP %d assigned to server %d\n", floatingIP.ID, server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/floatingip/create.go
+++ b/internal/cmd/floatingip/create.go
@@ -100,13 +100,13 @@ var CreateCmd = base.Cmd{
 			}
 		}
 
-		fmt.Printf("Floating IP %d created\n", result.FloatingIP.ID)
+		cmd.Printf("Floating IP %d created\n", result.FloatingIP.ID)
 
-		if err := changeProtection(ctx, client, waiter, result.FloatingIP, true, protectionOps); err != nil {
+		if err := changeProtection(ctx, client, waiter, cmd, result.FloatingIP, true, protectionOps); err != nil {
 			return err
 		}
 
-		fmt.Printf("IP%s: %s\n", result.FloatingIP.Type[2:], result.FloatingIP.IP)
+		cmd.Printf("IP%s: %s\n", result.FloatingIP.Type[2:], result.FloatingIP.IP)
 		return nil
 	},
 }

--- a/internal/cmd/floatingip/describe.go
+++ b/internal/cmd/floatingip/describe.go
@@ -2,7 +2,6 @@ package floatingip
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -25,43 +24,43 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(_ context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		floatingIP := resource.(*hcloud.FloatingIP)
 
-		fmt.Printf("ID:\t\t%d\n", floatingIP.ID)
-		fmt.Printf("Type:\t\t%s\n", floatingIP.Type)
-		fmt.Printf("Name:\t\t%s\n", floatingIP.Name)
-		fmt.Printf("Description:\t%s\n", util.NA(floatingIP.Description))
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(floatingIP.Created), humanize.Time(floatingIP.Created))
+		cmd.Printf("ID:\t\t%d\n", floatingIP.ID)
+		cmd.Printf("Type:\t\t%s\n", floatingIP.Type)
+		cmd.Printf("Name:\t\t%s\n", floatingIP.Name)
+		cmd.Printf("Description:\t%s\n", util.NA(floatingIP.Description))
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(floatingIP.Created), humanize.Time(floatingIP.Created))
 		if floatingIP.Network != nil {
-			fmt.Printf("IP:\t\t%s\n", floatingIP.Network.String())
+			cmd.Printf("IP:\t\t%s\n", floatingIP.Network.String())
 		} else {
-			fmt.Printf("IP:\t\t%s\n", floatingIP.IP.String())
+			cmd.Printf("IP:\t\t%s\n", floatingIP.IP.String())
 		}
-		fmt.Printf("Blocked:\t%s\n", util.YesNo(floatingIP.Blocked))
-		fmt.Printf("Home Location:\t%s\n", floatingIP.HomeLocation.Name)
+		cmd.Printf("Blocked:\t%s\n", util.YesNo(floatingIP.Blocked))
+		cmd.Printf("Home Location:\t%s\n", floatingIP.HomeLocation.Name)
 		if floatingIP.Server != nil {
-			fmt.Printf("Server:\n")
-			fmt.Printf("  ID:\t%d\n", floatingIP.Server.ID)
-			fmt.Printf("  Name:\t%s\n", client.Server().ServerName(floatingIP.Server.ID))
+			cmd.Printf("Server:\n")
+			cmd.Printf("  ID:\t%d\n", floatingIP.Server.ID)
+			cmd.Printf("  Name:\t%s\n", client.Server().ServerName(floatingIP.Server.ID))
 		} else {
-			fmt.Print("Server:\n  Not assigned\n")
+			cmd.Print("Server:\n  Not assigned\n")
 		}
-		fmt.Print("DNS:\n")
+		cmd.Print("DNS:\n")
 		if len(floatingIP.DNSPtr) == 0 {
-			fmt.Print("  No reverse DNS entries\n")
+			cmd.Print("  No reverse DNS entries\n")
 		} else {
 			for ip, dns := range floatingIP.DNSPtr {
-				fmt.Printf("  %s: %s\n", ip, dns)
+				cmd.Printf("  %s: %s\n", ip, dns)
 			}
 		}
 
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(floatingIP.Protection.Delete))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(floatingIP.Protection.Delete))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(floatingIP.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range floatingIP.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 		return nil

--- a/internal/cmd/floatingip/disable_protection.go
+++ b/internal/cmd/floatingip/disable_protection.go
@@ -41,6 +41,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, floatingIP, false, opts)
+		return changeProtection(ctx, client, waiter, cmd, floatingIP, false, opts)
 	},
 }

--- a/internal/cmd/floatingip/enable_protection.go
+++ b/internal/cmd/floatingip/enable_protection.go
@@ -34,7 +34,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.FloatingIPChan
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, floatingIP *hcloud.FloatingIP, enable bool, opts hcloud.FloatingIPChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	floatingIP *hcloud.FloatingIP, enable bool, opts hcloud.FloatingIPChangeProtectionOpts) error {
 
 	if opts.Delete == nil {
 		return nil
@@ -50,9 +51,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for floating IP %d\n", floatingIP.ID)
+		cmd.Printf("Resource protection enabled for floating IP %d\n", floatingIP.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for floating IP %d\n", floatingIP.ID)
+		cmd.Printf("Resource protection disabled for floating IP %d\n", floatingIP.ID)
 	}
 	return nil
 }
@@ -87,6 +88,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, floatingIP, true, opts)
+		return changeProtection(ctx, client, waiter, cmd, floatingIP, true, opts)
 	},
 }

--- a/internal/cmd/floatingip/unassign.go
+++ b/internal/cmd/floatingip/unassign.go
@@ -42,7 +42,7 @@ var UnassignCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Floating IP %d unassigned\n", floatingIP.ID)
+		cmd.Printf("Floating IP %d unassigned\n", floatingIP.ID)
 		return nil
 	},
 }

--- a/internal/cmd/image/describe.go
+++ b/internal/cmd/image/describe.go
@@ -36,42 +36,42 @@ var DescribeCmd = base.DescribeCmd{
 		}
 		return client.Image().GetForArchitecture(ctx, idOrName, hcloud.Architecture(arch))
 	},
-	PrintText: func(_ context.Context, _ hcapi2.Client, _ *cobra.Command, resource interface{}) error {
+	PrintText: func(_ context.Context, _ hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		image := resource.(*hcloud.Image)
 
-		fmt.Printf("ID:\t\t%d\n", image.ID)
-		fmt.Printf("Type:\t\t%s\n", image.Type)
-		fmt.Printf("Status:\t\t%s\n", image.Status)
-		fmt.Printf("Name:\t\t%s\n", util.NA(image.Name))
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(image.Created), humanize.Time(image.Created))
+		cmd.Printf("ID:\t\t%d\n", image.ID)
+		cmd.Printf("Type:\t\t%s\n", image.Type)
+		cmd.Printf("Status:\t\t%s\n", image.Status)
+		cmd.Printf("Name:\t\t%s\n", util.NA(image.Name))
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(image.Created), humanize.Time(image.Created))
 		if !image.Deprecated.IsZero() {
-			fmt.Printf("Deprecated:\t%s (%s)\n", util.Datetime(image.Deprecated), humanize.Time(image.Deprecated))
+			cmd.Printf("Deprecated:\t%s (%s)\n", util.Datetime(image.Deprecated), humanize.Time(image.Deprecated))
 		}
-		fmt.Printf("Description:\t%s\n", image.Description)
+		cmd.Printf("Description:\t%s\n", image.Description)
 		if image.ImageSize != 0 {
-			fmt.Printf("Image size:\t%.2f GB\n", image.ImageSize)
+			cmd.Printf("Image size:\t%.2f GB\n", image.ImageSize)
 		} else {
-			fmt.Printf("Image size:\t%s\n", util.NA(""))
+			cmd.Printf("Image size:\t%s\n", util.NA(""))
 		}
-		fmt.Printf("Disk size:\t%.0f GB\n", image.DiskSize)
-		fmt.Printf("OS flavor:\t%s\n", image.OSFlavor)
-		fmt.Printf("OS version:\t%s\n", util.NA(image.OSVersion))
-		fmt.Printf("Architecture:\t%s\n", image.Architecture)
-		fmt.Printf("Rapid deploy:\t%s\n", util.YesNo(image.RapidDeploy))
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(image.Protection.Delete))
+		cmd.Printf("Disk size:\t%.0f GB\n", image.DiskSize)
+		cmd.Printf("OS flavor:\t%s\n", image.OSFlavor)
+		cmd.Printf("OS version:\t%s\n", util.NA(image.OSVersion))
+		cmd.Printf("Architecture:\t%s\n", image.Architecture)
+		cmd.Printf("Rapid deploy:\t%s\n", util.YesNo(image.RapidDeploy))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(image.Protection.Delete))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(image.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range image.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 
 		if !image.Deprecated.IsZero() {
-			fmt.Printf("\nAttention: This image is deprecated and will be removed in the future.\n")
+			cmd.Printf("\nAttention: This image is deprecated and will be removed in the future.\n")
 		}
 		return nil
 	},

--- a/internal/cmd/image/disable_protection.go
+++ b/internal/cmd/image/disable_protection.go
@@ -28,7 +28,7 @@ var DisableProtectionCmd = base.Cmd{
 			DisableFlagsInUseLine: true,
 		}
 	},
-	Run: func(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, command *cobra.Command, args []string) error {
+	Run: func(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command, args []string) error {
 		imageID, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return errors.New("invalid image ID")
@@ -40,6 +40,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, image, false, opts)
+		return changeProtection(ctx, client, waiter, cmd, image, false, opts)
 	},
 }

--- a/internal/cmd/image/enable_protection.go
+++ b/internal/cmd/image/enable_protection.go
@@ -36,7 +36,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.ImageChangePro
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, image *hcloud.Image, enable bool, opts hcloud.ImageChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	image *hcloud.Image, enable bool, opts hcloud.ImageChangeProtectionOpts) error {
 
 	if opts.Delete == nil {
 		return nil
@@ -52,9 +53,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for image %d\n", image.ID)
+		cmd.Printf("Resource protection enabled for image %d\n", image.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for image %d\n", image.ID)
+		cmd.Printf("Resource protection disabled for image %d\n", image.ID)
 	}
 	return nil
 }
@@ -74,7 +75,7 @@ var EnableProtectionCmd = base.Cmd{
 			DisableFlagsInUseLine: true,
 		}
 	},
-	Run: func(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, command *cobra.Command, args []string) error {
+	Run: func(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command, args []string) error {
 		imageID, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return errors.New("invalid image ID")
@@ -86,6 +87,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, image, true, opts)
+		return changeProtection(ctx, client, waiter, cmd, image, true, opts)
 	},
 }

--- a/internal/cmd/iso/describe.go
+++ b/internal/cmd/iso/describe.go
@@ -2,7 +2,6 @@ package iso
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -25,17 +24,17 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		iso := resource.(*hcloud.ISO)
 
-		fmt.Printf("ID:\t\t%d\n", iso.ID)
-		fmt.Printf("Name:\t\t%s\n", iso.Name)
-		fmt.Printf("Description:\t%s\n", iso.Description)
-		fmt.Printf("Type:\t\t%s\n", iso.Type)
-		fmt.Printf(util.DescribeDeprecation(iso))
+		cmd.Printf("ID:\t\t%d\n", iso.ID)
+		cmd.Printf("Name:\t\t%s\n", iso.Name)
+		cmd.Printf("Description:\t%s\n", iso.Description)
+		cmd.Printf("Type:\t\t%s\n", iso.Type)
+		cmd.Printf(util.DescribeDeprecation(iso))
 
 		architecture := "-"
 		if iso.Architecture != nil {
 			architecture = string(*iso.Architecture)
 		}
-		fmt.Printf("Architecture:\t%s\n", architecture)
+		cmd.Printf("Architecture:\t%s\n", architecture)
 
 		return nil
 	},

--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -125,7 +125,7 @@ var AddServiceCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Service was added to Load Balancer %d\n", loadBalancer.ID)
+		cmd.Printf("Service was added to Load Balancer %d\n", loadBalancer.ID)
 
 		return nil
 	},

--- a/internal/cmd/loadbalancer/add_target.go
+++ b/internal/cmd/loadbalancer/add_target.go
@@ -100,7 +100,7 @@ var AddTargetCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Target added to Load Balancer %d\n", loadBalancer.ID)
+		cmd.Printf("Target added to Load Balancer %d\n", loadBalancer.ID)
 
 		return nil
 	},

--- a/internal/cmd/loadbalancer/attach_to_network.go
+++ b/internal/cmd/loadbalancer/attach_to_network.go
@@ -67,7 +67,7 @@ var AttachToNetworkCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Load Balancer %d attached to network %d\n", loadBalancer.ID, network.ID)
+		cmd.Printf("Load Balancer %d attached to network %d\n", loadBalancer.ID, network.ID)
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/change_algorithm.go
+++ b/internal/cmd/loadbalancer/change_algorithm.go
@@ -51,7 +51,7 @@ var ChangeAlgorithmCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Algorithm for Load Balancer %d was changed\n", loadBalancer.ID)
+		cmd.Printf("Algorithm for Load Balancer %d was changed\n", loadBalancer.ID)
 
 		return nil
 	},

--- a/internal/cmd/loadbalancer/change_type.go
+++ b/internal/cmd/loadbalancer/change_type.go
@@ -58,7 +58,7 @@ var ChangeTypeCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("LoadBalancer %d changed to type %s\n", loadBalancer.ID, loadBalancerType.Name)
+		cmd.Printf("LoadBalancer %d changed to type %s\n", loadBalancer.ID, loadBalancerType.Name)
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -2,7 +2,6 @@ package loadbalancer
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -90,14 +89,14 @@ var CreateCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Load Balancer %d created\n", loadBalancer.ID)
+		cmd.Printf("Load Balancer %d created\n", loadBalancer.ID)
 
-		if err := changeProtection(ctx, client, waiter, loadBalancer, true, protectionOpts); err != nil {
+		if err := changeProtection(ctx, client, waiter, cmd, loadBalancer, true, protectionOpts); err != nil {
 			return err
 		}
 
-		fmt.Printf("IPv4: %s\n", loadBalancer.PublicNet.IPv4.IP.String())
-		fmt.Printf("IPv6: %s\n", loadBalancer.PublicNet.IPv6.IP.String())
+		cmd.Printf("IPv4: %s\n", loadBalancer.PublicNet.IPv4.IP.String())
+		cmd.Printf("IPv6: %s\n", loadBalancer.PublicNet.IPv6.IP.String())
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/delete_service.go
+++ b/internal/cmd/loadbalancer/delete_service.go
@@ -42,7 +42,7 @@ var DeleteServiceCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Service on port %d deleted from Load Balancer %d\n", listenPort, loadBalancer.ID)
+		cmd.Printf("Service on port %d deleted from Load Balancer %d\n", listenPort, loadBalancer.ID)
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/describe.go
+++ b/internal/cmd/loadbalancer/describe.go
@@ -2,7 +2,6 @@ package loadbalancer
 
 import (
 	"context"
-	"fmt"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -29,134 +28,134 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		withLabelSelectorTargets, _ := cmd.Flags().GetBool("expand-targets")
 		loadBalancer := resource.(*hcloud.LoadBalancer)
-		fmt.Printf("ID:\t\t\t\t%d\n", loadBalancer.ID)
-		fmt.Printf("Name:\t\t\t\t%s\n", loadBalancer.Name)
-		fmt.Printf("Created:\t\t\t%s (%s)\n", util.Datetime(loadBalancer.Created), humanize.Time(loadBalancer.Created))
-		fmt.Printf("Public Net:\n")
-		fmt.Printf("  Enabled:\t\t\t%s\n", util.YesNo(loadBalancer.PublicNet.Enabled))
-		fmt.Printf("  IPv4:\t\t\t\t%s\n", loadBalancer.PublicNet.IPv4.IP.String())
-		fmt.Printf("  IPv4 DNS PTR:\t\t\t%s\n", loadBalancer.PublicNet.IPv4.DNSPtr)
-		fmt.Printf("  IPv6:\t\t\t\t%s\n", loadBalancer.PublicNet.IPv6.IP.String())
-		fmt.Printf("  IPv6 DNS PTR:\t\t\t%s\n", loadBalancer.PublicNet.IPv6.DNSPtr)
+		cmd.Printf("ID:\t\t\t\t%d\n", loadBalancer.ID)
+		cmd.Printf("Name:\t\t\t\t%s\n", loadBalancer.Name)
+		cmd.Printf("Created:\t\t\t%s (%s)\n", util.Datetime(loadBalancer.Created), humanize.Time(loadBalancer.Created))
+		cmd.Printf("Public Net:\n")
+		cmd.Printf("  Enabled:\t\t\t%s\n", util.YesNo(loadBalancer.PublicNet.Enabled))
+		cmd.Printf("  IPv4:\t\t\t\t%s\n", loadBalancer.PublicNet.IPv4.IP.String())
+		cmd.Printf("  IPv4 DNS PTR:\t\t\t%s\n", loadBalancer.PublicNet.IPv4.DNSPtr)
+		cmd.Printf("  IPv6:\t\t\t\t%s\n", loadBalancer.PublicNet.IPv6.IP.String())
+		cmd.Printf("  IPv6 DNS PTR:\t\t\t%s\n", loadBalancer.PublicNet.IPv6.DNSPtr)
 
-		fmt.Printf("Private Net:\n")
+		cmd.Printf("Private Net:\n")
 		if len(loadBalancer.PrivateNet) > 0 {
 			for _, n := range loadBalancer.PrivateNet {
-				fmt.Printf("  - ID:\t\t\t%d\n", n.Network.ID)
-				fmt.Printf("    Name:\t\t%s\n", client.Network().Name(n.Network.ID))
-				fmt.Printf("    IP:\t\t\t%s\n", n.IP.String())
+				cmd.Printf("  - ID:\t\t\t%d\n", n.Network.ID)
+				cmd.Printf("    Name:\t\t%s\n", client.Network().Name(n.Network.ID))
+				cmd.Printf("    IP:\t\t\t%s\n", n.IP.String())
 			}
 		} else {
-			fmt.Printf("    No Private Network\n")
+			cmd.Printf("    No Private Network\n")
 		}
-		fmt.Printf("Algorithm:\t\t\t%s\n", loadBalancer.Algorithm.Type)
+		cmd.Printf("Algorithm:\t\t\t%s\n", loadBalancer.Algorithm.Type)
 
-		fmt.Printf("Load Balancer Type:\t\t%s (ID: %d)\n", loadBalancer.LoadBalancerType.Name, loadBalancer.LoadBalancerType.ID)
-		fmt.Printf("  ID:\t\t\t\t%d\n", loadBalancer.LoadBalancerType.ID)
-		fmt.Printf("  Name:\t\t\t\t%s\n", loadBalancer.LoadBalancerType.Name)
-		fmt.Printf("  Description:\t\t\t%s\n", loadBalancer.LoadBalancerType.Description)
-		fmt.Printf("  Max Services:\t\t\t%d\n", loadBalancer.LoadBalancerType.MaxServices)
-		fmt.Printf("  Max Connections:\t\t%d\n", loadBalancer.LoadBalancerType.MaxConnections)
-		fmt.Printf("  Max Targets:\t\t\t%d\n", loadBalancer.LoadBalancerType.MaxTargets)
-		fmt.Printf("  Max assigned Certificates:\t%d\n", loadBalancer.LoadBalancerType.MaxAssignedCertificates)
+		cmd.Printf("Load Balancer Type:\t\t%s (ID: %d)\n", loadBalancer.LoadBalancerType.Name, loadBalancer.LoadBalancerType.ID)
+		cmd.Printf("  ID:\t\t\t\t%d\n", loadBalancer.LoadBalancerType.ID)
+		cmd.Printf("  Name:\t\t\t\t%s\n", loadBalancer.LoadBalancerType.Name)
+		cmd.Printf("  Description:\t\t\t%s\n", loadBalancer.LoadBalancerType.Description)
+		cmd.Printf("  Max Services:\t\t\t%d\n", loadBalancer.LoadBalancerType.MaxServices)
+		cmd.Printf("  Max Connections:\t\t%d\n", loadBalancer.LoadBalancerType.MaxConnections)
+		cmd.Printf("  Max Targets:\t\t\t%d\n", loadBalancer.LoadBalancerType.MaxTargets)
+		cmd.Printf("  Max assigned Certificates:\t%d\n", loadBalancer.LoadBalancerType.MaxAssignedCertificates)
 
-		fmt.Printf("Services:\n")
+		cmd.Printf("Services:\n")
 		if len(loadBalancer.Services) == 0 {
-			fmt.Print("  No services\n")
+			cmd.Print("  No services\n")
 		} else {
 			for _, service := range loadBalancer.Services {
-				fmt.Printf("  - Protocol:\t\t\t%s\n", service.Protocol)
-				fmt.Printf("    Listen Port:\t\t%d\n", service.ListenPort)
-				fmt.Printf("    Destination Port:\t\t%d\n", service.DestinationPort)
-				fmt.Printf("    Proxy Protocol:\t\t%s\n", util.YesNo(service.Proxyprotocol))
+				cmd.Printf("  - Protocol:\t\t\t%s\n", service.Protocol)
+				cmd.Printf("    Listen Port:\t\t%d\n", service.ListenPort)
+				cmd.Printf("    Destination Port:\t\t%d\n", service.DestinationPort)
+				cmd.Printf("    Proxy Protocol:\t\t%s\n", util.YesNo(service.Proxyprotocol))
 				if service.Protocol != hcloud.LoadBalancerServiceProtocolTCP {
-					fmt.Printf("    Sticky Sessions:\t\t%s\n", util.YesNo(service.HTTP.StickySessions))
+					cmd.Printf("    Sticky Sessions:\t\t%s\n", util.YesNo(service.HTTP.StickySessions))
 					if service.HTTP.StickySessions {
-						fmt.Printf("    Sticky Cookie Name:\t\t%s\n", service.HTTP.CookieName)
-						fmt.Printf("    Sticky Cookie Lifetime:\t%vs\n", service.HTTP.CookieLifetime.Seconds())
+						cmd.Printf("    Sticky Cookie Name:\t\t%s\n", service.HTTP.CookieName)
+						cmd.Printf("    Sticky Cookie Lifetime:\t%vs\n", service.HTTP.CookieLifetime.Seconds())
 					}
 					if service.Protocol == hcloud.LoadBalancerServiceProtocolHTTPS {
-						fmt.Printf("    Certificates:\n")
+						cmd.Printf("    Certificates:\n")
 						for _, cert := range service.HTTP.Certificates {
-							fmt.Printf("      - ID: \t\t\t%v\n", cert.ID)
+							cmd.Printf("      - ID: \t\t\t%v\n", cert.ID)
 						}
 					}
 				}
 
-				fmt.Printf("    Health Check:\n")
-				fmt.Printf("      Protocol:\t\t\t%s\n", service.HealthCheck.Protocol)
-				fmt.Printf("      Timeout:\t\t\t%vs\n", service.HealthCheck.Timeout.Seconds())
-				fmt.Printf("      Interval:\t\t\tevery %vs\n", service.HealthCheck.Interval.Seconds())
-				fmt.Printf("      Retries:\t\t\t%d\n", service.HealthCheck.Retries)
+				cmd.Printf("    Health Check:\n")
+				cmd.Printf("      Protocol:\t\t\t%s\n", service.HealthCheck.Protocol)
+				cmd.Printf("      Timeout:\t\t\t%vs\n", service.HealthCheck.Timeout.Seconds())
+				cmd.Printf("      Interval:\t\t\tevery %vs\n", service.HealthCheck.Interval.Seconds())
+				cmd.Printf("      Retries:\t\t\t%d\n", service.HealthCheck.Retries)
 				if service.HealthCheck.Protocol != hcloud.LoadBalancerServiceProtocolTCP {
-					fmt.Printf("      HTTP Domain:\t\t%s\n", service.HealthCheck.HTTP.Domain)
-					fmt.Printf("      HTTP Path:\t\t%s\n", service.HealthCheck.HTTP.Path)
-					fmt.Printf("      Response:\t\t%s\n", service.HealthCheck.HTTP.Response)
-					fmt.Printf("      TLS:\t\t\t%s\n", util.YesNo(service.HealthCheck.HTTP.TLS))
-					fmt.Printf("      Status Codes:\t\t%v\n", service.HealthCheck.HTTP.StatusCodes)
+					cmd.Printf("      HTTP Domain:\t\t%s\n", service.HealthCheck.HTTP.Domain)
+					cmd.Printf("      HTTP Path:\t\t%s\n", service.HealthCheck.HTTP.Path)
+					cmd.Printf("      Response:\t\t%s\n", service.HealthCheck.HTTP.Response)
+					cmd.Printf("      TLS:\t\t\t%s\n", util.YesNo(service.HealthCheck.HTTP.TLS))
+					cmd.Printf("      Status Codes:\t\t%v\n", service.HealthCheck.HTTP.StatusCodes)
 				}
 			}
 		}
 
-		fmt.Printf("Targets:\n")
+		cmd.Printf("Targets:\n")
 		if len(loadBalancer.Targets) == 0 {
-			fmt.Print("  No targets\n")
+			cmd.Print("  No targets\n")
 		}
 		for _, target := range loadBalancer.Targets {
-			fmt.Printf("  - Type:\t\t\t%s\n", target.Type)
+			cmd.Printf("  - Type:\t\t\t%s\n", target.Type)
 			switch target.Type {
 			case hcloud.LoadBalancerTargetTypeServer:
-				fmt.Printf("    Server:\n")
-				fmt.Printf("      ID:\t\t\t%d\n", target.Server.Server.ID)
-				fmt.Printf("      Name:\t\t\t%s\n", client.Server().ServerName(target.Server.Server.ID))
-				fmt.Printf("    Use Private IP:\t\t%s\n", util.YesNo(target.UsePrivateIP))
-				fmt.Printf("    Status:\n")
+				cmd.Printf("    Server:\n")
+				cmd.Printf("      ID:\t\t\t%d\n", target.Server.Server.ID)
+				cmd.Printf("      Name:\t\t\t%s\n", client.Server().ServerName(target.Server.Server.ID))
+				cmd.Printf("    Use Private IP:\t\t%s\n", util.YesNo(target.UsePrivateIP))
+				cmd.Printf("    Status:\n")
 				for _, healthStatus := range target.HealthStatus {
-					fmt.Printf("    - Service:\t\t\t%d\n", healthStatus.ListenPort)
-					fmt.Printf("      Status:\t\t\t%s\n", healthStatus.Status)
+					cmd.Printf("    - Service:\t\t\t%d\n", healthStatus.ListenPort)
+					cmd.Printf("      Status:\t\t\t%s\n", healthStatus.Status)
 				}
 			case hcloud.LoadBalancerTargetTypeLabelSelector:
-				fmt.Printf("    Label Selector:\t\t%s\n", target.LabelSelector.Selector)
-				fmt.Printf("      Targets: (%d)\n", len(target.Targets))
+				cmd.Printf("    Label Selector:\t\t%s\n", target.LabelSelector.Selector)
+				cmd.Printf("      Targets: (%d)\n", len(target.Targets))
 				if len(target.Targets) == 0 {
-					fmt.Print("      No targets\n")
+					cmd.Print("      No targets\n")
 				}
 				if !withLabelSelectorTargets {
 					continue
 				}
 				for _, lbtarget := range target.Targets {
-					fmt.Printf("      - Type:\t\t\t\t%s\n", lbtarget.Type)
-					fmt.Printf("        Server ID:\t\t\t%d\n", lbtarget.Server.Server.ID)
-					fmt.Printf("        Status:\n")
+					cmd.Printf("      - Type:\t\t\t\t%s\n", lbtarget.Type)
+					cmd.Printf("        Server ID:\t\t\t%d\n", lbtarget.Server.Server.ID)
+					cmd.Printf("        Status:\n")
 					for _, healthStatus := range lbtarget.HealthStatus {
-						fmt.Printf("          - Service:\t\t\t%d\n", healthStatus.ListenPort)
-						fmt.Printf("            Status:\t\t\t%s\n", healthStatus.Status)
+						cmd.Printf("          - Service:\t\t\t%d\n", healthStatus.ListenPort)
+						cmd.Printf("            Status:\t\t\t%s\n", healthStatus.Status)
 					}
 				}
 			case hcloud.LoadBalancerTargetTypeIP:
-				fmt.Printf("    IP:\t\t\t\t%s\n", target.IP.IP)
-				fmt.Printf("    Status:\n")
+				cmd.Printf("    IP:\t\t\t\t%s\n", target.IP.IP)
+				cmd.Printf("    Status:\n")
 				for _, healthStatus := range target.HealthStatus {
-					fmt.Printf("    - Service:\t\t\t%d\n", healthStatus.ListenPort)
-					fmt.Printf("      Status:\t\t\t%s\n", healthStatus.Status)
+					cmd.Printf("    - Service:\t\t\t%d\n", healthStatus.ListenPort)
+					cmd.Printf("      Status:\t\t\t%s\n", healthStatus.Status)
 				}
 			}
 		}
 
-		fmt.Printf("Traffic:\n")
-		fmt.Printf("  Outgoing:\t%v\n", humanize.IBytes(loadBalancer.OutgoingTraffic))
-		fmt.Printf("  Ingoing:\t%v\n", humanize.IBytes(loadBalancer.IngoingTraffic))
-		fmt.Printf("  Included:\t%v\n", humanize.IBytes(loadBalancer.IncludedTraffic))
+		cmd.Printf("Traffic:\n")
+		cmd.Printf("  Outgoing:\t%v\n", humanize.IBytes(loadBalancer.OutgoingTraffic))
+		cmd.Printf("  Ingoing:\t%v\n", humanize.IBytes(loadBalancer.IngoingTraffic))
+		cmd.Printf("  Included:\t%v\n", humanize.IBytes(loadBalancer.IncludedTraffic))
 
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(loadBalancer.Protection.Delete))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(loadBalancer.Protection.Delete))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(loadBalancer.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range loadBalancer.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 

--- a/internal/cmd/loadbalancer/detach_from_network.go
+++ b/internal/cmd/loadbalancer/detach_from_network.go
@@ -58,7 +58,7 @@ var DetachFromNetworkCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Load Balancer %d detached from Network %d\n", loadBalancer.ID, network.ID)
+		cmd.Printf("Load Balancer %d detached from Network %d\n", loadBalancer.ID, network.ID)
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/disable_protection.go
+++ b/internal/cmd/loadbalancer/disable_protection.go
@@ -41,6 +41,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, loadBalancer, false, opts)
+		return changeProtection(ctx, client, waiter, cmd, loadBalancer, false, opts)
 	},
 }

--- a/internal/cmd/loadbalancer/disable_public_interface.go
+++ b/internal/cmd/loadbalancer/disable_public_interface.go
@@ -42,7 +42,7 @@ var DisablePublicInterfaceCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Public interface of Load Balancer %d was disabled\n", loadBalancer.ID)
+		cmd.Printf("Public interface of Load Balancer %d was disabled\n", loadBalancer.ID)
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/enable_protection.go
+++ b/internal/cmd/loadbalancer/enable_protection.go
@@ -34,7 +34,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.LoadBalancerCh
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, loadBalancer *hcloud.LoadBalancer, enable bool, opts hcloud.LoadBalancerChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	loadBalancer *hcloud.LoadBalancer, enable bool, opts hcloud.LoadBalancerChangeProtectionOpts) error {
 
 	if opts.Delete == nil {
 		return nil
@@ -50,9 +51,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for Load Balancer %d\n", loadBalancer.ID)
+		cmd.Printf("Resource protection enabled for Load Balancer %d\n", loadBalancer.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for Load Balancer %d\n", loadBalancer.ID)
+		cmd.Printf("Resource protection disabled for Load Balancer %d\n", loadBalancer.ID)
 	}
 	return nil
 }
@@ -86,6 +87,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, loadBalancer, true, opts)
+		return changeProtection(ctx, client, waiter, cmd, loadBalancer, true, opts)
 	},
 }

--- a/internal/cmd/loadbalancer/enable_public_interface.go
+++ b/internal/cmd/loadbalancer/enable_public_interface.go
@@ -42,7 +42,7 @@ var EnablePublicInterfaceCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Public interface of Load Balancer %d was enabled\n", loadBalancer.ID)
+		cmd.Printf("Public interface of Load Balancer %d was enabled\n", loadBalancer.ID)
 		return nil
 	},
 }

--- a/internal/cmd/loadbalancer/metrics.go
+++ b/internal/cmd/loadbalancer/metrics.go
@@ -97,18 +97,18 @@ var MetricsCmd = base.Cmd{
 			sort.Strings(keys)
 			for _, k := range keys {
 				if len(m.TimeSeries[k]) == 0 {
-					fmt.Printf("Currently there are now metrics available. Please try it again later.")
+					cmd.Printf("Currently there are now metrics available. Please try it again later.")
 					return nil
 				}
-				fmt.Printf("Load Balancer: %s \t Metric: %s \t Start: %s \t End: %s\n", LoadBalancer.Name, k, m.Start.String(), m.End.String())
+				cmd.Printf("Load Balancer: %s \t Metric: %s \t Start: %s \t End: %s\n", LoadBalancer.Name, k, m.Start.String(), m.End.String())
 				var data []float64
 				for _, m := range m.TimeSeries[k] {
 					d, _ := strconv.ParseFloat(m.Value, 64)
 					data = append(data, d)
 				}
 				graph := asciigraph.Plot(data, asciigraph.Height(20), asciigraph.Width(100))
-				fmt.Println(graph)
-				fmt.Printf("\n\n")
+				cmd.Println(graph)
+				cmd.Printf("\n\n")
 			}
 		}
 		return nil

--- a/internal/cmd/loadbalancer/remove_target.go
+++ b/internal/cmd/loadbalancer/remove_target.go
@@ -92,7 +92,7 @@ var RemoveTargetCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Target removed from Load Balancer %d\n", loadBalancer.ID)
+		cmd.Printf("Target removed from Load Balancer %d\n", loadBalancer.ID)
 
 		return nil
 	},

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -167,7 +167,7 @@ var UpdateServiceCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Service %d on Load Balancer %d was updated\n", listenPort, loadBalancer.ID)
+		cmd.Printf("Service %d on Load Balancer %d was updated\n", listenPort, loadBalancer.ID)
 
 		return nil
 	},

--- a/internal/cmd/loadbalancertype/describe.go
+++ b/internal/cmd/loadbalancertype/describe.go
@@ -2,7 +2,6 @@ package loadbalancertype
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -20,22 +19,22 @@ var DescribeCmd = base.DescribeCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.LoadBalancerType().Get(ctx, idOrName)
 	},
-	PrintText: func(_ context.Context, _ hcapi2.Client, _ *cobra.Command, resource interface{}) error {
+	PrintText: func(_ context.Context, _ hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		loadBalancerType := resource.(*hcloud.LoadBalancerType)
 
-		fmt.Printf("ID:\t\t\t\t%d\n", loadBalancerType.ID)
-		fmt.Printf("Name:\t\t\t\t%s\n", loadBalancerType.Name)
-		fmt.Printf("Description:\t\t\t%s\n", loadBalancerType.Description)
-		fmt.Printf("Max Services:\t\t\t%d\n", loadBalancerType.MaxServices)
-		fmt.Printf("Max Connections:\t\t%d\n", loadBalancerType.MaxConnections)
-		fmt.Printf("Max Targets:\t\t\t%d\n", loadBalancerType.MaxTargets)
-		fmt.Printf("Max assigned Certificates:\t%d\n", loadBalancerType.MaxAssignedCertificates)
+		cmd.Printf("ID:\t\t\t\t%d\n", loadBalancerType.ID)
+		cmd.Printf("Name:\t\t\t\t%s\n", loadBalancerType.Name)
+		cmd.Printf("Description:\t\t\t%s\n", loadBalancerType.Description)
+		cmd.Printf("Max Services:\t\t\t%d\n", loadBalancerType.MaxServices)
+		cmd.Printf("Max Connections:\t\t%d\n", loadBalancerType.MaxConnections)
+		cmd.Printf("Max Targets:\t\t\t%d\n", loadBalancerType.MaxTargets)
+		cmd.Printf("Max assigned Certificates:\t%d\n", loadBalancerType.MaxAssignedCertificates)
 
-		fmt.Printf("Pricings per Location:\n")
+		cmd.Printf("Pricings per Location:\n")
 		for _, price := range loadBalancerType.Pricings {
-			fmt.Printf("  - Location:\t%s:\n", price.Location.Name)
-			fmt.Printf("    Hourly:\t€ %s\n", price.Hourly.Gross)
-			fmt.Printf("    Monthly:\t€ %s\n", price.Monthly.Gross)
+			cmd.Printf("  - Location:\t%s:\n", price.Location.Name)
+			cmd.Printf("    Hourly:\t€ %s\n", price.Hourly.Gross)
+			cmd.Printf("    Monthly:\t€ %s\n", price.Monthly.Gross)
 		}
 		return nil
 	},

--- a/internal/cmd/location/describe.go
+++ b/internal/cmd/location/describe.go
@@ -2,7 +2,6 @@ package location
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -24,14 +23,14 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		location := resource.(*hcloud.Location)
 
-		fmt.Printf("ID:\t\t%d\n", location.ID)
-		fmt.Printf("Name:\t\t%s\n", location.Name)
-		fmt.Printf("Description:\t%s\n", location.Description)
-		fmt.Printf("Network Zone:\t%s\n", location.NetworkZone)
-		fmt.Printf("Country:\t%s\n", location.Country)
-		fmt.Printf("City:\t\t%s\n", location.City)
-		fmt.Printf("Latitude:\t%f\n", location.Latitude)
-		fmt.Printf("Longitude:\t%f\n", location.Longitude)
+		cmd.Printf("ID:\t\t%d\n", location.ID)
+		cmd.Printf("Name:\t\t%s\n", location.Name)
+		cmd.Printf("Description:\t%s\n", location.Description)
+		cmd.Printf("Network Zone:\t%s\n", location.NetworkZone)
+		cmd.Printf("Country:\t%s\n", location.Country)
+		cmd.Printf("City:\t\t%s\n", location.City)
+		cmd.Printf("Latitude:\t%f\n", location.Latitude)
+		cmd.Printf("Longitude:\t%f\n", location.Longitude)
 		return nil
 	},
 }

--- a/internal/cmd/network/add_route.go
+++ b/internal/cmd/network/add_route.go
@@ -59,7 +59,7 @@ var AddRouteCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Route added to network %d\n", network.ID)
+		cmd.Printf("Route added to network %d\n", network.ID)
 
 		return nil
 	},

--- a/internal/cmd/network/add_subnet.go
+++ b/internal/cmd/network/add_subnet.go
@@ -74,7 +74,7 @@ var AddSubnetCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Subnet added to network %d\n", network.ID)
+		cmd.Printf("Subnet added to network %d\n", network.ID)
 
 		return nil
 	},

--- a/internal/cmd/network/change_ip_range.go
+++ b/internal/cmd/network/change_ip_range.go
@@ -53,7 +53,7 @@ var ChangeIPRangeCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("IP range of network %d changed\n", network.ID)
+		cmd.Printf("IP range of network %d changed\n", network.ID)
 		return nil
 	},
 }

--- a/internal/cmd/network/create.go
+++ b/internal/cmd/network/create.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/spf13/cobra"
@@ -60,8 +59,8 @@ var CreateCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Network %d created\n", network.ID)
+		cmd.Printf("Network %d created\n", network.ID)
 
-		return changeProtection(ctx, client, waiter, network, true, protectionOpts)
+		return changeProtection(ctx, client, waiter, cmd, network, true, protectionOpts)
 	},
 }

--- a/internal/cmd/network/describe.go
+++ b/internal/cmd/network/describe.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"fmt"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -26,46 +25,46 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		network := resource.(*hcloud.Network)
 
-		fmt.Printf("ID:\t\t%d\n", network.ID)
-		fmt.Printf("Name:\t\t%s\n", network.Name)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(network.Created), humanize.Time(network.Created))
-		fmt.Printf("IP Range:\t%s\n", network.IPRange.String())
-		fmt.Printf("Expose Routes to vSwitch: %s\n", util.YesNo(network.ExposeRoutesToVSwitch))
+		cmd.Printf("ID:\t\t%d\n", network.ID)
+		cmd.Printf("Name:\t\t%s\n", network.Name)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(network.Created), humanize.Time(network.Created))
+		cmd.Printf("IP Range:\t%s\n", network.IPRange.String())
+		cmd.Printf("Expose Routes to vSwitch: %s\n", util.YesNo(network.ExposeRoutesToVSwitch))
 
-		fmt.Printf("Subnets:\n")
+		cmd.Printf("Subnets:\n")
 		if len(network.Subnets) == 0 {
-			fmt.Print("  No subnets\n")
+			cmd.Print("  No subnets\n")
 		} else {
 			for _, subnet := range network.Subnets {
-				fmt.Printf("  - Type:\t\t%s\n", subnet.Type)
-				fmt.Printf("    Network Zone:\t%s\n", subnet.NetworkZone)
-				fmt.Printf("    IP Range:\t\t%s\n", subnet.IPRange.String())
-				fmt.Printf("    Gateway:\t\t%s\n", subnet.Gateway.String())
+				cmd.Printf("  - Type:\t\t%s\n", subnet.Type)
+				cmd.Printf("    Network Zone:\t%s\n", subnet.NetworkZone)
+				cmd.Printf("    IP Range:\t\t%s\n", subnet.IPRange.String())
+				cmd.Printf("    Gateway:\t\t%s\n", subnet.Gateway.String())
 				if subnet.Type == hcloud.NetworkSubnetTypeVSwitch {
-					fmt.Printf("    vSwitch ID:\t\t%d\n", subnet.VSwitchID)
+					cmd.Printf("    vSwitch ID:\t\t%d\n", subnet.VSwitchID)
 				}
 			}
 		}
 
-		fmt.Printf("Routes:\n")
+		cmd.Printf("Routes:\n")
 		if len(network.Routes) == 0 {
-			fmt.Print("  No routes\n")
+			cmd.Print("  No routes\n")
 		} else {
 			for _, route := range network.Routes {
-				fmt.Printf("  - Destination:\t%s\n", route.Destination.String())
-				fmt.Printf("    Gateway:\t\t%s\n", route.Gateway.String())
+				cmd.Printf("  - Destination:\t%s\n", route.Destination.String())
+				cmd.Printf("    Gateway:\t\t%s\n", route.Gateway.String())
 			}
 		}
 
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(network.Protection.Delete))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(network.Protection.Delete))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(network.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range network.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 

--- a/internal/cmd/network/disable_protection.go
+++ b/internal/cmd/network/disable_protection.go
@@ -41,6 +41,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, network, false, opts)
+		return changeProtection(ctx, client, waiter, cmd, network, false, opts)
 	},
 }

--- a/internal/cmd/network/enable_protection.go
+++ b/internal/cmd/network/enable_protection.go
@@ -34,7 +34,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.NetworkChangeP
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, network *hcloud.Network, enable bool, opts hcloud.NetworkChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	network *hcloud.Network, enable bool, opts hcloud.NetworkChangeProtectionOpts) error {
 
 	if opts.Delete == nil {
 		return nil
@@ -50,9 +51,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for network %d\n", network.ID)
+		cmd.Printf("Resource protection enabled for network %d\n", network.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for network %d\n", network.ID)
+		cmd.Printf("Resource protection disabled for network %d\n", network.ID)
 	}
 	return nil
 }
@@ -86,6 +87,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, network, true, opts)
+		return changeProtection(ctx, client, waiter, cmd, network, true, opts)
 	},
 }

--- a/internal/cmd/network/expose-routes-to-vswitch.go
+++ b/internal/cmd/network/expose-routes-to-vswitch.go
@@ -50,9 +50,9 @@ var ExposeRoutesToVSwitchCmd = base.Cmd{
 		}
 
 		if disable {
-			fmt.Printf("Exposing routes to connected vSwitch of network %s disabled\n", network.Name)
+			cmd.Printf("Exposing routes to connected vSwitch of network %s disabled\n", network.Name)
 		} else {
-			fmt.Printf("Exposing routes to connected vSwitch of network %s enabled\n", network.Name)
+			cmd.Printf("Exposing routes to connected vSwitch of network %s enabled\n", network.Name)
 		}
 
 		return nil

--- a/internal/cmd/network/remove_route.go
+++ b/internal/cmd/network/remove_route.go
@@ -58,7 +58,7 @@ var RemoveRouteCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Route removed from network %d\n", network.ID)
+		cmd.Printf("Route removed from network %d\n", network.ID)
 
 		return nil
 	},

--- a/internal/cmd/network/remove_subnet.go
+++ b/internal/cmd/network/remove_subnet.go
@@ -51,7 +51,7 @@ var RemoveSubnetCmd = base.Cmd{
 		if err := waiter.ActionProgress(ctx, action); err != nil {
 			return err
 		}
-		fmt.Printf("Subnet %s removed from network %d\n", ipRange.String(), network.ID)
+		cmd.Printf("Subnet %s removed from network %d\n", ipRange.String(), network.ID)
 
 		return nil
 	},

--- a/internal/cmd/placementgroup/create.go
+++ b/internal/cmd/placementgroup/create.go
@@ -2,7 +2,6 @@ package placementgroup
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -49,7 +48,7 @@ var CreateCmd = base.Cmd{
 			}
 		}
 
-		fmt.Printf("Placement group %d created\n", result.PlacementGroup.ID)
+		cmd.Printf("Placement group %d created\n", result.PlacementGroup.ID)
 
 		return nil
 	},

--- a/internal/cmd/placementgroup/describe.go
+++ b/internal/cmd/placementgroup/describe.go
@@ -2,7 +2,6 @@ package placementgroup
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -25,26 +24,26 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(_ context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		placementGroup := resource.(*hcloud.PlacementGroup)
 
-		fmt.Printf("ID:\t\t%d\n", placementGroup.ID)
-		fmt.Printf("Name:\t\t%s\n", placementGroup.Name)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(placementGroup.Created), humanize.Time(placementGroup.Created))
+		cmd.Printf("ID:\t\t%d\n", placementGroup.ID)
+		cmd.Printf("Name:\t\t%s\n", placementGroup.Name)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(placementGroup.Created), humanize.Time(placementGroup.Created))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(placementGroup.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range placementGroup.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 
-		fmt.Print("Servers:\n")
+		cmd.Print("Servers:\n")
 		for _, serverID := range placementGroup.Servers {
-			fmt.Printf("  - Server ID:\t\t%d\n", serverID)
-			fmt.Printf("    Server Name:\t%s\n", client.Server().ServerName(serverID))
+			cmd.Printf("  - Server ID:\t\t%d\n", serverID)
+			cmd.Printf("    Server Name:\t%s\n", client.Server().ServerName(serverID))
 		}
 
-		fmt.Printf("Type:\t\t%s\n", placementGroup.Type)
+		cmd.Printf("Type:\t\t%s\n", placementGroup.Type)
 		return nil
 	},
 }

--- a/internal/cmd/primaryip/assign.go
+++ b/internal/cmd/primaryip/assign.go
@@ -64,7 +64,7 @@ var AssignCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Primary IP %d assigned to %s %d\n", opts.ID, opts.AssigneeType, opts.AssigneeID)
+		cmd.Printf("Primary IP %d assigned to %s %d\n", opts.ID, opts.AssigneeType, opts.AssigneeID)
 		return nil
 	},
 }

--- a/internal/cmd/primaryip/changedns.go
+++ b/internal/cmd/primaryip/changedns.go
@@ -58,7 +58,7 @@ var ChangeDNSCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Primary IP %d DNS pointer: %s associated to %s\n", opts.ID, opts.DNSPtr, opts.IP)
+		cmd.Printf("Primary IP %d DNS pointer: %s associated to %s\n", opts.ID, opts.DNSPtr, opts.IP)
 		return nil
 	},
 }

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -2,7 +2,6 @@ package primaryip
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -74,15 +73,15 @@ var CreateCmd = base.Cmd{
 			}
 		}
 
-		fmt.Printf("Primary IP %d created\n", result.PrimaryIP.ID)
+		cmd.Printf("Primary IP %d created\n", result.PrimaryIP.ID)
 
 		if len(protection) > 0 {
-			if err := changeProtection(ctx, client, waiter, result.PrimaryIP, true, protectionOpts); err != nil {
+			if err := changeProtection(ctx, client, waiter, cmd, result.PrimaryIP, true, protectionOpts); err != nil {
 				return err
 			}
 		}
 
-		fmt.Printf("IP%s: %s\n", result.PrimaryIP.Type[2:], result.PrimaryIP.IP)
+		cmd.Printf("IP%s: %s\n", result.PrimaryIP.Type[2:], result.PrimaryIP.IP)
 		return nil
 	},
 }

--- a/internal/cmd/primaryip/describe.go
+++ b/internal/cmd/primaryip/describe.go
@@ -2,7 +2,6 @@ package primaryip
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -25,51 +24,51 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(_ context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		primaryIP := resource.(*hcloud.PrimaryIP)
 
-		fmt.Printf("ID:\t\t%d\n", primaryIP.ID)
-		fmt.Printf("Name:\t\t%s\n", primaryIP.Name)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(primaryIP.Created), humanize.Time(primaryIP.Created))
-		fmt.Printf("Type:\t\t%s\n", primaryIP.Type)
-		fmt.Printf("IP:\t\t%s\n", primaryIP.IP.String())
-		fmt.Printf("Blocked:\t%s\n", util.YesNo(primaryIP.Blocked))
-		fmt.Printf("Auto delete:\t%s\n", util.YesNo(primaryIP.AutoDelete))
+		cmd.Printf("ID:\t\t%d\n", primaryIP.ID)
+		cmd.Printf("Name:\t\t%s\n", primaryIP.Name)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(primaryIP.Created), humanize.Time(primaryIP.Created))
+		cmd.Printf("Type:\t\t%s\n", primaryIP.Type)
+		cmd.Printf("IP:\t\t%s\n", primaryIP.IP.String())
+		cmd.Printf("Blocked:\t%s\n", util.YesNo(primaryIP.Blocked))
+		cmd.Printf("Auto delete:\t%s\n", util.YesNo(primaryIP.AutoDelete))
 		if primaryIP.AssigneeID != 0 {
-			fmt.Printf("Assignee:\n")
-			fmt.Printf("  ID:\t%d\n", primaryIP.AssigneeID)
-			fmt.Printf("  Type:\t%s\n", primaryIP.AssigneeType)
+			cmd.Printf("Assignee:\n")
+			cmd.Printf("  ID:\t%d\n", primaryIP.AssigneeID)
+			cmd.Printf("  Type:\t%s\n", primaryIP.AssigneeType)
 		} else {
-			fmt.Print("Assignee:\n  Not assigned\n")
+			cmd.Print("Assignee:\n  Not assigned\n")
 		}
-		fmt.Print("DNS:\n")
+		cmd.Print("DNS:\n")
 		if len(primaryIP.DNSPtr) == 0 {
-			fmt.Print("  No reverse DNS entries\n")
+			cmd.Print("  No reverse DNS entries\n")
 		} else {
 			for ip, dns := range primaryIP.DNSPtr {
-				fmt.Printf("  %s: %s\n", ip, dns)
+				cmd.Printf("  %s: %s\n", ip, dns)
 			}
 		}
 
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(primaryIP.Protection.Delete))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(primaryIP.Protection.Delete))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(primaryIP.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range primaryIP.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
-		fmt.Printf("Datacenter:\n")
-		fmt.Printf("  ID:\t\t%d\n", primaryIP.Datacenter.ID)
-		fmt.Printf("  Name:\t\t%s\n", primaryIP.Datacenter.Name)
-		fmt.Printf("  Description:\t%s\n", primaryIP.Datacenter.Description)
-		fmt.Printf("  Location:\n")
-		fmt.Printf("    Name:\t\t%s\n", primaryIP.Datacenter.Location.Name)
-		fmt.Printf("    Description:\t%s\n", primaryIP.Datacenter.Location.Description)
-		fmt.Printf("    Country:\t\t%s\n", primaryIP.Datacenter.Location.Country)
-		fmt.Printf("    City:\t\t%s\n", primaryIP.Datacenter.Location.City)
-		fmt.Printf("    Latitude:\t\t%f\n", primaryIP.Datacenter.Location.Latitude)
-		fmt.Printf("    Longitude:\t\t%f\n", primaryIP.Datacenter.Location.Longitude)
+		cmd.Printf("Datacenter:\n")
+		cmd.Printf("  ID:\t\t%d\n", primaryIP.Datacenter.ID)
+		cmd.Printf("  Name:\t\t%s\n", primaryIP.Datacenter.Name)
+		cmd.Printf("  Description:\t%s\n", primaryIP.Datacenter.Description)
+		cmd.Printf("  Location:\n")
+		cmd.Printf("    Name:\t\t%s\n", primaryIP.Datacenter.Location.Name)
+		cmd.Printf("    Description:\t%s\n", primaryIP.Datacenter.Location.Description)
+		cmd.Printf("    Country:\t\t%s\n", primaryIP.Datacenter.Location.Country)
+		cmd.Printf("    City:\t\t%s\n", primaryIP.Datacenter.Location.City)
+		cmd.Printf("    Latitude:\t\t%f\n", primaryIP.Datacenter.Location.Latitude)
+		cmd.Printf("    Longitude:\t\t%f\n", primaryIP.Datacenter.Location.Longitude)
 		return nil
 	},
 }

--- a/internal/cmd/primaryip/disable_protection.go
+++ b/internal/cmd/primaryip/disable_protection.go
@@ -48,6 +48,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, actionWaiter, primaryIP, false, opts)
+		return changeProtection(ctx, client, actionWaiter, cmd, primaryIP, false, opts)
 	},
 }

--- a/internal/cmd/primaryip/enable_protection.go
+++ b/internal/cmd/primaryip/enable_protection.go
@@ -34,7 +34,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.PrimaryIPChang
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, primaryIp *hcloud.PrimaryIP, enable bool, opts hcloud.PrimaryIPChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	primaryIp *hcloud.PrimaryIP, enable bool, opts hcloud.PrimaryIPChangeProtectionOpts) error {
 
 	opts.ID = primaryIp.ID
 
@@ -48,9 +49,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for primary IP %d\n", opts.ID)
+		cmd.Printf("Resource protection enabled for primary IP %d\n", opts.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for primary IP %d\n", opts.ID)
+		cmd.Printf("Resource protection disabled for primary IP %d\n", opts.ID)
 	}
 	return nil
 }
@@ -91,6 +92,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, actionWaiter, primaryIP, true, opts)
+		return changeProtection(ctx, client, actionWaiter, cmd, primaryIP, true, opts)
 	},
 }

--- a/internal/cmd/primaryip/unassign.go
+++ b/internal/cmd/primaryip/unassign.go
@@ -45,7 +45,7 @@ var UnAssignCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Primary IP %d was unassigned successfully\n", primaryIP.ID)
+		cmd.Printf("Primary IP %d was unassigned successfully\n", primaryIP.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/add_to_placement_group.go
+++ b/internal/cmd/server/add_to_placement_group.go
@@ -55,7 +55,7 @@ var AddToPlacementGroupCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d added to placement group %s\n", server.ID, placementGroupIDOrName)
+		cmd.Printf("Server %d added to placement group %s\n", server.ID, placementGroupIDOrName)
 		return nil
 	},
 }

--- a/internal/cmd/server/attach_iso.go
+++ b/internal/cmd/server/attach_iso.go
@@ -27,7 +27,7 @@ var AttachISOCmd = base.Cmd{
 			DisableFlagsInUseLine: true,
 		}
 	},
-	Run: func(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, command *cobra.Command, args []string) error {
+	Run: func(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command, args []string) error {
 		idOrName := args[0]
 		server, _, err := client.Server().Get(ctx, idOrName)
 		if err != nil {
@@ -61,7 +61,7 @@ var AttachISOCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("ISO %s attached to server %d\n", iso.Name, server.ID)
+		cmd.Printf("ISO %s attached to server %d\n", iso.Name, server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/attach_to_network.go
+++ b/internal/cmd/server/attach_to_network.go
@@ -73,7 +73,7 @@ var AttachToNetworkCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d attached to network %d\n", server.ID, network.ID)
+		cmd.Printf("Server %d attached to network %d\n", server.ID, network.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/change_alias_ips.go
+++ b/internal/cmd/server/change_alias_ips.go
@@ -76,7 +76,7 @@ var ChangeAliasIPsCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Alias IPs changed for server %d in network %d\n", server.ID, network.ID)
+		cmd.Printf("Alias IPs changed for server %d in network %d\n", server.ID, network.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/change_type.go
+++ b/internal/cmd/server/change_type.go
@@ -50,7 +50,7 @@ var ChangeTypeCmd = base.Cmd{
 		}
 
 		if serverType.IsDeprecated() {
-			fmt.Print(warningDeprecatedServerType(serverType))
+			cmd.Print(warningDeprecatedServerType(serverType))
 		}
 
 		keepDisk, _ := cmd.Flags().GetBool("keep-disk")
@@ -68,9 +68,9 @@ var ChangeTypeCmd = base.Cmd{
 		}
 
 		if opts.UpgradeDisk {
-			fmt.Printf("Server %d changed to type %s\n", server.ID, serverType.Name)
+			cmd.Printf("Server %d changed to type %s\n", server.ID, serverType.Name)
 		} else {
-			fmt.Printf("Server %d changed to type %s (disk size was unchanged)\n", server.ID, serverType.Name)
+			cmd.Printf("Server %d changed to type %s (disk size was unchanged)\n", server.ID, serverType.Name)
 		}
 		return nil
 	},

--- a/internal/cmd/server/create_image.go
+++ b/internal/cmd/server/create_image.go
@@ -65,7 +65,7 @@ var CreateImageCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Image %d created from server %d\n", result.Image.ID, server.ID)
+		cmd.Printf("Image %d created from server %d\n", result.Image.ID, server.ID)
 
 		return nil
 	},

--- a/internal/cmd/server/describe.go
+++ b/internal/cmd/server/describe.go
@@ -25,175 +25,175 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		server := resource.(*hcloud.Server)
 
-		fmt.Printf("ID:\t\t%d\n", server.ID)
-		fmt.Printf("Name:\t\t%s\n", server.Name)
-		fmt.Printf("Status:\t\t%s\n", server.Status)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(server.Created), humanize.Time(server.Created))
+		cmd.Printf("ID:\t\t%d\n", server.ID)
+		cmd.Printf("Name:\t\t%s\n", server.Name)
+		cmd.Printf("Status:\t\t%s\n", server.Status)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(server.Created), humanize.Time(server.Created))
 
-		fmt.Printf("Server Type:\t%s (ID: %d)\n", server.ServerType.Name, server.ServerType.ID)
-		fmt.Printf("  ID:\t\t%d\n", server.ServerType.ID)
-		fmt.Printf("  Name:\t\t%s\n", server.ServerType.Name)
-		fmt.Printf("  Description:\t%s\n", server.ServerType.Description)
-		fmt.Printf("  Cores:\t%d\n", server.ServerType.Cores)
-		fmt.Printf("  CPU Type:\t%s\n", server.ServerType.CPUType)
-		fmt.Printf("  Memory:\t%v GB\n", server.ServerType.Memory)
-		fmt.Printf("  Disk:\t\t%d GB\n", server.PrimaryDiskSize)
-		fmt.Printf("  Storage Type:\t%s\n", server.ServerType.StorageType)
-		fmt.Printf(util.PrefixLines(util.DescribeDeprecation(server.ServerType), "  "))
+		cmd.Printf("Server Type:\t%s (ID: %d)\n", server.ServerType.Name, server.ServerType.ID)
+		cmd.Printf("  ID:\t\t%d\n", server.ServerType.ID)
+		cmd.Printf("  Name:\t\t%s\n", server.ServerType.Name)
+		cmd.Printf("  Description:\t%s\n", server.ServerType.Description)
+		cmd.Printf("  Cores:\t%d\n", server.ServerType.Cores)
+		cmd.Printf("  CPU Type:\t%s\n", server.ServerType.CPUType)
+		cmd.Printf("  Memory:\t%v GB\n", server.ServerType.Memory)
+		cmd.Printf("  Disk:\t\t%d GB\n", server.PrimaryDiskSize)
+		cmd.Printf("  Storage Type:\t%s\n", server.ServerType.StorageType)
+		cmd.Printf(util.PrefixLines(util.DescribeDeprecation(server.ServerType), "  "))
 
-		fmt.Printf("Public Net:\n")
-		fmt.Printf("  IPv4:\n")
+		cmd.Printf("Public Net:\n")
+		cmd.Printf("  IPv4:\n")
 		if server.PublicNet.IPv4.IsUnspecified() {
-			fmt.Printf("    No Primary IPv4\n")
+			cmd.Printf("    No Primary IPv4\n")
 		} else {
-			fmt.Printf("    ID:\t\t%d\n", server.PublicNet.IPv4.ID)
-			fmt.Printf("    IP:\t\t%s\n", server.PublicNet.IPv4.IP)
-			fmt.Printf("    Blocked:\t%s\n", util.YesNo(server.PublicNet.IPv4.Blocked))
-			fmt.Printf("    DNS:\t%s\n", server.PublicNet.IPv4.DNSPtr)
+			cmd.Printf("    ID:\t\t%d\n", server.PublicNet.IPv4.ID)
+			cmd.Printf("    IP:\t\t%s\n", server.PublicNet.IPv4.IP)
+			cmd.Printf("    Blocked:\t%s\n", util.YesNo(server.PublicNet.IPv4.Blocked))
+			cmd.Printf("    DNS:\t%s\n", server.PublicNet.IPv4.DNSPtr)
 		}
 
-		fmt.Printf("  IPv6:\n")
+		cmd.Printf("  IPv6:\n")
 		if server.PublicNet.IPv6.IsUnspecified() {
-			fmt.Printf("    No Primary IPv6\n")
+			cmd.Printf("    No Primary IPv6\n")
 		} else {
-			fmt.Printf("    ID:\t\t%d\n", server.PublicNet.IPv6.ID)
-			fmt.Printf("    IP:\t\t%s\n", server.PublicNet.IPv6.Network.String())
-			fmt.Printf("    Blocked:\t%s\n", util.YesNo(server.PublicNet.IPv6.Blocked))
+			cmd.Printf("    ID:\t\t%d\n", server.PublicNet.IPv6.ID)
+			cmd.Printf("    IP:\t\t%s\n", server.PublicNet.IPv6.Network.String())
+			cmd.Printf("    Blocked:\t%s\n", util.YesNo(server.PublicNet.IPv6.Blocked))
 		}
-		fmt.Printf("  Floating IPs:\n")
+		cmd.Printf("  Floating IPs:\n")
 		if len(server.PublicNet.FloatingIPs) > 0 {
 			for _, f := range server.PublicNet.FloatingIPs {
 				floatingIP, _, err := client.FloatingIP().GetByID(ctx, f.ID)
 				if err != nil {
 					return fmt.Errorf("error fetching Floating IP: %v", err)
 				}
-				fmt.Printf("  - ID:\t\t\t%d\n", floatingIP.ID)
-				fmt.Printf("    Description:\t%s\n", util.NA(floatingIP.Description))
-				fmt.Printf("    IP:\t\t\t%s\n", floatingIP.IP)
+				cmd.Printf("  - ID:\t\t\t%d\n", floatingIP.ID)
+				cmd.Printf("    Description:\t%s\n", util.NA(floatingIP.Description))
+				cmd.Printf("    IP:\t\t\t%s\n", floatingIP.IP)
 			}
 		} else {
-			fmt.Printf("    No Floating IPs\n")
+			cmd.Printf("    No Floating IPs\n")
 		}
 
-		fmt.Printf("Private Net:\n")
+		cmd.Printf("Private Net:\n")
 		if len(server.PrivateNet) > 0 {
 			for _, n := range server.PrivateNet {
 				network, _, err := client.Network().GetByID(ctx, n.Network.ID)
 				if err != nil {
 					return fmt.Errorf("error fetching network: %v", err)
 				}
-				fmt.Printf("  - ID:\t\t\t%d\n", network.ID)
-				fmt.Printf("    Name:\t\t%s\n", network.Name)
-				fmt.Printf("    IP:\t\t\t%s\n", n.IP.String())
-				fmt.Printf("    MAC Address:\t%s\n", n.MACAddress)
+				cmd.Printf("  - ID:\t\t\t%d\n", network.ID)
+				cmd.Printf("    Name:\t\t%s\n", network.Name)
+				cmd.Printf("    IP:\t\t\t%s\n", n.IP.String())
+				cmd.Printf("    MAC Address:\t%s\n", n.MACAddress)
 				if len(n.Aliases) > 0 {
-					fmt.Printf("    Alias IPs:\n")
+					cmd.Printf("    Alias IPs:\n")
 					for _, a := range n.Aliases {
-						fmt.Printf("     -\t\t\t%s\n", a)
+						cmd.Printf("     -\t\t\t%s\n", a)
 					}
 				} else {
-					fmt.Printf("    Alias IPs:\t\t%s\n", util.NA(""))
+					cmd.Printf("    Alias IPs:\t\t%s\n", util.NA(""))
 				}
 			}
 		} else {
-			fmt.Printf("    No Private Networks\n")
+			cmd.Printf("    No Private Networks\n")
 		}
 
-		fmt.Printf("Volumes:\n")
+		cmd.Printf("Volumes:\n")
 		if len(server.Volumes) > 0 {
 			for _, v := range server.Volumes {
 				volume, _, err := client.Volume().GetByID(ctx, v.ID)
 				if err != nil {
 					return fmt.Errorf("error fetching Volume: %v", err)
 				}
-				fmt.Printf("  - ID:\t\t%d\n", volume.ID)
-				fmt.Printf("    Name:\t%s\n", volume.Name)
-				fmt.Printf("    Size:\t%s\n", humanize.Bytes(uint64(volume.Size*humanize.GByte)))
+				cmd.Printf("  - ID:\t\t%d\n", volume.ID)
+				cmd.Printf("    Name:\t%s\n", volume.Name)
+				cmd.Printf("    Size:\t%s\n", humanize.Bytes(uint64(volume.Size*humanize.GByte)))
 			}
 		} else {
-			fmt.Printf("  No Volumes\n")
+			cmd.Printf("  No Volumes\n")
 		}
-		fmt.Printf("Image:\n")
+		cmd.Printf("Image:\n")
 		if server.Image != nil {
 			image := server.Image
-			fmt.Printf("  ID:\t\t%d\n", image.ID)
-			fmt.Printf("  Type:\t\t%s\n", image.Type)
-			fmt.Printf("  Status:\t%s\n", image.Status)
-			fmt.Printf("  Name:\t\t%s\n", util.NA(image.Name))
-			fmt.Printf("  Description:\t%s\n", image.Description)
+			cmd.Printf("  ID:\t\t%d\n", image.ID)
+			cmd.Printf("  Type:\t\t%s\n", image.Type)
+			cmd.Printf("  Status:\t%s\n", image.Status)
+			cmd.Printf("  Name:\t\t%s\n", util.NA(image.Name))
+			cmd.Printf("  Description:\t%s\n", image.Description)
 			if image.ImageSize != 0 {
-				fmt.Printf("  Image size:\t%.2f GB\n", image.ImageSize)
+				cmd.Printf("  Image size:\t%.2f GB\n", image.ImageSize)
 			} else {
-				fmt.Printf("  Image size:\t%s\n", util.NA(""))
+				cmd.Printf("  Image size:\t%s\n", util.NA(""))
 			}
-			fmt.Printf("  Disk size:\t%.0f GB\n", image.DiskSize)
-			fmt.Printf("  Created:\t%s (%s)\n", util.Datetime(image.Created), humanize.Time(image.Created))
-			fmt.Printf("  OS flavor:\t%s\n", image.OSFlavor)
-			fmt.Printf("  OS version:\t%s\n", util.NA(image.OSVersion))
-			fmt.Printf("  Rapid deploy:\t%s\n", util.YesNo(image.RapidDeploy))
+			cmd.Printf("  Disk size:\t%.0f GB\n", image.DiskSize)
+			cmd.Printf("  Created:\t%s (%s)\n", util.Datetime(image.Created), humanize.Time(image.Created))
+			cmd.Printf("  OS flavor:\t%s\n", image.OSFlavor)
+			cmd.Printf("  OS version:\t%s\n", util.NA(image.OSVersion))
+			cmd.Printf("  Rapid deploy:\t%s\n", util.YesNo(image.RapidDeploy))
 		} else {
-			fmt.Printf("  No Image\n")
+			cmd.Printf("  No Image\n")
 		}
 
-		fmt.Printf("Datacenter:\n")
-		fmt.Printf("  ID:\t\t%d\n", server.Datacenter.ID)
-		fmt.Printf("  Name:\t\t%s\n", server.Datacenter.Name)
-		fmt.Printf("  Description:\t%s\n", server.Datacenter.Description)
-		fmt.Printf("  Location:\n")
-		fmt.Printf("    Name:\t\t%s\n", server.Datacenter.Location.Name)
-		fmt.Printf("    Description:\t%s\n", server.Datacenter.Location.Description)
-		fmt.Printf("    Country:\t\t%s\n", server.Datacenter.Location.Country)
-		fmt.Printf("    City:\t\t%s\n", server.Datacenter.Location.City)
-		fmt.Printf("    Latitude:\t\t%f\n", server.Datacenter.Location.Latitude)
-		fmt.Printf("    Longitude:\t\t%f\n", server.Datacenter.Location.Longitude)
+		cmd.Printf("Datacenter:\n")
+		cmd.Printf("  ID:\t\t%d\n", server.Datacenter.ID)
+		cmd.Printf("  Name:\t\t%s\n", server.Datacenter.Name)
+		cmd.Printf("  Description:\t%s\n", server.Datacenter.Description)
+		cmd.Printf("  Location:\n")
+		cmd.Printf("    Name:\t\t%s\n", server.Datacenter.Location.Name)
+		cmd.Printf("    Description:\t%s\n", server.Datacenter.Location.Description)
+		cmd.Printf("    Country:\t\t%s\n", server.Datacenter.Location.Country)
+		cmd.Printf("    City:\t\t%s\n", server.Datacenter.Location.City)
+		cmd.Printf("    Latitude:\t\t%f\n", server.Datacenter.Location.Latitude)
+		cmd.Printf("    Longitude:\t\t%f\n", server.Datacenter.Location.Longitude)
 
-		fmt.Printf("Traffic:\n")
-		fmt.Printf("  Outgoing:\t%v\n", humanize.IBytes(server.OutgoingTraffic))
-		fmt.Printf("  Ingoing:\t%v\n", humanize.IBytes(server.IngoingTraffic))
-		fmt.Printf("  Included:\t%v\n", humanize.IBytes(server.IncludedTraffic))
+		cmd.Printf("Traffic:\n")
+		cmd.Printf("  Outgoing:\t%v\n", humanize.IBytes(server.OutgoingTraffic))
+		cmd.Printf("  Ingoing:\t%v\n", humanize.IBytes(server.IngoingTraffic))
+		cmd.Printf("  Included:\t%v\n", humanize.IBytes(server.IncludedTraffic))
 
 		if server.BackupWindow != "" {
-			fmt.Printf("Backup Window:\t%s\n", server.BackupWindow)
+			cmd.Printf("Backup Window:\t%s\n", server.BackupWindow)
 		} else {
-			fmt.Printf("Backup Window:\tBackups disabled\n")
+			cmd.Printf("Backup Window:\tBackups disabled\n")
 		}
 
 		if server.RescueEnabled {
-			fmt.Printf("Rescue System:\tenabled\n")
+			cmd.Printf("Rescue System:\tenabled\n")
 		} else {
-			fmt.Printf("Rescue System:\tdisabled\n")
+			cmd.Printf("Rescue System:\tdisabled\n")
 		}
 
-		fmt.Printf("ISO:\n")
+		cmd.Printf("ISO:\n")
 		if server.ISO != nil {
-			fmt.Printf("  ID:\t\t%d\n", server.ISO.ID)
-			fmt.Printf("  Name:\t\t%s\n", server.ISO.Name)
-			fmt.Printf("  Description:\t%s\n", server.ISO.Description)
-			fmt.Printf("  Type:\t\t%s\n", server.ISO.Type)
+			cmd.Printf("  ID:\t\t%d\n", server.ISO.ID)
+			cmd.Printf("  Name:\t\t%s\n", server.ISO.Name)
+			cmd.Printf("  Description:\t%s\n", server.ISO.Description)
+			cmd.Printf("  Type:\t\t%s\n", server.ISO.Type)
 		} else {
-			fmt.Printf("  No ISO attached\n")
+			cmd.Printf("  No ISO attached\n")
 		}
 
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(server.Protection.Delete))
-		fmt.Printf("  Rebuild:\t%s\n", util.YesNo(server.Protection.Rebuild))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(server.Protection.Delete))
+		cmd.Printf("  Rebuild:\t%s\n", util.YesNo(server.Protection.Rebuild))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(server.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range server.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 
-		fmt.Print("Placement Group:\n")
+		cmd.Print("Placement Group:\n")
 		if server.PlacementGroup != nil {
-			fmt.Printf("  ID:\t\t%d\n", server.PlacementGroup.ID)
-			fmt.Printf("  Name:\t\t%s\n", server.PlacementGroup.Name)
-			fmt.Printf("  Type:\t\t%s\n", server.PlacementGroup.Type)
+			cmd.Printf("  ID:\t\t%d\n", server.PlacementGroup.ID)
+			cmd.Printf("  Name:\t\t%s\n", server.PlacementGroup.Name)
+			cmd.Printf("  Type:\t\t%s\n", server.PlacementGroup.Type)
 		} else {
-			fmt.Print("  No Placement Group set\n")
+			cmd.Print("  No Placement Group set\n")
 		}
 
 		return nil

--- a/internal/cmd/server/detach_from_network.go
+++ b/internal/cmd/server/detach_from_network.go
@@ -59,7 +59,7 @@ var DetachFromNetworkCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d detached from network %d\n", server.ID, network.ID)
+		cmd.Printf("Server %d detached from network %d\n", server.ID, network.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/detach_iso.go
+++ b/internal/cmd/server/detach_iso.go
@@ -42,7 +42,7 @@ var DetachISOCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("ISO detached from server %d\n", server.ID)
+		cmd.Printf("ISO detached from server %d\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/disable_backup.go
+++ b/internal/cmd/server/disable_backup.go
@@ -42,7 +42,7 @@ var DisableBackupCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Backup disabled for server %d\n", server.ID)
+		cmd.Printf("Backup disabled for server %d\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/disable_protection.go
+++ b/internal/cmd/server/disable_protection.go
@@ -41,6 +41,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, server, false, opts)
+		return changeProtection(ctx, client, waiter, cmd, server, false, opts)
 	},
 }

--- a/internal/cmd/server/disable_rescue.go
+++ b/internal/cmd/server/disable_rescue.go
@@ -42,7 +42,7 @@ var DisableRescueCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Rescue disabled for server %d\n", server.ID)
+		cmd.Printf("Rescue disabled for server %d\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/enable_backup.go
+++ b/internal/cmd/server/enable_backup.go
@@ -39,7 +39,7 @@ var EnableBackupCmd = base.Cmd{
 
 		window, _ := cmd.Flags().GetString("window")
 		if window != "" {
-			fmt.Print("[WARN] The ability to specify a backup window when enabling backups has been removed. Ignoring flag.\n")
+			cmd.Print("[WARN] The ability to specify a backup window when enabling backups has been removed. Ignoring flag.\n")
 		}
 
 		action, _, err := client.Server().EnableBackup(ctx, server, "")
@@ -51,7 +51,7 @@ var EnableBackupCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Backup enabled for server %d\n", server.ID)
+		cmd.Printf("Backup enabled for server %d\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/enable_protection.go
+++ b/internal/cmd/server/enable_protection.go
@@ -36,7 +36,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.ServerChangePr
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, server *hcloud.Server, enable bool, opts hcloud.ServerChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	server *hcloud.Server, enable bool, opts hcloud.ServerChangeProtectionOpts) error {
 
 	if opts.Delete == nil && opts.Rebuild == nil {
 		return nil
@@ -52,9 +53,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for server %d\n", server.ID)
+		cmd.Printf("Resource protection enabled for server %d\n", server.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for server %d\n", server.ID)
+		cmd.Printf("Resource protection disabled for server %d\n", server.ID)
 	}
 	return nil
 }
@@ -88,6 +89,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, server, true, opts)
+		return changeProtection(ctx, client, waiter, cmd, server, true, opts)
 	},
 }

--- a/internal/cmd/server/enable_rescue.go
+++ b/internal/cmd/server/enable_rescue.go
@@ -67,7 +67,7 @@ var EnableRescueCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Rescue enabled for server %d with root password: %s\n", server.ID, result.RootPassword)
+		cmd.Printf("Rescue enabled for server %d with root password: %s\n", server.ID, result.RootPassword)
 		return nil
 	},
 }

--- a/internal/cmd/server/ip.go
+++ b/internal/cmd/server/ip.go
@@ -39,12 +39,12 @@ var IPCmd = base.Cmd{
 			if server.PublicNet.IPv6.IsUnspecified() {
 				return fmt.Errorf("server %s has not primary IPv6", idOrName)
 			}
-			fmt.Println(server.PublicNet.IPv6.IP.String() + "1")
+			cmd.Println(server.PublicNet.IPv6.IP.String() + "1")
 		} else {
 			if server.PublicNet.IPv4.IsUnspecified() {
 				return fmt.Errorf("server %s has not primary IPv4", idOrName)
 			}
-			fmt.Println(server.PublicNet.IPv4.IP.String())
+			cmd.Println(server.PublicNet.IPv4.IP.String())
 		}
 		return nil
 	},

--- a/internal/cmd/server/metrics.go
+++ b/internal/cmd/server/metrics.go
@@ -96,18 +96,18 @@ var MetricsCmd = base.Cmd{
 			sort.Strings(keys)
 			for _, k := range keys {
 				if len(m.TimeSeries[k]) == 0 {
-					fmt.Printf("Currently there are now metrics available. Please try it again later.")
+					cmd.Printf("Currently there are now metrics available. Please try it again later.")
 					return nil
 				}
-				fmt.Printf("Server: %s \t Metric: %s \t Start: %s \t End: %s\n", server.Name, k, m.Start.String(), m.End.String())
+				cmd.Printf("Server: %s \t Metric: %s \t Start: %s \t End: %s\n", server.Name, k, m.Start.String(), m.End.String())
 				var data []float64
 				for _, m := range m.TimeSeries[k] {
 					d, _ := strconv.ParseFloat(m.Value, 64)
 					data = append(data, d)
 				}
 				graph := asciigraph.Plot(data, asciigraph.Height(20), asciigraph.Width(100))
-				fmt.Println(graph)
-				fmt.Printf("\n\n")
+				cmd.Println(graph)
+				cmd.Printf("\n\n")
 			}
 		}
 		return nil

--- a/internal/cmd/server/poweroff.go
+++ b/internal/cmd/server/poweroff.go
@@ -42,7 +42,7 @@ var PoweroffCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d stopped\n", server.ID)
+		cmd.Printf("Server %d stopped\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/poweron.go
+++ b/internal/cmd/server/poweron.go
@@ -42,7 +42,7 @@ var PoweronCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d started\n", server.ID)
+		cmd.Printf("Server %d started\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/reboot.go
+++ b/internal/cmd/server/reboot.go
@@ -42,7 +42,7 @@ var RebootCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d rebooted\n", server.ID)
+		cmd.Printf("Server %d rebooted\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/rebuild.go
+++ b/internal/cmd/server/rebuild.go
@@ -56,7 +56,7 @@ var RebuildCmd = base.Cmd{
 		allowDeprecatedImage, _ := cmd.Flags().GetBool("allow-deprecated-image")
 		if !image.Deprecated.IsZero() {
 			if allowDeprecatedImage {
-				fmt.Printf("Attention: image %s is deprecated. It will continue to be available until %s.\n", image.Name, image.Deprecated.AddDate(0, 3, 0).Format(time.DateOnly))
+				cmd.Printf("Attention: image %s is deprecated. It will continue to be available until %s.\n", image.Name, image.Deprecated.AddDate(0, 3, 0).Format(time.DateOnly))
 			} else {
 				return fmt.Errorf("image %s is deprecated, please use --allow-deprecated-image to create a server with this image. It will continue to be available until %s", image.Name, image.Deprecated.AddDate(0, 3, 0).Format(time.DateOnly))
 			}
@@ -74,12 +74,12 @@ var RebuildCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d rebuilt with image %s\n", server.ID, image.Name)
+		cmd.Printf("Server %d rebuilt with image %s\n", server.ID, image.Name)
 
 		// Only print the root password if it's not empty,
 		// which is only the case if it wasn't created with an SSH key.
 		if result.RootPassword != "" {
-			fmt.Printf("Root password: %s\n", result.RootPassword)
+			cmd.Printf("Root password: %s\n", result.RootPassword)
 		}
 
 		return nil

--- a/internal/cmd/server/remove_from_placement_group.go
+++ b/internal/cmd/server/remove_from_placement_group.go
@@ -43,7 +43,7 @@ var RemoveFromPlacementGroupCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d removed from placement group\n", server.ID)
+		cmd.Printf("Server %d removed from placement group\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/request_console.go
+++ b/internal/cmd/server/request_console.go
@@ -57,9 +57,9 @@ var RequestConsoleCmd = base.Cmd{
 			})
 		}
 
-		fmt.Printf("Console for server %d:\n", server.ID)
-		fmt.Printf("WebSocket URL: %s\n", result.WSSURL)
-		fmt.Printf("VNC Password: %s\n", result.Password)
+		cmd.Printf("Console for server %d:\n", server.ID)
+		cmd.Printf("WebSocket URL: %s\n", result.WSSURL)
+		cmd.Printf("VNC Password: %s\n", result.Password)
 		return nil
 	},
 }

--- a/internal/cmd/server/reset.go
+++ b/internal/cmd/server/reset.go
@@ -42,7 +42,7 @@ var ResetCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Server %d reset\n", server.ID)
+		cmd.Printf("Server %d reset\n", server.ID)
 		return nil
 	},
 }

--- a/internal/cmd/server/reset_password.go
+++ b/internal/cmd/server/reset_password.go
@@ -42,7 +42,7 @@ var ResetPasswordCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Password of server %d reset to: %s\n", server.ID, result.RootPassword)
+		cmd.Printf("Password of server %d reset to: %s\n", server.ID, result.RootPassword)
 		return nil
 	},
 }

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -61,7 +61,7 @@ var ShutdownCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Sent shutdown signal to server %d\n", server.ID)
+		cmd.Printf("Sent shutdown signal to server %d\n", server.ID)
 
 		if wait {
 			start := time.Now()
@@ -97,7 +97,7 @@ var ShutdownCmd = base.Cmd{
 				return err
 			}
 
-			fmt.Printf("Server %d shut down\n", server.ID)
+			cmd.Printf("Server %d shut down\n", server.ID)
 		}
 
 		return nil

--- a/internal/cmd/servertype/describe.go
+++ b/internal/cmd/servertype/describe.go
@@ -2,7 +2,6 @@ package servertype
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -21,26 +20,26 @@ var DescribeCmd = base.DescribeCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.ServerType().Get(ctx, idOrName)
 	},
-	PrintText: func(_ context.Context, _ hcapi2.Client, _ *cobra.Command, resource interface{}) error {
+	PrintText: func(_ context.Context, _ hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		serverType := resource.(*hcloud.ServerType)
 
-		fmt.Printf("ID:\t\t\t%d\n", serverType.ID)
-		fmt.Printf("Name:\t\t\t%s\n", serverType.Name)
-		fmt.Printf("Description:\t\t%s\n", serverType.Description)
-		fmt.Printf("Cores:\t\t\t%d\n", serverType.Cores)
-		fmt.Printf("CPU Type:\t\t%s\n", serverType.CPUType)
-		fmt.Printf("Architecture:\t\t%s\n", serverType.Architecture)
-		fmt.Printf("Memory:\t\t\t%.1f GB\n", serverType.Memory)
-		fmt.Printf("Disk:\t\t\t%d GB\n", serverType.Disk)
-		fmt.Printf("Storage Type:\t\t%s\n", serverType.StorageType)
-		fmt.Printf("Included Traffic:\t%d TB\n", serverType.IncludedTraffic/util.Tebibyte)
-		fmt.Printf(util.DescribeDeprecation(serverType))
+		cmd.Printf("ID:\t\t\t%d\n", serverType.ID)
+		cmd.Printf("Name:\t\t\t%s\n", serverType.Name)
+		cmd.Printf("Description:\t\t%s\n", serverType.Description)
+		cmd.Printf("Cores:\t\t\t%d\n", serverType.Cores)
+		cmd.Printf("CPU Type:\t\t%s\n", serverType.CPUType)
+		cmd.Printf("Architecture:\t\t%s\n", serverType.Architecture)
+		cmd.Printf("Memory:\t\t\t%.1f GB\n", serverType.Memory)
+		cmd.Printf("Disk:\t\t\t%d GB\n", serverType.Disk)
+		cmd.Printf("Storage Type:\t\t%s\n", serverType.StorageType)
+		cmd.Printf("Included Traffic:\t%d TB\n", serverType.IncludedTraffic/util.Tebibyte)
+		cmd.Printf(util.DescribeDeprecation(serverType))
 
-		fmt.Printf("Pricings per Location:\n")
+		cmd.Printf("Pricings per Location:\n")
 		for _, price := range serverType.Pricings {
-			fmt.Printf("  - Location:\t%s:\n", price.Location.Name)
-			fmt.Printf("    Hourly:\t€ %s\n", price.Hourly.Gross)
-			fmt.Printf("    Monthly:\t€ %s\n", price.Monthly.Gross)
+			cmd.Printf("  - Location:\t%s:\n", price.Location.Name)
+			cmd.Printf("    Hourly:\t€ %s\n", price.Hourly.Gross)
+			cmd.Printf("    Monthly:\t€ %s\n", price.Monthly.Gross)
 		}
 		return nil
 	},

--- a/internal/cmd/sshkey/create.go
+++ b/internal/cmd/sshkey/create.go
@@ -2,7 +2,6 @@ package sshkey
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 
@@ -63,7 +62,7 @@ var CreateCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("SSH key %d created\n", sshKey.ID)
+		cmd.Printf("SSH key %d created\n", sshKey.ID)
 
 		return nil
 	},

--- a/internal/cmd/sshkey/describe.go
+++ b/internal/cmd/sshkey/describe.go
@@ -2,7 +2,6 @@ package sshkey
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/dustin/go-humanize"
@@ -23,19 +22,19 @@ var DescribeCmd = base.DescribeCmd{
 	Fetch: func(ctx context.Context, client hcapi2.Client, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
 		return client.SSHKey().Get(ctx, idOrName)
 	},
-	PrintText: func(_ context.Context, _ hcapi2.Client, _ *cobra.Command, resource interface{}) error {
+	PrintText: func(_ context.Context, _ hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		sshKey := resource.(*hcloud.SSHKey)
-		fmt.Printf("ID:\t\t%d\n", sshKey.ID)
-		fmt.Printf("Name:\t\t%s\n", sshKey.Name)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(sshKey.Created), humanize.Time(sshKey.Created))
-		fmt.Printf("Fingerprint:\t%s\n", sshKey.Fingerprint)
-		fmt.Printf("Public Key:\n%s\n", strings.TrimSpace(sshKey.PublicKey))
-		fmt.Print("Labels:\n")
+		cmd.Printf("ID:\t\t%d\n", sshKey.ID)
+		cmd.Printf("Name:\t\t%s\n", sshKey.Name)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(sshKey.Created), humanize.Time(sshKey.Created))
+		cmd.Printf("Fingerprint:\t%s\n", sshKey.Fingerprint)
+		cmd.Printf("Public Key:\n%s\n", strings.TrimSpace(sshKey.PublicKey))
+		cmd.Print("Labels:\n")
 		if len(sshKey.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range sshKey.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -1,8 +1,6 @@
 package version
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/state"
@@ -21,6 +19,6 @@ func NewCommand(cli *state.State) *cobra.Command {
 }
 
 func runVersion(cli *state.State, cmd *cobra.Command, args []string) error {
-	fmt.Printf("hcloud %s\n", version.Version)
+	cmd.Printf("hcloud %s\n", version.Version)
 	return nil
 }

--- a/internal/cmd/volume/attach.go
+++ b/internal/cmd/volume/attach.go
@@ -61,7 +61,7 @@ var AttachCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Volume %d attached to server %s\n", volume.ID, server.Name)
+		cmd.Printf("Volume %d attached to server %s\n", volume.ID, server.Name)
 		return nil
 	},
 }

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -104,8 +104,8 @@ var CreateCmd = base.Cmd{
 		if err := waiter.WaitForActions(ctx, result.NextActions); err != nil {
 			return err
 		}
-		fmt.Printf("Volume %d created\n", result.Volume.ID)
+		cmd.Printf("Volume %d created\n", result.Volume.ID)
 
-		return changeProtection(ctx, client, waiter, result.Volume, true, protectionOpts)
+		return changeProtection(ctx, client, waiter, cmd, result.Volume, true, protectionOpts)
 	},
 }

--- a/internal/cmd/volume/describe.go
+++ b/internal/cmd/volume/describe.go
@@ -2,7 +2,6 @@ package volume
 
 import (
 	"context"
-	"fmt"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -25,34 +24,34 @@ var DescribeCmd = base.DescribeCmd{
 	PrintText: func(_ context.Context, client hcapi2.Client, cmd *cobra.Command, resource interface{}) error {
 		volume := resource.(*hcloud.Volume)
 
-		fmt.Printf("ID:\t\t%d\n", volume.ID)
-		fmt.Printf("Name:\t\t%s\n", volume.Name)
-		fmt.Printf("Created:\t%s (%s)\n", util.Datetime(volume.Created), humanize.Time(volume.Created))
-		fmt.Printf("Size:\t\t%s\n", humanize.Bytes(uint64(volume.Size*humanize.GByte)))
-		fmt.Printf("Linux Device:\t%s\n", volume.LinuxDevice)
-		fmt.Printf("Location:\n")
-		fmt.Printf("  Name:\t\t%s\n", volume.Location.Name)
-		fmt.Printf("  Description:\t%s\n", volume.Location.Description)
-		fmt.Printf("  Country:\t%s\n", volume.Location.Country)
-		fmt.Printf("  City:\t\t%s\n", volume.Location.City)
-		fmt.Printf("  Latitude:\t%f\n", volume.Location.Latitude)
-		fmt.Printf("  Longitude:\t%f\n", volume.Location.Longitude)
+		cmd.Printf("ID:\t\t%d\n", volume.ID)
+		cmd.Printf("Name:\t\t%s\n", volume.Name)
+		cmd.Printf("Created:\t%s (%s)\n", util.Datetime(volume.Created), humanize.Time(volume.Created))
+		cmd.Printf("Size:\t\t%s\n", humanize.Bytes(uint64(volume.Size*humanize.GByte)))
+		cmd.Printf("Linux Device:\t%s\n", volume.LinuxDevice)
+		cmd.Printf("Location:\n")
+		cmd.Printf("  Name:\t\t%s\n", volume.Location.Name)
+		cmd.Printf("  Description:\t%s\n", volume.Location.Description)
+		cmd.Printf("  Country:\t%s\n", volume.Location.Country)
+		cmd.Printf("  City:\t\t%s\n", volume.Location.City)
+		cmd.Printf("  Latitude:\t%f\n", volume.Location.Latitude)
+		cmd.Printf("  Longitude:\t%f\n", volume.Location.Longitude)
 		if volume.Server != nil {
-			fmt.Printf("Server:\n")
-			fmt.Printf("  ID:\t\t%d\n", volume.Server.ID)
-			fmt.Printf("  Name:\t\t%s\n", client.Server().ServerName(volume.Server.ID))
+			cmd.Printf("Server:\n")
+			cmd.Printf("  ID:\t\t%d\n", volume.Server.ID)
+			cmd.Printf("  Name:\t\t%s\n", client.Server().ServerName(volume.Server.ID))
 		} else {
-			fmt.Print("Server:\n  Not attached\n")
+			cmd.Print("Server:\n  Not attached\n")
 		}
-		fmt.Printf("Protection:\n")
-		fmt.Printf("  Delete:\t%s\n", util.YesNo(volume.Protection.Delete))
+		cmd.Printf("Protection:\n")
+		cmd.Printf("  Delete:\t%s\n", util.YesNo(volume.Protection.Delete))
 
-		fmt.Print("Labels:\n")
+		cmd.Print("Labels:\n")
 		if len(volume.Labels) == 0 {
-			fmt.Print("  No labels\n")
+			cmd.Print("  No labels\n")
 		} else {
 			for key, value := range volume.Labels {
-				fmt.Printf("  %s: %s\n", key, value)
+				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}
 

--- a/internal/cmd/volume/detach.go
+++ b/internal/cmd/volume/detach.go
@@ -41,7 +41,7 @@ var DetachCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Volume %d detached\n", volume.ID)
+		cmd.Printf("Volume %d detached\n", volume.ID)
 		return nil
 	},
 }

--- a/internal/cmd/volume/disable_protection.go
+++ b/internal/cmd/volume/disable_protection.go
@@ -40,6 +40,6 @@ var DisableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, volume, false, opts)
+		return changeProtection(ctx, client, waiter, cmd, volume, false, opts)
 	},
 }

--- a/internal/cmd/volume/enable_protection.go
+++ b/internal/cmd/volume/enable_protection.go
@@ -34,7 +34,8 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.VolumeChangePr
 	return opts, nil
 }
 
-func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, volume *hcloud.Volume, enable bool, opts hcloud.VolumeChangeProtectionOpts) error {
+func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.ActionWaiter, cmd *cobra.Command,
+	volume *hcloud.Volume, enable bool, opts hcloud.VolumeChangeProtectionOpts) error {
 
 	if opts.Delete == nil {
 		return nil
@@ -50,9 +51,9 @@ func changeProtection(ctx context.Context, client hcapi2.Client, waiter state.Ac
 	}
 
 	if enable {
-		fmt.Printf("Resource protection enabled for volume %d\n", volume.ID)
+		cmd.Printf("Resource protection enabled for volume %d\n", volume.ID)
 	} else {
-		fmt.Printf("Resource protection disabled for volume %d\n", volume.ID)
+		cmd.Printf("Resource protection disabled for volume %d\n", volume.ID)
 	}
 	return nil
 }
@@ -85,6 +86,6 @@ var EnableProtectionCmd = base.Cmd{
 			return err
 		}
 
-		return changeProtection(ctx, client, waiter, volume, true, opts)
+		return changeProtection(ctx, client, waiter, cmd, volume, true, opts)
 	},
 }

--- a/internal/cmd/volume/resize.go
+++ b/internal/cmd/volume/resize.go
@@ -45,8 +45,8 @@ var ResizeCmd = base.Cmd{
 			return err
 		}
 
-		fmt.Printf("Volume %d resized\n", volume.ID)
-		fmt.Printf("You might need to adjust the filesystem size on the server too\n")
+		cmd.Printf("Volume %d resized\n", volume.ID)
+		cmd.Printf("You might need to adjust the filesystem size on the server too\n")
 		return nil
 	},
 }

--- a/internal/testutil/fixture.go
+++ b/internal/testutil/fixture.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -39,7 +40,12 @@ func (f *Fixture) ExpectEnsureToken() {
 // potential error.
 func (f *Fixture) Run(cmd *cobra.Command, args []string) (string, string, error) {
 	cmd.SetArgs(args)
-	return CaptureOutStreams(cmd.Execute)
+	return CaptureOutStreams(func() error {
+		// We need to re-set the output because CaptureOutStream changes os.Stdout
+		// and the command's outWriter still points to the old os.Stdout.
+		cmd.SetOut(os.Stdout)
+		return cmd.Execute()
+	})
 }
 
 // Finish must be called after the test is finished, preferably via `defer` directly after


### PR DESCRIPTION
This change makes it possible to easily change which stream command outputs are printed to. This is in preparation for the resource creation JSON output feature (as described in #470)