### PR TITLE
feat: pretty-print JSON output

### DIFF
--- a/internal/cmd/util/util.go
+++ b/internal/cmd/util/util.go
@@ -158,6 +158,7 @@ func DescribeFormat(object interface{}, format string) error {
 
 func DescribeJSON(object interface{}) error {
 	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
 	return enc.Encode(object)
 }
 


### PR DESCRIPTION
This PR makes the JSON output (for example when using `... describe -o=json`) properly formatted, with 2 spaces as indent.