### PR TITLE
docs: improve command usage documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ Command usage descriptions (namely `cobra.Command.Use`) should follow the [docop
 Additionally:
 - Optional flags should be the first in the usage string.
   - If there is more than one optional flag, you can use `[options]` to abbreviate.
-- Required flags should always be documented explicitly and after the positional arguments.
+- Required flags should always be documented explicitly and before the positional arguments, but after the 
+  optional flags.
 
 ### Subcommand groups
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,15 @@ goreleaser --snapshot --skip-publish --rm-dist
 
 ## Conventions
 
+### Command usage
+
+Command usage descriptions (namely `cobra.Command.Use`) should follow the [docopt](http://docopt.org/) syntax.
+
+Additionally:
+- Optional flags should be the first in the usage string.
+  - If there is more than one optional flag, you can use `[options]` to abbreviate.
+- Required flags should always be documented explicitly and after the positional arguments.
+
 ### Subcommand groups
 
 Cobra offers the functionality to group subcommands. The conventions on when and how to group commands are as follows:

--- a/internal/cmd/all/list.go
+++ b/internal/cmd/all/list.go
@@ -50,7 +50,7 @@ var ListCmd = base.Cmd{
 		}
 
 		cmd := &cobra.Command{
-			Use:   "list FLAGS",
+			Use:   "list [options]",
 			Short: "List all resources in the project",
 			Long: `List all resources in the project. This does not include static/public resources like locations, public ISOs, etc.
 

--- a/internal/cmd/base/delete.go
+++ b/internal/cmd/base/delete.go
@@ -26,8 +26,13 @@ type DeleteCmd struct {
 
 // CobraCommand creates a command that can be registered with cobra.
 func (dc *DeleteCmd) CobraCommand(s state.State) *cobra.Command {
+	opts := ""
+	if dc.AdditionalFlags != nil {
+		opts = "[options] "
+	}
+
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("delete [FLAGS] %s", strings.ToUpper(dc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("delete %s<%s>", opts, strings.ToLower(dc.ResourceNameSingular)),
 		Short:                 dc.ShortDescription,
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(dc.NameSuggestions(s.Client()))),

--- a/internal/cmd/base/describe.go
+++ b/internal/cmd/base/describe.go
@@ -33,7 +33,7 @@ type DescribeCmd struct {
 // CobraCommand creates a command that can be registered with cobra.
 func (dc *DescribeCmd) CobraCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("describe [FLAGS] %s", strings.ToUpper(dc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("describe [options] <%s>", strings.ToLower(dc.ResourceNameSingular)),
 		Short:                 dc.ShortDescription,
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(dc.NameSuggestions(s.Client()))),

--- a/internal/cmd/base/labels.go
+++ b/internal/cmd/base/labels.go
@@ -27,7 +27,7 @@ type LabelCmds struct {
 // AddCobraCommand creates a command that can be registered with cobra.
 func (lc *LabelCmds) AddCobraCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("add-label [FLAGS] %s LABEL...", strings.ToUpper(lc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("add-label [--overwrite] <%s> <label>...", strings.ToLower(lc.ResourceNameSingular)),
 		Short:                 lc.ShortDescriptionAdd,
 		Args:                  cobra.MinimumNArgs(2),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(lc.NameSuggestions(s.Client()))),
@@ -89,7 +89,7 @@ func validateAddLabel(_ *cobra.Command, args []string) error {
 // RemoveCobraCommand creates a command that can be registered with cobra.
 func (lc *LabelCmds) RemoveCobraCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("remove-label [FLAGS] %s LABEL...", strings.ToUpper(lc.ResourceNameSingular)),
+		Use:   fmt.Sprintf("remove-label <%s> (--all | <label>...)", strings.ToLower(lc.ResourceNameSingular)),
 		Short: lc.ShortDescriptionRemove,
 		Args:  cobra.MinimumNArgs(1),
 		ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -29,7 +29,7 @@ func (lc *ListCmd) CobraCommand(s state.State) *cobra.Command {
 	outputColumns := lc.OutputTable(s.Client()).Columns()
 
 	cmd := &cobra.Command{
-		Use:   "list [FlAGS]",
+		Use:   "list [options]",
 		Short: fmt.Sprintf("List %s", lc.ResourceNamePlural),
 		Long: util.ListLongDescription(
 			fmt.Sprintf("Displays a list of %s.", lc.ResourceNamePlural),

--- a/internal/cmd/base/set_rdns.go
+++ b/internal/cmd/base/set_rdns.go
@@ -28,7 +28,7 @@ type SetRdnsCmd struct {
 // CobraCommand creates a command that can be registered with cobra.
 func (rc *SetRdnsCmd) CobraCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("set-rdns [options] <%s> --hostname <hostname>", strings.ToLower(rc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("set-rdns [options] --hostname <hostname> <%s>", strings.ToLower(rc.ResourceNameSingular)),
 		Short:                 rc.ShortDescription,
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(rc.NameSuggestions(s.Client()))),

--- a/internal/cmd/base/set_rdns.go
+++ b/internal/cmd/base/set_rdns.go
@@ -28,7 +28,7 @@ type SetRdnsCmd struct {
 // CobraCommand creates a command that can be registered with cobra.
 func (rc *SetRdnsCmd) CobraCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("set-rdns [FLAGS] %s", strings.ToUpper(rc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("set-rdns [options] <%s> --hostname <hostname>", strings.ToLower(rc.ResourceNameSingular)),
 		Short:                 rc.ShortDescription,
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(rc.NameSuggestions(s.Client()))),

--- a/internal/cmd/base/update.go
+++ b/internal/cmd/base/update.go
@@ -28,7 +28,7 @@ type UpdateCmd struct {
 // CobraCommand creates a command that can be registered with cobra.
 func (uc *UpdateCmd) CobraCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("update [FLAGS] %s", strings.ToUpper(uc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("update [options] <%s>", strings.ToLower(uc.ResourceNameSingular)),
 		Short:                 uc.ShortDescription,
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(uc.NameSuggestions(s.Client()))),

--- a/internal/cmd/certificate/create.go
+++ b/internal/cmd/certificate/create.go
@@ -17,7 +17,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create [options] --name <name> (--type managed | --type uploaded --cert-file <file> --key-file <file>)",
+			Use:   "create [options] --name <name> (--type managed --domain <domain> | --type uploaded --cert-file <file> --key-file <file>)",
 			Short: "Create or upload a Certificate",
 			Args:  cobra.ExactArgs(0),
 		}

--- a/internal/cmd/certificate/create.go
+++ b/internal/cmd/certificate/create.go
@@ -17,7 +17,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create [FLAGS]",
+			Use:   "create [options] --name <name> (--type managed | --type uploaded --cert-file <file> --key-file <file>)",
 			Short: "Create or upload a Certificate",
 			Args:  cobra.ExactArgs(0),
 		}

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -33,7 +33,7 @@ import (
 
 func NewCommand(_ state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "completion [FLAGS] SHELL",
+		Use:   "completion <shell>",
 		Short: "Output shell completion code for the specified shell",
 		Long: `To load completions:
 

--- a/internal/cmd/context/active.go
+++ b/internal/cmd/context/active.go
@@ -11,7 +11,7 @@ import (
 
 func newActiveCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "active [FLAGS]",
+		Use:                   "active",
 		Short:                 "Show active context",
 		Args:                  cobra.NoArgs,
 		TraverseChildren:      true,

--- a/internal/cmd/context/context.go
+++ b/internal/cmd/context/context.go
@@ -8,7 +8,7 @@ import (
 
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "context [FLAGS]",
+		Use:                   "context",
 		Short:                 "Manage contexts",
 		Args:                  cobra.NoArgs,
 		TraverseChildren:      true,

--- a/internal/cmd/context/create.go
+++ b/internal/cmd/context/create.go
@@ -17,7 +17,7 @@ import (
 
 func newCreateCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "create [FLAGS] NAME",
+		Use:                   "create <name>",
 		Short:                 "Create a new context",
 		Args:                  cobra.ExactArgs(1),
 		TraverseChildren:      true,

--- a/internal/cmd/context/delete.go
+++ b/internal/cmd/context/delete.go
@@ -13,7 +13,7 @@ import (
 
 func newDeleteCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "delete [FLAGS] NAME",
+		Use:                   "delete <context>",
 		Short:                 "Delete a context",
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidates(config.ContextNames(s.Config())...)),

--- a/internal/cmd/context/list.go
+++ b/internal/cmd/context/list.go
@@ -24,7 +24,7 @@ func init() {
 
 func newListCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list [FLAGS]",
+		Use:   "list [options]",
 		Short: "List contexts",
 		Long: util.ListLongDescription(
 			"Displays a list of contexts.",

--- a/internal/cmd/context/use.go
+++ b/internal/cmd/context/use.go
@@ -13,7 +13,7 @@ import (
 
 func newUseCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "use [FLAGS] NAME",
+		Use:                   "use <context>",
 		Short:                 "Use a context",
 		Args:                  cobra.ExactArgs(1),
 		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidates(config.ContextNames(s.Config())...)),

--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -16,7 +16,7 @@ import (
 var AddRuleCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-rule [options] <firewall> (--direction in --source-ips <ips> | --direction out --destination-ips <ips>) --protocol <icmp|udp|tcp|esp|gre>",
+			Use:                   "add-rule [options] (--direction in --source-ips <ips> | --direction out --destination-ips <ips>) --protocol <icmp|udp|tcp|esp|gre> <firewall>",
 			Short:                 "Add a single rule to a firewall",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -16,7 +16,7 @@ import (
 var AddRuleCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-rule FIREWALL FLAGS",
+			Use:                   "add-rule [options] <firewall> (--direction in --source-ips <ips> | --direction out --destination-ips <ips>) --protocol <icmp|udp|tcp|esp|gre>",
 			Short:                 "Add a single rule to a firewall",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/apply_to_resource.go
+++ b/internal/cmd/firewall/apply_to_resource.go
@@ -15,7 +15,7 @@ import (
 var ApplyToResourceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "apply-to-resource <firewall> (--type server --server <server> | --type label_selector --label-selector <label-selector>)",
+			Use:                   "apply-to-resource (--type server --server <server> | --type label_selector --label-selector <label-selector>) <firewall>",
 			Short:                 "Applies a Firewall to a single resource",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/apply_to_resource.go
+++ b/internal/cmd/firewall/apply_to_resource.go
@@ -15,7 +15,7 @@ import (
 var ApplyToResourceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "apply-to-resource FIREWALL FLAGS",
+			Use:                   "apply-to-resource <firewall> (--type server --server <server> | --type label_selector --label-selector <label-selector>)",
 			Short:                 "Applies a Firewall to a single resource",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/create.go
+++ b/internal/cmd/firewall/create.go
@@ -20,7 +20,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create FLAGS",
+			Use:   "create [options] --name <name>",
 			Short: "Create a Firewall",
 			Args:  cobra.NoArgs,
 		}

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -17,7 +17,7 @@ import (
 var DeleteRuleCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "delete-rule FIREWALL FLAGS",
+			Use:                   "delete-rule [options] <firewall> (--direction in --source-ips <ips> | --direction out --destination-ips <ips>) --protocol <icmp|esp|gre|udp|tcp>",
 			Short:                 "Delete a single rule to a firewall",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -17,7 +17,7 @@ import (
 var DeleteRuleCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "delete-rule [options] <firewall> (--direction in --source-ips <ips> | --direction out --destination-ips <ips>) --protocol <icmp|esp|gre|udp|tcp>",
+			Use:                   "delete-rule [options] (--direction in --source-ips <ips> | --direction out --destination-ips <ips>) --protocol <icmp|esp|gre|udp|tcp> <firewall>",
 			Short:                 "Delete a single rule to a firewall",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/remove_from_resource.go
+++ b/internal/cmd/firewall/remove_from_resource.go
@@ -15,7 +15,7 @@ import (
 var RemoveFromResourceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-from-resource FIREWALL FLAGS",
+			Use:                   "remove-from-resource <firewall> (--type server --server <server> | --type label_selector --label-selector <label-selector>)",
 			Short:                 "Removes a Firewall from a single resource",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/remove_from_resource.go
+++ b/internal/cmd/firewall/remove_from_resource.go
@@ -15,7 +15,7 @@ import (
 var RemoveFromResourceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-from-resource <firewall> (--type server --server <server> | --type label_selector --label-selector <label-selector>)",
+			Use:                   "remove-from-resource (--type server --server <server> | --type label_selector --label-selector <label-selector>) <firewall>",
 			Short:                 "Removes a Firewall from a single resource",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/replace_rules.go
+++ b/internal/cmd/firewall/replace_rules.go
@@ -20,7 +20,7 @@ import (
 var ReplaceRulesCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "replace-rules <firewall> --rules-file <file>",
+			Use:                   "replace-rules --rules-file <file> <firewall>",
 			Short:                 "Replaces all rules from a Firewall from a file",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/firewall/replace_rules.go
+++ b/internal/cmd/firewall/replace_rules.go
@@ -20,7 +20,7 @@ import (
 var ReplaceRulesCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "replace-rules FIREWALL FLAGS",
+			Use:                   "replace-rules <firewall> --rules-file <file>",
 			Short:                 "Replaces all rules from a Firewall from a file",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Firewall().Names)),

--- a/internal/cmd/floatingip/assign.go
+++ b/internal/cmd/floatingip/assign.go
@@ -14,7 +14,7 @@ import (
 var AssignCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "assign [FLAGS] FLOATINGIP SERVER",
+			Use:   "assign <floating-ip> <server>",
 			Short: "Assign a Floating IP to a server",
 			Args:  cobra.ExactArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/floatingip/create.go
+++ b/internal/cmd/floatingip/create.go
@@ -17,7 +17,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "create FLAGS",
+			Use:                   "create [options] --type <ipv4|ipv6> (--home-location <location> | --server <server>)",
 			Short:                 "Create a Floating IP",
 			Args:                  cobra.NoArgs,
 			TraverseChildren:      true,

--- a/internal/cmd/floatingip/disable_protection.go
+++ b/internal/cmd/floatingip/disable_protection.go
@@ -14,7 +14,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "disable-protection [FLAGS] FLOATINGIP PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <floating-ip> <protection-level>...",
 			Short: "Disable resource protection for a Floating IP",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/floatingip/enable_protection.go
+++ b/internal/cmd/floatingip/enable_protection.go
@@ -60,7 +60,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "enable-protection [FLAGS] FLOATINGIP PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <floating-ip> <protection-level>...",
 			Short: "Enable resource protection for a Floating IP",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/floatingip/unassign.go
+++ b/internal/cmd/floatingip/unassign.go
@@ -14,7 +14,7 @@ import (
 var UnassignCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "unassign [FLAGS] FLOATINGIP",
+			Use:                   "unassign <floating-ip>",
 			Short:                 "Unassign a Floating IP",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.FloatingIP().Names)),

--- a/internal/cmd/image/disable_protection.go
+++ b/internal/cmd/image/disable_protection.go
@@ -16,7 +16,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "disable-protection [FLAGS] IMAGE PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <image> <protection-level>...",
 			Short: "Disable resource protection for an image",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/image/enable_protection.go
+++ b/internal/cmd/image/enable_protection.go
@@ -63,7 +63,7 @@ var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 
 		return &cobra.Command{
-			Use:   "enable-protection [FLAGS] IMAGE PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <image> <protection-level>...",
 			Short: "Enable resource protection for an image",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -15,7 +15,7 @@ import (
 var AddServiceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-service [options] <load-balancer> (--protocol http | --protocol tcp --listen-port <1-65535> --destination-port <1-65535> | --protocol https --http-certificates <ids>)",
+			Use:                   "add-service [options] (--protocol http | --protocol tcp --listen-port <1-65535> --destination-port <1-65535> | --protocol https --http-certificates <ids>) <load-balancer>",
 			Short:                 "Add a service to a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -15,7 +15,7 @@ import (
 var AddServiceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-service LOADBALANCER FLAGS",
+			Use:                   "add-service [options] <load-balancer> (--protocol http | --protocol tcp --listen-port <1-65535> --destination-port <1-65535> | --protocol https --http-certificates <ids>)",
 			Short:                 "Add a service to a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/add_target.go
+++ b/internal/cmd/loadbalancer/add_target.go
@@ -17,7 +17,7 @@ import (
 var AddTargetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-target LOADBALANCER FLAGS",
+			Use:                   "add-target [options] <load-balancer>",
 			Short:                 "Add a target to a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/add_target.go
+++ b/internal/cmd/loadbalancer/add_target.go
@@ -17,7 +17,7 @@ import (
 var AddTargetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-target [options] <load-balancer>",
+			Use:                   "add-target [options] (--server <server> | --label-selector <label-selector> | --ip <ip>) <load-balancer>",
 			Short:                 "Add a target to a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/attach_to_network.go
+++ b/internal/cmd/loadbalancer/attach_to_network.go
@@ -15,7 +15,7 @@ import (
 var AttachToNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "attach-to-network [FLAGS] LOADBALANCER",
+			Use:                   "attach-to-network [--ip <ip>] <load-balancer> --network <network>",
 			Short:                 "Attach a Load Balancer to a Network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/attach_to_network.go
+++ b/internal/cmd/loadbalancer/attach_to_network.go
@@ -15,7 +15,7 @@ import (
 var AttachToNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "attach-to-network [--ip <ip>] <load-balancer> --network <network>",
+			Use:                   "attach-to-network [--ip <ip>] --network <network> <load-balancer>",
 			Short:                 "Attach a Load Balancer to a Network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/change_algorithm.go
+++ b/internal/cmd/loadbalancer/change_algorithm.go
@@ -15,7 +15,7 @@ import (
 var ChangeAlgorithmCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "change-algorithm <load-balancer> --algorithm-type <round_robin|least_connections>",
+			Use:                   "change-algorithm --algorithm-type <round_robin|least_connections> <load-balancer>",
 			Short:                 "Changes the algorithm of a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/change_algorithm.go
+++ b/internal/cmd/loadbalancer/change_algorithm.go
@@ -15,7 +15,7 @@ import (
 var ChangeAlgorithmCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "change-algorithm LOADBALANCER FLAGS",
+			Use:                   "change-algorithm <load-balancer> --algorithm-type <round_robin|least_connections>",
 			Short:                 "Changes the algorithm of a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/change_type.go
+++ b/internal/cmd/loadbalancer/change_type.go
@@ -15,7 +15,7 @@ import (
 var ChangeTypeCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "change-type [FLAGS] LOADBALANCER LOADBALANCERTYPE",
+			Use:   "change-type <load-balancer> <load-balancer-type>",
 			Short: "Change type of a Load Balancer",
 			Args:  cobra.ExactArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -14,7 +14,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "create [FLAGS]",
+			Use:                   "create [options] --name <name> --type <type>",
 			Short:                 "Create a Load Balancer",
 			Args:                  cobra.NoArgs,
 			TraverseChildren:      true,

--- a/internal/cmd/loadbalancer/delete_service.go
+++ b/internal/cmd/loadbalancer/delete_service.go
@@ -14,7 +14,7 @@ import (
 var DeleteServiceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "delete-service [FLAGS] LOADBALANCER",
+			Use:                   "delete-service <load-balancer> --listen-port <1-65535>",
 			Short:                 "Deletes a service from a Load Balancer",
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),
 			Args:                  cobra.RangeArgs(1, 2),

--- a/internal/cmd/loadbalancer/delete_service.go
+++ b/internal/cmd/loadbalancer/delete_service.go
@@ -14,7 +14,7 @@ import (
 var DeleteServiceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "delete-service <load-balancer> --listen-port <1-65535>",
+			Use:                   "delete-service --listen-port <1-65535> <load-balancer>",
 			Short:                 "Deletes a service from a Load Balancer",
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),
 			Args:                  cobra.RangeArgs(1, 2),

--- a/internal/cmd/loadbalancer/detach_from_network.go
+++ b/internal/cmd/loadbalancer/detach_from_network.go
@@ -15,7 +15,7 @@ import (
 var DetachFromNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "detach-from-network [FLAGS] LOADBALANCER",
+			Use:                   "detach-from-network <load-balancer> --network <network>",
 			Short:                 "Detach a Load Balancer from a Network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/detach_from_network.go
+++ b/internal/cmd/loadbalancer/detach_from_network.go
@@ -15,7 +15,7 @@ import (
 var DetachFromNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "detach-from-network <load-balancer> --network <network>",
+			Use:                   "detach-from-network --network <network> <load-balancer>",
 			Short:                 "Detach a Load Balancer from a Network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/disable_protection.go
+++ b/internal/cmd/loadbalancer/disable_protection.go
@@ -14,7 +14,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "disable-protection [FLAGS] LOADBALANCER PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <load-balancer> <protection-level>...",
 			Short: "Disable resource protection for a Load Balancer",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/loadbalancer/disable_public_interface.go
+++ b/internal/cmd/loadbalancer/disable_public_interface.go
@@ -14,7 +14,7 @@ import (
 var DisablePublicInterfaceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "disable-public-interface [options] <load-balancer>",
+			Use:                   "disable-public-interface <load-balancer>",
 			Short:                 "Disable the public interface of a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/disable_public_interface.go
+++ b/internal/cmd/loadbalancer/disable_public_interface.go
@@ -14,7 +14,7 @@ import (
 var DisablePublicInterfaceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "disable-public-interface [FLAGS] LOADBALANCER",
+			Use:                   "disable-public-interface [options] <load-balancer>",
 			Short:                 "Disable the public interface of a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/enable_protection.go
+++ b/internal/cmd/loadbalancer/enable_protection.go
@@ -60,7 +60,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "enable-protection [FLAGS] LOADBALANCER PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <load-balancer> <protection-level>...",
 			Short: "Enable resource protection for a Load Balancer",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/loadbalancer/enable_public_interface.go
+++ b/internal/cmd/loadbalancer/enable_public_interface.go
@@ -14,7 +14,7 @@ import (
 var EnablePublicInterfaceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "enable-public-interface [FLAGS] LOADBALANCER",
+			Use:                   "enable-public-interface <load-balancer>",
 			Short:                 "Enable the public interface of a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/metrics.go
+++ b/internal/cmd/loadbalancer/metrics.go
@@ -31,7 +31,7 @@ var metricTypeStrings = []string{
 var MetricsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   fmt.Sprintf("metrics [options] <load-balancer> (--type <%s>)...", strings.Join(metricTypeStrings, "|")),
+			Use:                   fmt.Sprintf("metrics [options] (--type <%s>)... <load-balancer>", strings.Join(metricTypeStrings, "|")),
 			Short:                 "[ALPHA] Metrics from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/metrics.go
+++ b/internal/cmd/loadbalancer/metrics.go
@@ -31,7 +31,7 @@ var metricTypeStrings = []string{
 var MetricsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   fmt.Sprintf("metrics [options] <load-balancer> --type <%s>", strings.Join(metricTypeStrings, "|")),
+			Use:                   fmt.Sprintf("metrics [options] <load-balancer> (--type <%s>)...", strings.Join(metricTypeStrings, "|")),
 			Short:                 "[ALPHA] Metrics from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/metrics.go
+++ b/internal/cmd/loadbalancer/metrics.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/guptarohit/asciigraph"
@@ -30,7 +31,7 @@ var metricTypeStrings = []string{
 var MetricsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "metrics [FLAGS] LOADBALANCER",
+			Use:                   fmt.Sprintf("metrics [options] <load-balancer> --type <%s>", strings.Join(metricTypeStrings, "|")),
 			Short:                 "[ALPHA] Metrics from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/remove_target.go
+++ b/internal/cmd/loadbalancer/remove_target.go
@@ -17,7 +17,7 @@ import (
 var RemoveTargetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-target LOADBALANCER FLAGS",
+			Use:                   "remove-target [options] <load-balancer>",
 			Short:                 "Remove a target from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -16,7 +16,7 @@ import (
 var UpdateServiceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "update-service [options] <load-balancer> --listen-port <1-65535>",
+			Use:                   "update-service [options] --listen-port <1-65535> <load-balancer>",
 			Short:                 "Updates a service from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -16,7 +16,7 @@ import (
 var UpdateServiceCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "update-service LOADBALANCER FLAGS",
+			Use:                   "update-service [options] <load-balancer> --listen-port <1-65535>",
 			Short:                 "Updates a service from a Load Balancer",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.LoadBalancer().Names)),

--- a/internal/cmd/network/add_route.go
+++ b/internal/cmd/network/add_route.go
@@ -16,7 +16,7 @@ import (
 var AddRouteCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-route <network> --destination <destination> --gateway <ip>",
+			Use:                   "add-route --destination <destination> --gateway <ip> <network>",
 			Short:                 "Add a route to a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/add_route.go
+++ b/internal/cmd/network/add_route.go
@@ -16,7 +16,7 @@ import (
 var AddRouteCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-route NETWORK FLAGS",
+			Use:                   "add-route <network> --destination <destination> --gateway <ip>",
 			Short:                 "Add a route to a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/add_subnet.go
+++ b/internal/cmd/network/add_subnet.go
@@ -16,7 +16,7 @@ import (
 var AddSubnetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-subnet NETWORK FLAGS",
+			Use:                   "add-subnet [options] <network> --type <cloud|server|vswitch> --network-zone <zone>",
 			Short:                 "Add a subnet to a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/add_subnet.go
+++ b/internal/cmd/network/add_subnet.go
@@ -16,7 +16,7 @@ import (
 var AddSubnetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "add-subnet [options] <network> --type <cloud|server|vswitch> --network-zone <zone>",
+			Use:                   "add-subnet [options] --type <cloud|server|vswitch> --network-zone <zone> <network>",
 			Short:                 "Add a subnet to a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/change_ip_range.go
+++ b/internal/cmd/network/change_ip_range.go
@@ -16,7 +16,7 @@ import (
 var ChangeIPRangeCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "change-ip-range <network> --ip-range <ip-range>",
+			Use:                   "change-ip-range --ip-range <ip-range> <network>",
 			Short:                 "Change the IP range of a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/change_ip_range.go
+++ b/internal/cmd/network/change_ip_range.go
@@ -16,7 +16,7 @@ import (
 var ChangeIPRangeCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "change-ip-range [FLAGS] NETWORK",
+			Use:                   "change-ip-range <network> --ip-range <ip-range>",
 			Short:                 "Change the IP range of a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/create.go
+++ b/internal/cmd/network/create.go
@@ -16,7 +16,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create [FLAGS]",
+			Use:   "create [options] --name <name> --ip-range <ip-range>",
 			Short: "Create a network",
 			Args:  cobra.NoArgs,
 		}

--- a/internal/cmd/network/disable_protection.go
+++ b/internal/cmd/network/disable_protection.go
@@ -14,7 +14,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "disable-protection [FLAGS] NETWORK PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <network> <protection-level>...",
 			Short: "Disable resource protection for a network",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/network/enable_protection.go
+++ b/internal/cmd/network/enable_protection.go
@@ -60,7 +60,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "enable-protection [FLAGS] NETWORK PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <network> <protection-level>...",
 			Short: "Enable resource protection for a network",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/network/expose_routes_to_vswitch.go
+++ b/internal/cmd/network/expose_routes_to_vswitch.go
@@ -15,7 +15,7 @@ import (
 var ExposeRoutesToVSwitchCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "expose-routes-to-vswitch [flags] network",
+			Use:                   "expose-routes-to-vswitch [--disable] <network>",
 			Short:                 "Expose routes to connected vSwitch",
 			Long:                  "Enabling this will expose routes to the connected vSwitch. Set the --disable flag to remove the exposed routes.",
 			Args:                  cobra.ExactArgs(1),

--- a/internal/cmd/network/remove_route.go
+++ b/internal/cmd/network/remove_route.go
@@ -16,7 +16,7 @@ import (
 var RemoveRouteCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-route NETWORK FLAGS",
+			Use:                   "remove-route <network> --destination <destination> --gateway <ip>",
 			Short:                 "Remove a route from a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/remove_route.go
+++ b/internal/cmd/network/remove_route.go
@@ -16,7 +16,7 @@ import (
 var RemoveRouteCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-route <network> --destination <destination> --gateway <ip>",
+			Use:                   "remove-route --destination <destination> --gateway <ip> <network>",
 			Short:                 "Remove a route from a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/remove_subnet.go
+++ b/internal/cmd/network/remove_subnet.go
@@ -16,7 +16,7 @@ import (
 var RemoveSubnetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-subnet <network> --ip-range <ip-range>",
+			Use:                   "remove-subnet --ip-range <ip-range> <network>",
 			Short:                 "Remove a subnet from a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/network/remove_subnet.go
+++ b/internal/cmd/network/remove_subnet.go
@@ -16,7 +16,7 @@ import (
 var RemoveSubnetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "remove-subnet NETWORK FLAGS",
+			Use:                   "remove-subnet <network> --ip-range <ip-range>",
 			Short:                 "Remove a subnet from a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Network().Names)),

--- a/internal/cmd/placementgroup/create.go
+++ b/internal/cmd/placementgroup/create.go
@@ -13,7 +13,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create FLAGS",
+			Use:   "create [options] --name <name> --type <type>",
 			Short: "Create a placement group",
 		}
 		cmd.Flags().String("name", "", "Name")

--- a/internal/cmd/primaryip/assign.go
+++ b/internal/cmd/primaryip/assign.go
@@ -15,7 +15,7 @@ import (
 var AssignCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "assign <primary-ip> --server <server>",
+			Use:   "assign --server <server> <primary-ip>",
 			Short: "Assign a Primary IP to an assignee (usually a server)",
 			Args:  cobra.ExactArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/primaryip/assign.go
+++ b/internal/cmd/primaryip/assign.go
@@ -15,7 +15,7 @@ import (
 var AssignCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "assign [FLAGS] PRIMARYIP",
+			Use:   "assign <primary-ip> --server <server>",
 			Short: "Assign a Primary IP to an assignee (usually a server)",
 			Args:  cobra.ExactArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -14,7 +14,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "create FLAGS",
+			Use:                   "create [options] --type <ipv4|ipv6> --name <name>",
 			Short:                 "Create a Primary IP",
 			Args:                  cobra.NoArgs,
 			TraverseChildren:      true,

--- a/internal/cmd/primaryip/disable_protection.go
+++ b/internal/cmd/primaryip/disable_protection.go
@@ -14,7 +14,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "disable-protection PRIMARYIP [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <primary-ip> [<protection-level>...]", // optional because of backwards compatibility
 			Short: "Disable Protection for a Primary IP",
 			Args:  cobra.MinimumNArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/primaryip/enable_protection.go
+++ b/internal/cmd/primaryip/enable_protection.go
@@ -58,7 +58,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "enable-protection PRIMARYIP [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <primary-ip> [<protection-level>...]", // optional because of backwards compatibility
 			Short: "Enable Protection for a Primary IP",
 			Args:  cobra.MinimumNArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/primaryip/unassign.go
+++ b/internal/cmd/primaryip/unassign.go
@@ -14,7 +14,7 @@ import (
 var UnAssignCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "unassign [FLAGS] PRIMARYIP",
+			Use:   "unassign <primary-ip>",
 			Short: "Unassign a Primary IP from an assignee (usually a server)",
 			Args:  cobra.ExactArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/server/add_to_placement_group.go
+++ b/internal/cmd/server/add_to_placement_group.go
@@ -14,7 +14,7 @@ import (
 var AddToPlacementGroupCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:               "add-to-placement-group [FLAGS] SERVER",
+			Use:               "add-to-placement-group <server> --placement-group <placement-group>",
 			Short:             "Add a server to a placement group",
 			Args:              cobra.ExactArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/add_to_placement_group.go
+++ b/internal/cmd/server/add_to_placement_group.go
@@ -14,7 +14,7 @@ import (
 var AddToPlacementGroupCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:               "add-to-placement-group <server> --placement-group <placement-group>",
+			Use:               "add-to-placement-group --placement-group <placement-group> <server>",
 			Short:             "Add a server to a placement group",
 			Args:              cobra.ExactArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/attach_iso.go
+++ b/internal/cmd/server/attach_iso.go
@@ -15,7 +15,7 @@ import (
 var AttachISOCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:              "attach-iso [FLAGS] SERVER ISO",
+			Use:              "attach-iso <server> <iso>",
 			Short:            "Attach an ISO to a server",
 			Args:             cobra.ExactArgs(2),
 			TraverseChildren: true,

--- a/internal/cmd/server/attach_to_network.go
+++ b/internal/cmd/server/attach_to_network.go
@@ -16,7 +16,7 @@ import (
 var AttachToNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "attach-to-network [options] <server> --network <network>",
+			Use:                   "attach-to-network [options] --network <network> <server>",
 			Short:                 "Attach a server to a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/attach_to_network.go
+++ b/internal/cmd/server/attach_to_network.go
@@ -16,7 +16,7 @@ import (
 var AttachToNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "attach-to-network [FLAGS] SERVER",
+			Use:                   "attach-to-network [options] <server> --network <network>",
 			Short:                 "Attach a server to a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/change_alias_ips.go
+++ b/internal/cmd/server/change_alias_ips.go
@@ -16,7 +16,7 @@ import (
 var ChangeAliasIPsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "change-alias-ips [FLAGS] SERVER",
+			Use:                   "change-alias-ips [options] <server> --network <network>",
 			Short:                 "Change a server's alias IPs in a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/change_alias_ips.go
+++ b/internal/cmd/server/change_alias_ips.go
@@ -16,7 +16,7 @@ import (
 var ChangeAliasIPsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "change-alias-ips [options] <server> --network <network>",
+			Use:                   "change-alias-ips [options] --network <network> <server>",
 			Short:                 "Change a server's alias IPs in a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/change_type.go
+++ b/internal/cmd/server/change_type.go
@@ -15,7 +15,7 @@ import (
 var ChangeTypeCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "change-type [FLAGS] SERVER SERVERTYPE",
+			Use:   "change-type [--keep-disk] <server> <server-type>",
 			Short: "Change type of a server",
 			Args:  cobra.ExactArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -36,7 +36,7 @@ type createResultSchema struct {
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create FLAGS",
+			Use:   "create [options] --name <name> --type <server-type> --image <image>",
 			Short: "Create a server",
 		}
 

--- a/internal/cmd/server/create_image.go
+++ b/internal/cmd/server/create_image.go
@@ -15,7 +15,7 @@ import (
 var CreateImageCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create-image [FLAGS] SERVER",
+			Use:   "create-image [options] <server>",
 			Short: "Create an image from a server",
 			Args:  cobra.ExactArgs(1),
 		}

--- a/internal/cmd/server/create_image.go
+++ b/internal/cmd/server/create_image.go
@@ -15,7 +15,7 @@ import (
 var CreateImageCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create-image [options] <server> --type <snapshot|backup>",
+			Use:   "create-image [options] --type <snapshot|backup> <server>",
 			Short: "Create an image from a server",
 			Args:  cobra.ExactArgs(1),
 		}

--- a/internal/cmd/server/create_image.go
+++ b/internal/cmd/server/create_image.go
@@ -15,7 +15,7 @@ import (
 var CreateImageCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create-image [options] <server>",
+			Use:   "create-image [options] <server> --type <snapshot|backup>",
 			Short: "Create an image from a server",
 			Args:  cobra.ExactArgs(1),
 		}

--- a/internal/cmd/server/detach_from_network.go
+++ b/internal/cmd/server/detach_from_network.go
@@ -15,7 +15,7 @@ import (
 var DetachFromNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "detach-from-network <server> --network <network>",
+			Use:                   "detach-from-network --network <network> <server>",
 			Short:                 "Detach a server from a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/detach_from_network.go
+++ b/internal/cmd/server/detach_from_network.go
@@ -15,7 +15,7 @@ import (
 var DetachFromNetworkCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "detach-from-network [FLAGS] SERVER",
+			Use:                   "detach-from-network <server> --network <network>",
 			Short:                 "Detach a server from a network",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/detach_iso.go
+++ b/internal/cmd/server/detach_iso.go
@@ -14,7 +14,7 @@ import (
 var DetachISOCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "detach-iso [FLAGS] SERVER",
+			Use:                   "detach-iso <server>",
 			Short:                 "Detach an ISO from a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/disable_backup.go
+++ b/internal/cmd/server/disable_backup.go
@@ -14,7 +14,7 @@ import (
 var DisableBackupCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "disable-backup [FLAGS] SERVER",
+			Use:                   "disable-backup <server>",
 			Short:                 "Disable backup for a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/disable_protection.go
+++ b/internal/cmd/server/disable_protection.go
@@ -14,7 +14,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "disable-protection [FLAGS] SERVER PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <server> <protection-level>...",
 			Short: "Disable resource protection for a server",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/server/disable_rescue.go
+++ b/internal/cmd/server/disable_rescue.go
@@ -14,7 +14,7 @@ import (
 var DisableRescueCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "disable-rescue [FLAGS] SERVER",
+			Use:                   "disable-rescue <server>",
 			Short:                 "Disable rescue for a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/enable_backup.go
+++ b/internal/cmd/server/enable_backup.go
@@ -14,7 +14,7 @@ import (
 var EnableBackupCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "enable-backup [FLAGS] SERVER",
+			Use:                   "enable-backup <server>",
 			Short:                 "Enable backup for a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/enable_protection.go
+++ b/internal/cmd/server/enable_protection.go
@@ -62,7 +62,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "enable-protection [FLAGS] SERVER PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <server> <protection-level>...",
 			Short: "Enable resource protection for a server",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/server/enable_rescue.go
+++ b/internal/cmd/server/enable_rescue.go
@@ -15,7 +15,7 @@ import (
 var EnableRescueCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "enable-rescue [FLAGS] SERVER",
+			Use:                   "enable-rescue [options] <server>",
 			Short:                 "Enable rescue for a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/ip.go
+++ b/internal/cmd/server/ip.go
@@ -14,7 +14,7 @@ import (
 var IPCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "ip SERVER FLAGS",
+			Use:                   "ip [--ipv6] <server>",
 			Short:                 "Print a server's IP address",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/metrics.go
+++ b/internal/cmd/server/metrics.go
@@ -30,7 +30,7 @@ var metricTypeStrings = []string{
 var MetricsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   fmt.Sprintf("metrics [options] <server> (--type <%s>)...", strings.Join(metricTypeStrings, "|")),
+			Use:                   fmt.Sprintf("metrics [options] (--type <%s>)... <server>", strings.Join(metricTypeStrings, "|")),
 			Short:                 "[ALPHA] Metrics from a Server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/metrics.go
+++ b/internal/cmd/server/metrics.go
@@ -29,7 +29,7 @@ var metricTypeStrings = []string{
 var MetricsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "metrics [FLAGS] SERVER",
+			Use:                   "metrics [options] <server>",
 			Short:                 "[ALPHA] Metrics from a Server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/metrics.go
+++ b/internal/cmd/server/metrics.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/guptarohit/asciigraph"
@@ -29,7 +30,7 @@ var metricTypeStrings = []string{
 var MetricsCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "metrics [options] <server>",
+			Use:                   fmt.Sprintf("metrics [options] <server> (--type <%s>)...", strings.Join(metricTypeStrings, "|")),
 			Short:                 "[ALPHA] Metrics from a Server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/poweroff.go
+++ b/internal/cmd/server/poweroff.go
@@ -14,7 +14,7 @@ import (
 var PoweroffCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "poweroff [FLAGS] SERVER",
+			Use:                   "poweroff <server>",
 			Short:                 "Poweroff a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/poweron.go
+++ b/internal/cmd/server/poweron.go
@@ -14,7 +14,7 @@ import (
 var PoweronCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "poweron [FLAGS] SERVER",
+			Use:                   "poweron <server>",
 			Short:                 "Poweron a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/reboot.go
+++ b/internal/cmd/server/reboot.go
@@ -14,7 +14,7 @@ import (
 var RebootCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "reboot [FLAGS] SERVER",
+			Use:                   "reboot <server>",
 			Short:                 "Reboot a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/rebuild.go
+++ b/internal/cmd/server/rebuild.go
@@ -16,7 +16,7 @@ import (
 var RebuildCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "rebuild [FLAGS] SERVER",
+			Use:                   "rebuild [--allow-deprecated-image] <server> --image <image>",
 			Short:                 "Rebuild a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/rebuild.go
+++ b/internal/cmd/server/rebuild.go
@@ -16,7 +16,7 @@ import (
 var RebuildCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "rebuild [--allow-deprecated-image] <server> --image <image>",
+			Use:                   "rebuild [--allow-deprecated-image] --image <image> <server>",
 			Short:                 "Rebuild a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/remove_from_placement_group.go
+++ b/internal/cmd/server/remove_from_placement_group.go
@@ -14,7 +14,7 @@ import (
 var RemoveFromPlacementGroupCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:               "remove-from-placement-group SERVER",
+			Use:               "remove-from-placement-group <server>",
 			Short:             "Removes a server from a placement group",
 			Args:              cobra.ExactArgs(1),
 			ValidArgsFunction: cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/request_console.go
+++ b/internal/cmd/server/request_console.go
@@ -16,7 +16,7 @@ import (
 var RequestConsoleCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "request-console [FLAGS] SERVER",
+			Use:                   "request-console [options] <server>",
 			Short:                 "Request a WebSocket VNC console for a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/reset.go
+++ b/internal/cmd/server/reset.go
@@ -14,7 +14,7 @@ import (
 var ResetCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "reset [FLAGS] SERVER",
+			Use:                   "reset [options] <server>",
 			Short:                 "Reset a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/reset_password.go
+++ b/internal/cmd/server/reset_password.go
@@ -14,7 +14,7 @@ import (
 var ResetPasswordCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "reset-password [FLAGS] SERVER",
+			Use:                   "reset-password <server>",
 			Short:                 "Reset the root password of a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -23,7 +23,7 @@ var ShutdownCmd = base.Cmd{
 			"server to shut down before returning."
 
 		cmd := &cobra.Command{
-			Use:                   "shutdown [FLAGS] SERVER",
+			Use:                   "shutdown [options] <server>",
 			Short:                 "Shutdown a server",
 			Long:                  description,
 			Args:                  cobra.ExactArgs(1),

--- a/internal/cmd/server/ssh.go
+++ b/internal/cmd/server/ssh.go
@@ -18,7 +18,7 @@ import (
 var SSHCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "ssh [FLAGS] SERVER [COMMAND...]",
+			Use:                   "ssh [options] <server> [command]",
 			Short:                 "Spawn an SSH connection for the server",
 			Args:                  cobra.MinimumNArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),

--- a/internal/cmd/sshkey/create.go
+++ b/internal/cmd/sshkey/create.go
@@ -16,7 +16,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:   "create FLAGS",
+			Use:   "create [options] --name <name> (--public-key <key> | --public-key-from-file <file>)",
 			Short: "Create a SSH key",
 			Args:  cobra.NoArgs,
 		}

--- a/internal/cmd/volume/attach.go
+++ b/internal/cmd/volume/attach.go
@@ -15,7 +15,7 @@ import (
 var AttachCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "attach [FLAGS] VOLUME",
+			Use:                   "attach [--automount] <volume> --server <server>",
 			Short:                 "Attach a volume to a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Volume().Names)),

--- a/internal/cmd/volume/attach.go
+++ b/internal/cmd/volume/attach.go
@@ -15,7 +15,7 @@ import (
 var AttachCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "attach [--automount] <volume> --server <server>",
+			Use:                   "attach [--automount] --server <server> <volume>",
 			Short:                 "Attach a volume to a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Volume().Names)),

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -17,7 +17,7 @@ import (
 var CreateCmd = base.CreateCmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "create FLAGS",
+			Use:                   "create [options] --name <name> --size <size>",
 			Short:                 "Create a volume",
 			Args:                  cobra.NoArgs,
 			TraverseChildren:      true,

--- a/internal/cmd/volume/detach.go
+++ b/internal/cmd/volume/detach.go
@@ -14,7 +14,7 @@ import (
 var DetachCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:                   "detach [FLAGS] VOLUME",
+			Use:                   "detach <volume>",
 			Short:                 "Detach a volume",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Volume().Names)),

--- a/internal/cmd/volume/disable_protection.go
+++ b/internal/cmd/volume/disable_protection.go
@@ -14,7 +14,7 @@ import (
 var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "disable-protection [FLAGS] VOLUME PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "disable-protection <volume> <protection-level>...",
 			Short: "Disable resource protection for a volume",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/volume/enable_protection.go
+++ b/internal/cmd/volume/enable_protection.go
@@ -60,7 +60,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		return &cobra.Command{
-			Use:   "enable-protection [FLAGS] VOLUME PROTECTIONLEVEL [PROTECTIONLEVEL...]",
+			Use:   "enable-protection <volume> <protection-level>...",
 			Short: "Enable resource protection for a volume",
 			Args:  cobra.MinimumNArgs(2),
 			ValidArgsFunction: cmpl.SuggestArgs(

--- a/internal/cmd/volume/resize.go
+++ b/internal/cmd/volume/resize.go
@@ -14,7 +14,7 @@ import (
 var ResizeCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "resize [FLAGS] VOLUME",
+			Use:                   "resize <volume> --size <size>",
 			Short:                 "Resize a volume",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Volume().Names)),

--- a/internal/cmd/volume/resize.go
+++ b/internal/cmd/volume/resize.go
@@ -14,7 +14,7 @@ import (
 var ResizeCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "resize <volume> --size <size>",
+			Use:                   "resize --size <size> <volume>",
 			Short:                 "Resize a volume",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Volume().Names)),


### PR DESCRIPTION
This PR makes command usage documentation consistent by enforcing [docopt](http://docopt.org/) rules and also defining and documenting other additional conventions.

Fixes #708