### PR TITLE
fix(firewall): missing error when not setting port for tcp rule

### DIFF
--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -71,10 +71,9 @@ var AddRuleCmd = base.Cmd{
 		}
 
 		switch rule.Protocol {
-		case hcloud.FirewallRuleProtocolTCP:
-		case hcloud.FirewallRuleProtocolUDP:
+		case hcloud.FirewallRuleProtocolUDP, hcloud.FirewallRuleProtocolTCP:
 			if port == "" {
-				return fmt.Errorf("port is required")
+				return fmt.Errorf("port is required (--port)")
 			}
 		default:
 			if port != "" {

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -70,10 +70,9 @@ var DeleteRuleCmd = base.Cmd{
 		}
 
 		switch rule.Protocol {
-		case hcloud.FirewallRuleProtocolTCP:
-		case hcloud.FirewallRuleProtocolUDP:
+		case hcloud.FirewallRuleProtocolTCP, hcloud.FirewallRuleProtocolUDP:
 			if port == "" {
-				return fmt.Errorf("port is required")
+				return fmt.Errorf("port is required (--port)")
 			}
 		default:
 			if port != "" {


### PR DESCRIPTION
Switch cases don't fall through by default in Go, which lead to there being no user-friendly error emitted when the user attempts to create a TCP rule without specifying a port.

Related to #733