### PR TITLE
fix: refetch after creating managed certificate

### DIFF
--- a/internal/cmd/certificate/create.go
+++ b/internal/cmd/certificate/create.go
@@ -133,6 +133,10 @@ func createManaged(s state.State, cmd *cobra.Command) (*hcloud.Certificate, erro
 	if err := s.ActionProgress(cmd, s, res.Action); err != nil {
 		return nil, err
 	}
-	cmd.Printf("Certificate %d created\n", res.Certificate.ID)
-	return res.Certificate, nil
+	defer cmd.Printf("Certificate %d created\n", res.Certificate.ID)
+	cert, _, err := s.Client().Certificate().GetByID(s, res.Certificate.ID)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
 }

--- a/internal/cmd/certificate/create_test.go
+++ b/internal/cmd/certificate/create_test.go
@@ -43,6 +43,14 @@ func TestCreateManaged(t *testing.T) {
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+	fx.Client.CertificateClient.EXPECT().
+		GetByID(gomock.Any(), int64(123)).
+		Return(&hcloud.Certificate{
+			ID:          123,
+			Name:        "test",
+			Type:        hcloud.CertificateTypeManaged,
+			DomainNames: []string{"example.com"},
+		}, nil, nil)
 
 	out, _, err := fx.Run(cmd, []string{"--name", "test", "--type", "managed", "--domain", "example.com"})
 
@@ -71,8 +79,8 @@ func TestCreateManagedJSON(t *testing.T) {
 				Name:           "test",
 				Type:           hcloud.CertificateTypeManaged,
 				Created:        time.Date(2020, 8, 24, 12, 0, 0, 0, time.UTC),
-				NotValidBefore: time.Date(2020, 8, 24, 12, 0, 0, 0, time.UTC),
-				NotValidAfter:  time.Date(2036, 8, 12, 12, 0, 0, 0, time.UTC),
+				NotValidBefore: time.Time{},
+				NotValidAfter:  time.Time{},
 				DomainNames:    []string{"example.com"},
 				Labels:         map[string]string{"key": "value"},
 				UsedBy: []hcloud.CertificateUsedByRef{{
@@ -80,16 +88,36 @@ func TestCreateManagedJSON(t *testing.T) {
 					Type: hcloud.CertificateUsedByRefTypeLoadBalancer,
 				}},
 				Status: &hcloud.CertificateStatus{
-					Error: &hcloud.Error{
-						Code:    "cert_error",
-						Message: "Certificate error",
-					},
+					Issuance: hcloud.CertificateStatusTypePending,
+					Renewal:  hcloud.CertificateStatusTypeUnavailable,
 				},
 			},
 			Action: &hcloud.Action{ID: 321},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
 		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+	fx.Client.CertificateClient.EXPECT().
+		GetByID(gomock.Any(), int64(123)).
+		Return(&hcloud.Certificate{
+			ID:             123,
+			Name:           "test",
+			Type:           hcloud.CertificateTypeManaged,
+			Created:        time.Date(2020, 8, 24, 12, 0, 0, 0, time.UTC),
+			NotValidBefore: time.Date(2020, 8, 24, 12, 0, 0, 0, time.UTC),
+			NotValidAfter:  time.Date(2036, 8, 12, 12, 0, 0, 0, time.UTC),
+			DomainNames:    []string{"example.com"},
+			Labels:         map[string]string{"key": "value"},
+			UsedBy: []hcloud.CertificateUsedByRef{{
+				ID:   123,
+				Type: hcloud.CertificateUsedByRefTypeLoadBalancer,
+			}},
+			Status: &hcloud.CertificateStatus{
+				Issuance: hcloud.CertificateStatusTypeCompleted,
+				Renewal:  hcloud.CertificateStatusTypeUnavailable,
+			},
+			Fingerprint: "fingerprint placeholder",
+			Certificate: "certificate data placeholder",
+		}, nil, nil)
 
 	jsonOut, out, err := fx.Run(cmd, []string{"-o=json", "--name", "test", "--type", "managed", "--domain", "example.com"})
 

--- a/internal/cmd/certificate/testdata/managed_create_response.json
+++ b/internal/cmd/certificate/testdata/managed_create_response.json
@@ -1,11 +1,11 @@
 {
   "certificate": {
-    "certificate": "",
+    "certificate": "certificate data placeholder",
     "created": "2020-08-24T12:00:00Z",
     "domain_names": [
       "example.com"
     ],
-    "fingerprint": "",
+    "fingerprint": "fingerprint placeholder",
     "id": 123,
     "labels": {
       "key": "value"
@@ -14,14 +14,8 @@
     "not_valid_after": "2036-08-12T12:00:00Z",
     "not_valid_before": "2020-08-24T12:00:00Z",
     "status": {
-      "error": {
-        "Details": null,
-        "code": "cert_error",
-        "details": null,
-        "message": "Certificate error"
-      },
-      "issuance": "",
-      "renewal": ""
+      "issuance": "completed",
+      "renewal": "unavailable"
     },
     "type": "managed",
     "used_by": [


### PR DESCRIPTION
When creating a managed certificate, the complete data is only available once the related action has completed. Instead of then returning the initial response data, we now fetch the certificate and return this request's response data.