### PR TITLE
feat: iso deprecated field was removed

### DIFF
--- a/internal/cmd/server/testdata/create_response.json
+++ b/internal/cmd/server/testdata/create_response.json
@@ -50,7 +50,6 @@
     "ingoing_traffic": null,
     "iso": {
       "architecture": null,
-      "deprecated": null,
       "deprecation": null,
       "description": "FreeBSD 11.0 x64",
       "id": 1,


### PR DESCRIPTION
See https://docs.hetzner.cloud/changelog#2024-01