### PR TITLE
feat(server): allow JSON & YAML output in reset-password

### DIFF
--- a/internal/cmd/server/reset_password.go
+++ b/internal/cmd/server/reset_password.go
@@ -7,22 +7,28 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/cmd/output"
+	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 )
 
 var ResetPasswordCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
-		return &cobra.Command{
-			Use:                   "reset-password <server>",
+		cmd := &cobra.Command{
+			Use:                   "reset-password [options] <server>",
 			Short:                 "Reset the root password of a server",
 			Args:                  cobra.ExactArgs(1),
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),
 			TraverseChildren:      true,
 			DisableFlagsInUseLine: true,
 		}
+		output.AddFlag(cmd, output.OptionJSON(), output.OptionYAML())
+		return cmd
 	},
 	Run: func(s state.State, cmd *cobra.Command, args []string) error {
+		outputFlags := output.FlagsForCommand(cmd)
+
 		idOrName := args[0]
 		server, _, err := s.Client().Server().Get(s, idOrName)
 		if err != nil {
@@ -39,6 +45,16 @@ var ResetPasswordCmd = base.Cmd{
 
 		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
 			return err
+		}
+
+		if outputFlags.IsSet("json") || outputFlags.IsSet("yaml") {
+			schema := make(map[string]interface{})
+			schema["root_password"] = result.RootPassword
+			if outputFlags.IsSet("json") {
+				return util.DescribeJSON(schema)
+			} else {
+				return util.DescribeYAML(schema)
+			}
 		}
 
 		cmd.Printf("Password of server %d reset to: %s\n", server.ID, result.RootPassword)


### PR DESCRIPTION
This PR adds the ability to output the root password after a password reset in JSON or YAML format.

Closes #715