### PR TITLE
fix: removing last rule from firewall fails with invalid_input error

### DIFF
--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -114,6 +114,9 @@ var DeleteRuleCmd = base.Cmd{
 		if len(rules) == len(firewall.Rules) {
 			return fmt.Errorf("the specified rule was not found in the ruleset of Firewall %d", firewall.ID)
 		}
+		if len(rules) == 0 {
+			rules = []hcloud.FirewallRule{}
+		}
 		actions, _, err := s.Client().Firewall().SetRules(s, firewall,
 			hcloud.FirewallSetRulesOpts{Rules: rules},
 		)

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -105,7 +105,7 @@ var DeleteRuleCmd = base.Cmd{
 			}
 		}
 
-		var rules []hcloud.FirewallRule
+		var rules = make([]hcloud.FirewallRule, 0)
 		for _, existingRule := range firewall.Rules {
 			if !reflect.DeepEqual(existingRule, rule) {
 				rules = append(rules, existingRule)
@@ -113,9 +113,6 @@ var DeleteRuleCmd = base.Cmd{
 		}
 		if len(rules) == len(firewall.Rules) {
 			return fmt.Errorf("the specified rule was not found in the ruleset of Firewall %d", firewall.ID)
-		}
-		if len(rules) == 0 {
-			rules = []hcloud.FirewallRule{}
 		}
 		actions, _, err := s.Client().Firewall().SetRules(s, firewall,
 			hcloud.FirewallSetRulesOpts{Rules: rules},

--- a/internal/cmd/firewall/delete_rule_test.go
+++ b/internal/cmd/firewall/delete_rule_test.go
@@ -36,7 +36,7 @@ func TestDeleteRule(t *testing.T) {
 		Get(gomock.Any(), "test").
 		Return(fw, nil, nil)
 	fx.Client.FirewallClient.EXPECT().
-		SetRules(gomock.Any(), fw, hcloud.FirewallSetRulesOpts{Rules: nil}).
+		SetRules(gomock.Any(), fw, hcloud.FirewallSetRulesOpts{Rules: []hcloud.FirewallRule{}}).
 		Return([]*hcloud.Action{{ID: 123}, {ID: 321}}, nil, nil)
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 123}, {ID: 321}}).


### PR DESCRIPTION
If you try to delete last firewall rule, rule is `null` but should be `[]`, resulting in error message 

> hcloud: invalid input in field 'rules' (invalid_input)

`hcloud firewall delete-rule --direction in --protocol tcp --source-ips '8.8.8.8/32' --port 443 f2b`