### PR TITLE
ci: go cache is handled by golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Run gofmt
         run: diff -u <(echo -n) <(gofmt -d -s .)


### PR DESCRIPTION
The golangci/golangci-lint-action handle its own cache, we should not pollute it with the setup-go cache.