### PR TITLE
docs: add available types to hcloud image list --help

### DIFF
--- a/internal/cmd/image/list.go
+++ b/internal/cmd/image/list.go
@@ -24,7 +24,7 @@ var ListCmd = base.ListCmd{
 	JSONKeyGetByName:   "images",
 	DefaultColumns:     []string{"id", "type", "name", "description", "architecture", "image_size", "disk_size", "created", "deprecated"},
 	AdditionalFlags: func(cmd *cobra.Command) {
-		cmd.Flags().StringSliceP("type", "t", []string{}, "Only show images of given type")
+		cmd.Flags().StringSliceP("type", "t", []string{}, "Only show images of given type: system|app|snapshot|backup")
 		cmd.RegisterFlagCompletionFunc("type", cmpl.SuggestCandidates("backup", "snapshot", "system", "app"))
 
 		cmd.Flags().StringSliceP("architecture", "a", []string{}, "Only show images of given architecture: x86|arm")


### PR DESCRIPTION
As of now, I had to use `-oyaml | yq` to filter out the supported types.  
It would be good to have it in the help message itself. 