### PR TITLE
feat!: remove deprecated backup window flag

### DIFF
--- a/internal/cmd/server/enable_backup.go
+++ b/internal/cmd/server/enable_backup.go
@@ -20,9 +20,6 @@ var EnableBackupCmd = base.Cmd{
 			TraverseChildren:      true,
 			DisableFlagsInUseLine: true,
 		}
-		cmd.Flags().String(
-			"window", "",
-			"(deprecated) The time window for the daily backup to run. All times are in UTC. 22-02 means that the backup will be started between 10 PM and 2 AM.")
 		return cmd
 	},
 	Run: func(s state.State, cmd *cobra.Command, args []string) error {
@@ -33,11 +30,6 @@ var EnableBackupCmd = base.Cmd{
 		}
 		if server == nil {
 			return fmt.Errorf("server not found: %s", idOrName)
-		}
-
-		window, _ := cmd.Flags().GetString("window")
-		if window != "" {
-			cmd.Print("[WARN] The ability to specify a backup window when enabling backups has been removed. Ignoring flag.\n")
 		}
 
 		action, _, err := s.Client().Server().EnableBackup(s, server, "")


### PR DESCRIPTION
This flag has been deprecated (and not working) since 2018: https://github.com/hetznercloud/cli/pull/147