### PR TITLE
feat: new action waiting progress 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/boumenot/gocover-cobertura v1.2.0
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/dustin/go-humanize v1.0.1
+	github.com/fatih/color v1.16.0
 	github.com/fatih/structs v1.1.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/golang/mock v1.6.0
@@ -24,7 +25,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.16.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/internal/cmd/base/set_rdns.go
+++ b/internal/cmd/base/set_rdns.go
@@ -73,7 +73,7 @@ func (rc *SetRdnsCmd) Run(s state.State, cmd *cobra.Command, args []string) erro
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/certificate/create.go
+++ b/internal/cmd/certificate/create.go
@@ -129,7 +129,7 @@ func createManaged(s state.State, cmd *cobra.Command) (*hcloud.Certificate, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := s.ActionProgress(cmd, s, res.Action); err != nil {
+	if err := s.WaitForActions(cmd, s, res.Action); err != nil {
 		return nil, err
 	}
 	defer cmd.Printf("Certificate %d created\n", res.Certificate.ID)

--- a/internal/cmd/certificate/create_test.go
+++ b/internal/cmd/certificate/create_test.go
@@ -42,7 +42,7 @@ func TestCreateManaged(t *testing.T) {
 			Action: &hcloud.Action{ID: 321},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 	fx.Client.CertificateClient.EXPECT().
 		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.Certificate{
@@ -96,7 +96,7 @@ func TestCreateManagedJSON(t *testing.T) {
 			Action: &hcloud.Action{ID: 321},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 	fx.Client.CertificateClient.EXPECT().
 		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.Certificate{

--- a/internal/cmd/context/create.go
+++ b/internal/cmd/context/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/cli/internal/state/config"
+	"github.com/hetznercloud/cli/internal/ui"
 )
 
 func newCreateCommand(s state.State) *cobra.Command {
@@ -30,7 +31,7 @@ func newCreateCommand(s state.State) *cobra.Command {
 
 func runCreate(s state.State, cmd *cobra.Command, args []string) error {
 	cfg := s.Config()
-	if !state.StdoutIsTerminal() {
+	if !ui.StdoutIsTerminal() {
 		return errors.New("context create is an interactive command")
 	}
 

--- a/internal/cmd/firewall/add_rule.go
+++ b/internal/cmd/firewall/add_rule.go
@@ -110,7 +110,7 @@ var AddRuleCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.WaitForActions(cmd, s, actions); err != nil {
+		if err := s.WaitForActions(cmd, s, actions...); err != nil {
 			return err
 		}
 

--- a/internal/cmd/firewall/apply_to_resource.go
+++ b/internal/cmd/firewall/apply_to_resource.go
@@ -81,7 +81,7 @@ var ApplyToResourceCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.WaitForActions(cmd, s, actions); err != nil {
+		if err := s.WaitForActions(cmd, s, actions...); err != nil {
 			return err
 		}
 		cmd.Printf("Firewall %d applied\n", firewall.ID)

--- a/internal/cmd/firewall/create.go
+++ b/internal/cmd/firewall/create.go
@@ -82,7 +82,7 @@ var CreateCmd = base.CreateCmd{
 			return nil, nil, err
 		}
 
-		if err := s.WaitForActions(cmd, s, result.Actions); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Actions...); err != nil {
 			return nil, nil, err
 		}
 

--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -118,7 +118,7 @@ var DeleteRuleCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.WaitForActions(cmd, s, actions); err != nil {
+		if err := s.WaitForActions(cmd, s, actions...); err != nil {
 			return err
 		}
 		cmd.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)

--- a/internal/cmd/firewall/remove_from_resource.go
+++ b/internal/cmd/firewall/remove_from_resource.go
@@ -80,7 +80,7 @@ var RemoveFromResourceCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.WaitForActions(cmd, s, actions); err != nil {
+		if err := s.WaitForActions(cmd, s, actions...); err != nil {
 			return err
 		}
 		cmd.Printf("Firewall %d applied\n", firewall.ID)

--- a/internal/cmd/firewall/replace_rules.go
+++ b/internal/cmd/firewall/replace_rules.go
@@ -93,7 +93,7 @@ var ReplaceRulesCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.WaitForActions(cmd, s, actions); err != nil {
+		if err := s.WaitForActions(cmd, s, actions...); err != nil {
 			return err
 		}
 		cmd.Printf("Firewall Rules for Firewall %d updated\n", firewall.ID)

--- a/internal/cmd/floatingip/assign.go
+++ b/internal/cmd/floatingip/assign.go
@@ -48,7 +48,7 @@ var AssignCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/floatingip/assign_test.go
+++ b/internal/cmd/floatingip/assign_test.go
@@ -28,7 +28,7 @@ func TestAssign(t *testing.T) {
 		Assign(gomock.Any(), &hcloud.FloatingIP{ID: 123}, &hcloud.Server{ID: 456}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"my-ip", "my-server"})

--- a/internal/cmd/floatingip/create.go
+++ b/internal/cmd/floatingip/create.go
@@ -94,7 +94,7 @@ var CreateCmd = base.CreateCmd{
 		}
 
 		if result.Action != nil {
-			if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+			if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/internal/cmd/floatingip/create_test.go
+++ b/internal/cmd/floatingip/create_test.go
@@ -116,14 +116,14 @@ func TestCreateProtection(t *testing.T) {
 				ID: 321,
 			},
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
 
 	fx.Client.FloatingIPClient.EXPECT().
 		ChangeProtection(gomock.Any(), floatingIp, hcloud.FloatingIPChangeProtectionOpts{
 			Delete: hcloud.Ptr(true),
 		}).
 		Return(&hcloud.Action{ID: 333}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 333}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 333}).Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"--name", "myFloatingIP", "--type", "ipv4", "--home-location", "fsn1", "--enable-protection", "delete"})
 

--- a/internal/cmd/floatingip/disable_protection_test.go
+++ b/internal/cmd/floatingip/disable_protection_test.go
@@ -27,7 +27,7 @@ func TestDisableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"test", "delete"})

--- a/internal/cmd/floatingip/enable_protection.go
+++ b/internal/cmd/floatingip/enable_protection.go
@@ -45,7 +45,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/floatingip/enable_protection_test.go
+++ b/internal/cmd/floatingip/enable_protection_test.go
@@ -27,7 +27,7 @@ func TestEnableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"test", "delete"})

--- a/internal/cmd/floatingip/set_rdns_test.go
+++ b/internal/cmd/floatingip/set_rdns_test.go
@@ -31,7 +31,7 @@ func TestSetRDNS(t *testing.T) {
 		ChangeDNSPtr(gomock.Any(), floatingIP, floatingIP.IP, hcloud.Ptr("example.com")).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"--hostname", "example.com", "test"})

--- a/internal/cmd/floatingip/unassign.go
+++ b/internal/cmd/floatingip/unassign.go
@@ -36,7 +36,7 @@ var UnassignCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/floatingip/unassign_test.go
+++ b/internal/cmd/floatingip/unassign_test.go
@@ -25,7 +25,7 @@ func TestUnassign(t *testing.T) {
 		Unassign(gomock.Any(), &hcloud.FloatingIP{ID: 123}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"my-ip"})

--- a/internal/cmd/image/disable_protection_test.go
+++ b/internal/cmd/image/disable_protection_test.go
@@ -24,7 +24,7 @@ func TestDisableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "delete"})

--- a/internal/cmd/image/enable_protection.go
+++ b/internal/cmd/image/enable_protection.go
@@ -47,7 +47,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/image/enable_protection_test.go
+++ b/internal/cmd/image/enable_protection_test.go
@@ -24,7 +24,7 @@ func TestEnableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "delete"})

--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -208,7 +208,7 @@ var AddServiceCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Service was added to Load Balancer %d\n", loadBalancer.ID)

--- a/internal/cmd/loadbalancer/add_service_test.go
+++ b/internal/cmd/loadbalancer/add_service_test.go
@@ -87,7 +87,7 @@ func TestAddServiceWithHealthCheck(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{

--- a/internal/cmd/loadbalancer/add_service_test.go
+++ b/internal/cmd/loadbalancer/add_service_test.go
@@ -35,7 +35,7 @@ func TestAddService(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--protocol", "http", "--listen-port", "80", "--destination-port", "8080"})

--- a/internal/cmd/loadbalancer/add_target.go
+++ b/internal/cmd/loadbalancer/add_target.go
@@ -95,7 +95,7 @@ var AddTargetCmd = base.Cmd{
 			return fmt.Errorf("specify one of --server, --label-selector, or --ip")
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Target added to Load Balancer %d\n", loadBalancer.ID)

--- a/internal/cmd/loadbalancer/add_target_test.go
+++ b/internal/cmd/loadbalancer/add_target_test.go
@@ -32,7 +32,7 @@ func TestAddTargetServer(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--server", "my-server"})
@@ -61,7 +61,7 @@ func TestAddTargetLabelSelector(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--label-selector", "my-label"})
@@ -89,7 +89,7 @@ func TestAddTargetIP(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--ip", "192.168.2.1"})

--- a/internal/cmd/loadbalancer/attach_to_network.go
+++ b/internal/cmd/loadbalancer/attach_to_network.go
@@ -61,7 +61,7 @@ var AttachToNetworkCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/loadbalancer/attach_to_network_test.go
+++ b/internal/cmd/loadbalancer/attach_to_network_test.go
@@ -30,7 +30,7 @@ func TestAttachToNetwork(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--network", "my-network"})

--- a/internal/cmd/loadbalancer/change_algorithm.go
+++ b/internal/cmd/loadbalancer/change_algorithm.go
@@ -46,7 +46,7 @@ var ChangeAlgorithmCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Algorithm for Load Balancer %d was changed\n", loadBalancer.ID)

--- a/internal/cmd/loadbalancer/change_algorithm_test.go
+++ b/internal/cmd/loadbalancer/change_algorithm_test.go
@@ -27,7 +27,7 @@ func TestChangeAlgorithm(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--algorithm-type", "least_connections"})

--- a/internal/cmd/loadbalancer/change_type.go
+++ b/internal/cmd/loadbalancer/change_type.go
@@ -52,7 +52,7 @@ var ChangeTypeCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/loadbalancer/change_type_test.go
+++ b/internal/cmd/loadbalancer/change_type_test.go
@@ -32,7 +32,7 @@ func TestChangeType(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "lb21"})

--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -80,7 +80,7 @@ var CreateCmd = base.CreateCmd{
 			return nil, nil, err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return nil, nil, err
 		}
 		loadBalancer, _, err := s.Client().LoadBalancer().GetByID(s, result.LoadBalancer.ID)

--- a/internal/cmd/loadbalancer/create_test.go
+++ b/internal/cmd/loadbalancer/create_test.go
@@ -35,7 +35,7 @@ func TestCreate(t *testing.T) {
 			LoadBalancer: &hcloud.LoadBalancer{ID: 123},
 			Action:       &hcloud.Action{ID: 321},
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
 	fx.Client.LoadBalancerClient.EXPECT().
 		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.LoadBalancer{
@@ -98,7 +98,7 @@ func TestCreateJSON(t *testing.T) {
 			LoadBalancer: lb,
 			Action:       &hcloud.Action{ID: 321},
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
 	fx.Client.LoadBalancerClient.EXPECT().
 		GetByID(gomock.Any(), int64(123)).
 		Return(lb, nil, nil)
@@ -142,7 +142,7 @@ func TestCreateProtection(t *testing.T) {
 			LoadBalancer: &hcloud.LoadBalancer{ID: 123},
 			Action:       &hcloud.Action{ID: 321},
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)
 	fx.Client.LoadBalancerClient.EXPECT().
 		GetByID(gomock.Any(), int64(123)).
 		Return(loadBalancer, nil, nil)
@@ -151,7 +151,7 @@ func TestCreateProtection(t *testing.T) {
 			Delete: hcloud.Ptr(true),
 		}).
 		Return(&hcloud.Action{ID: 333}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 333}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 333}).Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"--name", "myLoadBalancer", "--type", "lb11", "--location", "fsn1", "--enable-protection", "delete"})
 

--- a/internal/cmd/loadbalancer/detach_from_network.go
+++ b/internal/cmd/loadbalancer/detach_from_network.go
@@ -52,7 +52,7 @@ var DetachFromNetworkCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/loadbalancer/detach_from_network_test.go
+++ b/internal/cmd/loadbalancer/detach_from_network_test.go
@@ -30,7 +30,7 @@ func TestDetachFromNetwork(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--network", "my-network"})

--- a/internal/cmd/loadbalancer/disable_protection_test.go
+++ b/internal/cmd/loadbalancer/disable_protection_test.go
@@ -27,7 +27,7 @@ func TestDisableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "delete"})

--- a/internal/cmd/loadbalancer/disable_public_interface.go
+++ b/internal/cmd/loadbalancer/disable_public_interface.go
@@ -36,7 +36,7 @@ var DisablePublicInterfaceCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/loadbalancer/disable_public_interface_test.go
+++ b/internal/cmd/loadbalancer/disable_public_interface_test.go
@@ -25,7 +25,7 @@ func TestDisablePublicInterface(t *testing.T) {
 		DisablePublicInterface(gomock.Any(), &hcloud.LoadBalancer{ID: 123}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123"})

--- a/internal/cmd/loadbalancer/enable_protection.go
+++ b/internal/cmd/loadbalancer/enable_protection.go
@@ -45,7 +45,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/loadbalancer/enable_protection_test.go
+++ b/internal/cmd/loadbalancer/enable_protection_test.go
@@ -27,7 +27,7 @@ func TestEnableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "delete"})

--- a/internal/cmd/loadbalancer/enable_public_interface.go
+++ b/internal/cmd/loadbalancer/enable_public_interface.go
@@ -36,7 +36,7 @@ var EnablePublicInterfaceCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/loadbalancer/enable_public_interface_test.go
+++ b/internal/cmd/loadbalancer/enable_public_interface_test.go
@@ -25,7 +25,7 @@ func TestEnablePublicInterface(t *testing.T) {
 		EnablePublicInterface(gomock.Any(), &hcloud.LoadBalancer{ID: 123}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123"})

--- a/internal/cmd/loadbalancer/remove_target.go
+++ b/internal/cmd/loadbalancer/remove_target.go
@@ -87,7 +87,7 @@ var RemoveTargetCmd = base.Cmd{
 			return fmt.Errorf("specify one of --server, --label-selector, or --ip")
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Target removed from Load Balancer %d\n", loadBalancer.ID)

--- a/internal/cmd/loadbalancer/remove_target_test.go
+++ b/internal/cmd/loadbalancer/remove_target_test.go
@@ -29,7 +29,7 @@ func TestRemoveTargetServer(t *testing.T) {
 		RemoveServerTarget(gomock.Any(), &hcloud.LoadBalancer{ID: 123}, &hcloud.Server{ID: 321}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--server", "my-server"})
@@ -55,7 +55,7 @@ func TestRemoveTargetLabelSelector(t *testing.T) {
 		RemoveLabelSelectorTarget(gomock.Any(), &hcloud.LoadBalancer{ID: 123}, "my-label").
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--label-selector", "my-label"})
@@ -81,7 +81,7 @@ func TestRemoveTargetIP(t *testing.T) {
 		RemoveIPTarget(gomock.Any(), &hcloud.LoadBalancer{ID: 123}, net.ParseIP("192.168.2.1")).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--ip", "192.168.2.1"})

--- a/internal/cmd/loadbalancer/set_rdns_test.go
+++ b/internal/cmd/loadbalancer/set_rdns_test.go
@@ -35,7 +35,7 @@ func TestSetRDNS(t *testing.T) {
 		ChangeDNSPtr(gomock.Any(), loadBalancer, loadBalancer.PublicNet.IPv4.IP, hcloud.Ptr("example.com")).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"--hostname", "example.com", "test"})

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -162,7 +162,7 @@ var UpdateServiceCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Service %d on Load Balancer %d was updated\n", listenPort, loadBalancer.ID)

--- a/internal/cmd/loadbalancer/update_service_test.go
+++ b/internal/cmd/loadbalancer/update_service_test.go
@@ -51,7 +51,7 @@ func TestUpdateService(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 321}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{

--- a/internal/cmd/network/add_route.go
+++ b/internal/cmd/network/add_route.go
@@ -54,7 +54,7 @@ var AddRouteCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Route added to network %d\n", network.ID)

--- a/internal/cmd/network/add_route_test.go
+++ b/internal/cmd/network/add_route_test.go
@@ -34,7 +34,7 @@ func TestAddRoute(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 456}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
+		WaitForActions(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--destination", "10.0.0.0/24", "--gateway", "10.0.0.1"})

--- a/internal/cmd/network/add_subnet.go
+++ b/internal/cmd/network/add_subnet.go
@@ -69,7 +69,7 @@ var AddSubnetCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Subnet added to network %d\n", network.ID)

--- a/internal/cmd/network/add_subnet_test.go
+++ b/internal/cmd/network/add_subnet_test.go
@@ -35,7 +35,7 @@ func TestAddSubnet(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 456}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
+		WaitForActions(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--type", "cloud", "--network-zone", "eu-central", "--ip-range", "10.0.0.0/24"})

--- a/internal/cmd/network/change_ip_range.go
+++ b/internal/cmd/network/change_ip_range.go
@@ -48,7 +48,7 @@ var ChangeIPRangeCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("IP range of network %d changed\n", network.ID)

--- a/internal/cmd/network/change_ip_range_test.go
+++ b/internal/cmd/network/change_ip_range_test.go
@@ -31,7 +31,7 @@ func TestChangeIPRange(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 456}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
+		WaitForActions(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--ip-range", "10.0.0.0/24"})

--- a/internal/cmd/network/create_test.go
+++ b/internal/cmd/network/create_test.go
@@ -108,7 +108,7 @@ func TestCreateProtection(t *testing.T) {
 			Delete: hcloud.Ptr(true),
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"--name", "myNetwork", "--ip-range", "10.0.0.0/24", "--enable-protection", "delete"})
 

--- a/internal/cmd/network/disable_protection_test.go
+++ b/internal/cmd/network/disable_protection_test.go
@@ -29,7 +29,7 @@ func TestDisableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"myNetwork", "delete"}

--- a/internal/cmd/network/enable_protection.go
+++ b/internal/cmd/network/enable_protection.go
@@ -45,7 +45,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/network/enable_protection_test.go
+++ b/internal/cmd/network/enable_protection_test.go
@@ -29,7 +29,7 @@ func TestEnableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"myNetwork", "delete"}

--- a/internal/cmd/network/remove_route.go
+++ b/internal/cmd/network/remove_route.go
@@ -53,7 +53,7 @@ var RemoveRouteCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Route removed from network %d\n", network.ID)

--- a/internal/cmd/network/remove_route_test.go
+++ b/internal/cmd/network/remove_route_test.go
@@ -34,7 +34,7 @@ func TestRemoveRoute(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 456}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
+		WaitForActions(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--destination", "10.0.0.0/24", "--gateway", "10.0.0.1"})

--- a/internal/cmd/network/remove_subnet.go
+++ b/internal/cmd/network/remove_subnet.go
@@ -46,7 +46,7 @@ var RemoveSubnetCmd = base.Cmd{
 		if err != nil {
 			return err
 		}
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 		cmd.Printf("Subnet %s removed from network %d\n", ipRange.String(), network.ID)

--- a/internal/cmd/network/remove_subnet_test.go
+++ b/internal/cmd/network/remove_subnet_test.go
@@ -33,7 +33,7 @@ func TestRemoveSubnet(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 456}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
+		WaitForActions(gomock.Any(), fx.State(), &hcloud.Action{ID: 456}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--ip-range", "10.0.0.0/24"})

--- a/internal/cmd/placementgroup/create.go
+++ b/internal/cmd/placementgroup/create.go
@@ -42,7 +42,7 @@ var CreateCmd = base.CreateCmd{
 		}
 
 		if result.Action != nil {
-			if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+			if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/internal/cmd/placementgroup/create_test.go
+++ b/internal/cmd/placementgroup/create_test.go
@@ -42,7 +42,7 @@ func TestCreate(t *testing.T) {
 		Return(hcloud.PlacementGroupCreateResult{PlacementGroup: &placementGroup, Action: &hcloud.Action{ID: 321}}, nil, nil)
 
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
 	out, errOut, err := fx.Run(cmd, []string{"--name", placementGroup.Name, "--type", string(placementGroup.Type)})
 
@@ -84,7 +84,7 @@ func TestCreateJSON(t *testing.T) {
 		}, nil, nil)
 
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
 	jsonOut, out, err := fx.Run(cmd, []string{"-o=json", "--name", "myPlacementGroup", "--type", "spread"})
 

--- a/internal/cmd/primaryip/assign.go
+++ b/internal/cmd/primaryip/assign.go
@@ -58,7 +58,7 @@ var AssignCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/primaryip/assign_test.go
+++ b/internal/cmd/primaryip/assign_test.go
@@ -54,7 +54,7 @@ func TestAssign(t *testing.T) {
 			nil,
 		)
 
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), action).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"13", "--server", "15"})
 

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -66,7 +66,7 @@ var CreateCmd = base.CreateCmd{
 		}
 
 		if result.Action != nil {
-			if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+			if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/internal/cmd/primaryip/create_test.go
+++ b/internal/cmd/primaryip/create_test.go
@@ -47,7 +47,7 @@ func TestCreate(t *testing.T) {
 		)
 
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
 	out, errOut, err := fx.Run(cmd, []string{"--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14"})
 
@@ -102,7 +102,7 @@ func TestCreateJSON(t *testing.T) {
 			}, nil, nil)
 
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
 	jsonOut, out, err := fx.Run(cmd, []string{"-o=json", "--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14"})
 

--- a/internal/cmd/primaryip/disable_protection_test.go
+++ b/internal/cmd/primaryip/disable_protection_test.go
@@ -43,7 +43,7 @@ func TestEnable(t *testing.T) {
 			nil,
 		)
 
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), action).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
 	out, errOut, err := fx.Run(cmd, []string{"13"})
 
 	expOut := "Resource protection disabled for primary IP 13\n"

--- a/internal/cmd/primaryip/enable_protection.go
+++ b/internal/cmd/primaryip/enable_protection.go
@@ -43,7 +43,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/primaryip/enable_protection_test.go
+++ b/internal/cmd/primaryip/enable_protection_test.go
@@ -43,7 +43,7 @@ func TestEnableProtection(t *testing.T) {
 			nil,
 		)
 
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), action).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
 	out, errOut, err := fx.Run(cmd, []string{"13"})
 
 	expOut := "Resource protection enabled for primary IP 13\n"

--- a/internal/cmd/primaryip/set_rdns_test.go
+++ b/internal/cmd/primaryip/set_rdns_test.go
@@ -42,7 +42,7 @@ func TestSetRDNS(t *testing.T) {
 			nil,
 		)
 
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), action).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"--hostname=server.your-host.de", "--ip=192.168.0.1", "13"})
 

--- a/internal/cmd/primaryip/unassign.go
+++ b/internal/cmd/primaryip/unassign.go
@@ -39,7 +39,7 @@ var UnAssignCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/primaryip/unassign_test.go
+++ b/internal/cmd/primaryip/unassign_test.go
@@ -39,7 +39,7 @@ func TestUnAssign(t *testing.T) {
 			nil,
 		)
 
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), action).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"13"})
 

--- a/internal/cmd/server/add_to_placement_group.go
+++ b/internal/cmd/server/add_to_placement_group.go
@@ -49,7 +49,7 @@ var AddToPlacementGroupCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/add_to_placement_group_test.go
+++ b/internal/cmd/server/add_to_placement_group_test.go
@@ -37,7 +37,7 @@ func TestAddToPlacementGroup(t *testing.T) {
 		Return(&placementGroup, nil, nil)
 	fx.Client.ServerClient.EXPECT().
 		AddToPlacementGroup(gomock.Any(), &server, &placementGroup)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"-g", placementGroup.Name, server.Name})
 

--- a/internal/cmd/server/attach_iso.go
+++ b/internal/cmd/server/attach_iso.go
@@ -55,7 +55,7 @@ var AttachISOCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/attach_iso_test.go
+++ b/internal/cmd/server/attach_iso_test.go
@@ -31,7 +31,7 @@ func TestAttachISO(t *testing.T) {
 		AttachISO(gomock.Any(), srv, iso).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "my-iso"}

--- a/internal/cmd/server/attach_to_network.go
+++ b/internal/cmd/server/attach_to_network.go
@@ -67,7 +67,7 @@ var AttachToNetworkCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/attach_to_network_test.go
+++ b/internal/cmd/server/attach_to_network_test.go
@@ -39,7 +39,7 @@ func TestAttachToNetwork(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "--network", "my-network", "--ip", "192.168.0.1", "--alias-ips", "10.0.1.2,10.0.1.3"}

--- a/internal/cmd/server/change_alias_ips.go
+++ b/internal/cmd/server/change_alias_ips.go
@@ -70,7 +70,7 @@ var ChangeAliasIPsCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/change_alias_ips_test.go
+++ b/internal/cmd/server/change_alias_ips_test.go
@@ -38,7 +38,7 @@ func TestChangeAliasIPs(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "--network", "my-network", "--alias-ips", "10.0.1.2,10.0.1.3"}

--- a/internal/cmd/server/change_type.go
+++ b/internal/cmd/server/change_type.go
@@ -61,7 +61,7 @@ var ChangeTypeCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/change_type_test.go
+++ b/internal/cmd/server/change_type_test.go
@@ -34,7 +34,7 @@ func TestChangeType(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "cax21"}
@@ -68,7 +68,7 @@ func TestChangeTypeKeepDisk(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "cax21", "--keep-disk"}

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -110,7 +110,7 @@ var CreateCmd = base.CreateCmd{
 		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return nil, nil, err
 		}
-		if err := s.WaitForActions(cmd, s, result.NextActions); err != nil {
+		if err := s.WaitForActions(cmd, s, result.NextActions...); err != nil {
 			return nil, nil, err
 		}
 

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -107,10 +108,7 @@ var CreateCmd = base.CreateCmd{
 			return nil, nil, err
 		}
 
-		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
-			return nil, nil, err
-		}
-		if err := s.WaitForActions(cmd, s, result.NextActions...); err != nil {
+		if err := s.WaitForActions(cmd, s, util.MergeNextActions(result.Action, result.NextActions)...); err != nil {
 			return nil, nil, err
 		}
 

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -107,7 +107,7 @@ var CreateCmd = base.CreateCmd{
 			return nil, nil, err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return nil, nil, err
 		}
 		if err := s.WaitForActions(cmd, s, result.NextActions); err != nil {
@@ -132,7 +132,7 @@ var CreateCmd = base.CreateCmd{
 				return nil, nil, err
 			}
 
-			if err := s.ActionProgress(cmd, s, action); err != nil {
+			if err := s.WaitForActions(cmd, s, action); err != nil {
 				return nil, nil, err
 			}
 

--- a/internal/cmd/server/create_image.go
+++ b/internal/cmd/server/create_image.go
@@ -59,7 +59,7 @@ var CreateImageCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/create_image_test.go
+++ b/internal/cmd/server/create_image_test.go
@@ -34,7 +34,7 @@ func TestCreateImage(t *testing.T) {
 			Image:  &hcloud.Image{ID: 456},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "--type", "snapshot", "--description", "my-snapshot"}

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -59,8 +59,9 @@ func TestCreate(t *testing.T) {
 				},
 			},
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
-	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
+	fx.ActionWaiter.EXPECT().
+		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 123}, {ID: 234}}).
+		Return(nil)
 
 	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
 	out, errOut, err := fx.Run(cmd, args)
@@ -155,8 +156,9 @@ func TestCreateJSON(t *testing.T) {
 	fx.Client.ServerClient.EXPECT().
 		GetByID(gomock.Any(), int64(1234)).
 		Return(srv, nil, nil)
-	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
-	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
+	fx.ActionWaiter.EXPECT().
+		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 123}, {ID: 234}}).
+		Return(nil)
 
 	args := []string{"-o=json", "--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
 	jsonOut, out, err := fx.Run(cmd, args)
@@ -217,8 +219,9 @@ func TestCreateProtectionBackup(t *testing.T) {
 	fx.Client.ServerClient.EXPECT().
 		GetByID(gomock.Any(), int64(1234)).
 		Return(srv, nil, nil)
-	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
-	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
+	fx.ActionWaiter.EXPECT().
+		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 123}, {ID: 234}}).
+		Return(nil)
 
 	fx.Client.ServerClient.EXPECT().
 		ChangeProtection(gomock.Any(), srv, hcloud.ServerChangeProtectionOpts{

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -59,7 +59,7 @@ func TestCreate(t *testing.T) {
 				},
 			},
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
 
 	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
@@ -155,7 +155,7 @@ func TestCreateJSON(t *testing.T) {
 	fx.Client.ServerClient.EXPECT().
 		GetByID(gomock.Any(), int64(1234)).
 		Return(srv, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
 
 	args := []string{"-o=json", "--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
@@ -217,7 +217,7 @@ func TestCreateProtectionBackup(t *testing.T) {
 	fx.Client.ServerClient.EXPECT().
 		GetByID(gomock.Any(), int64(1234)).
 		Return(srv, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).Return(nil)
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 234}}).Return(nil)
 
 	fx.Client.ServerClient.EXPECT().
@@ -227,14 +227,14 @@ func TestCreateProtectionBackup(t *testing.T) {
 		Return(&hcloud.Action{
 			ID: 1337,
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 1337}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 1337}).Return(nil)
 
 	fx.Client.ServerClient.EXPECT().
 		EnableBackup(gomock.Any(), srv, "").
 		Return(&hcloud.Action{
 			ID: 42,
 		}, nil, nil)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 42}).Return(nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 42}).Return(nil)
 
 	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04", "--enable-protection", "rebuild,delete", "--enable-backup"}
 	out, errOut, err := fx.Run(cmd, args)

--- a/internal/cmd/server/delete.go
+++ b/internal/cmd/server/delete.go
@@ -23,7 +23,7 @@ var DeleteCmd = base.DeleteCmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/delete_test.go
+++ b/internal/cmd/server/delete_test.go
@@ -34,7 +34,7 @@ func TestDelete(t *testing.T) {
 			Action: &hcloud.Action{ID: 321},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
 	out, errOut, err := fx.Run(cmd, []string{"test"})
 
@@ -82,7 +82,7 @@ func TestDeleteMultiple(t *testing.T) {
 				Action: &hcloud.Action{ID: int64(i)},
 			}, nil, nil)
 		fx.ActionWaiter.EXPECT().
-			ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: int64(i)})
+			WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: int64(i)})
 	}
 
 	out, errOut, err := fx.Run(cmd, names)

--- a/internal/cmd/server/detach_from_network.go
+++ b/internal/cmd/server/detach_from_network.go
@@ -53,7 +53,7 @@ var DetachFromNetworkCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/detach_from_network_test.go
+++ b/internal/cmd/server/detach_from_network_test.go
@@ -33,7 +33,7 @@ func TestDetachFromNetwork(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "--network", "my-network"}

--- a/internal/cmd/server/detach_iso.go
+++ b/internal/cmd/server/detach_iso.go
@@ -36,7 +36,7 @@ var DetachISOCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/detach_iso_test.go
+++ b/internal/cmd/server/detach_iso_test.go
@@ -27,7 +27,7 @@ func TestDetachISO(t *testing.T) {
 		DetachISO(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/disable_backup.go
+++ b/internal/cmd/server/disable_backup.go
@@ -36,7 +36,7 @@ var DisableBackupCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/disable_backup_test.go
+++ b/internal/cmd/server/disable_backup_test.go
@@ -27,7 +27,7 @@ func TestDisableBackup(t *testing.T) {
 		DisableBackup(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/disable_protection_test.go
+++ b/internal/cmd/server/disable_protection_test.go
@@ -30,7 +30,7 @@ func TestDisableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "delete", "rebuild"}

--- a/internal/cmd/server/disable_rescue.go
+++ b/internal/cmd/server/disable_rescue.go
@@ -36,7 +36,7 @@ var DisableRescueCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/disable_rescue_test.go
+++ b/internal/cmd/server/disable_rescue_test.go
@@ -27,7 +27,7 @@ func TestDisableRescue(t *testing.T) {
 		DisableRescue(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/enable_backup.go
+++ b/internal/cmd/server/enable_backup.go
@@ -45,7 +45,7 @@ var EnableBackupCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/enable_backup_test.go
+++ b/internal/cmd/server/enable_backup_test.go
@@ -27,7 +27,7 @@ func TestEnableBackup(t *testing.T) {
 		EnableBackup(gomock.Any(), srv, "").
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/enable_protection.go
+++ b/internal/cmd/server/enable_protection.go
@@ -47,7 +47,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/server/enable_protection_test.go
+++ b/internal/cmd/server/enable_protection_test.go
@@ -30,7 +30,7 @@ func TestEnableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "delete", "rebuild"}

--- a/internal/cmd/server/enable_rescue.go
+++ b/internal/cmd/server/enable_rescue.go
@@ -70,7 +70,7 @@ var EnableRescueCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/enable_rescue_test.go
+++ b/internal/cmd/server/enable_rescue_test.go
@@ -30,7 +30,7 @@ func TestEnableRescue(t *testing.T) {
 			RootPassword: "root-password",
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/poweroff.go
+++ b/internal/cmd/server/poweroff.go
@@ -36,7 +36,7 @@ var PoweroffCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/poweroff_test.go
+++ b/internal/cmd/server/poweroff_test.go
@@ -27,7 +27,7 @@ func TestPoweroff(t *testing.T) {
 		Poweroff(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/poweron.go
+++ b/internal/cmd/server/poweron.go
@@ -36,7 +36,7 @@ var PoweronCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/poweron_test.go
+++ b/internal/cmd/server/poweron_test.go
@@ -27,7 +27,7 @@ func TestPoweron(t *testing.T) {
 		Poweron(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/reboot.go
+++ b/internal/cmd/server/reboot.go
@@ -36,7 +36,7 @@ var RebootCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/reboot_test.go
+++ b/internal/cmd/server/reboot_test.go
@@ -27,7 +27,7 @@ func TestReboot(t *testing.T) {
 		Reboot(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/rebuild.go
+++ b/internal/cmd/server/rebuild.go
@@ -68,7 +68,7 @@ var RebuildCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/rebuild_test.go
+++ b/internal/cmd/server/rebuild_test.go
@@ -35,7 +35,7 @@ func TestRebuild(t *testing.T) {
 			RootPassword: "root-password",
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "--image", "ubuntu-22.04"}

--- a/internal/cmd/server/remove_from_placement_group.go
+++ b/internal/cmd/server/remove_from_placement_group.go
@@ -37,7 +37,7 @@ var RemoveFromPlacementGroupCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/remove_from_placement_group_test.go
+++ b/internal/cmd/server/remove_from_placement_group_test.go
@@ -28,7 +28,7 @@ func TestRemoveFromPlacementGroup(t *testing.T) {
 		Return(&srv, nil, nil)
 	fx.Client.ServerClient.EXPECT().
 		RemoveFromPlacementGroup(gomock.Any(), &srv)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), nil)
 
 	out, errOut, err := fx.Run(cmd, []string{srv.Name})
 

--- a/internal/cmd/server/request_console.go
+++ b/internal/cmd/server/request_console.go
@@ -41,7 +41,7 @@ var RequestConsoleCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/request_console_test.go
+++ b/internal/cmd/server/request_console_test.go
@@ -31,7 +31,7 @@ func TestRequestConsole(t *testing.T) {
 			WSSURL:   "wss://console.hetzner.cloud/?token=123",
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}
@@ -62,7 +62,7 @@ func TestRequestConsoleJSON(t *testing.T) {
 			WSSURL:   "wss://console.hetzner.cloud/?token=123",
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "-o=json"}

--- a/internal/cmd/server/reset.go
+++ b/internal/cmd/server/reset.go
@@ -36,7 +36,7 @@ var ResetCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/reset_password.go
+++ b/internal/cmd/server/reset_password.go
@@ -42,7 +42,7 @@ var ResetPasswordCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/server/reset_password_test.go
+++ b/internal/cmd/server/reset_password_test.go
@@ -30,7 +30,7 @@ func TestResetPassword(t *testing.T) {
 			RootPassword: "root-password",
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/reset_test.go
+++ b/internal/cmd/server/reset_test.go
@@ -27,7 +27,7 @@ func TestReset(t *testing.T) {
 		Reset(gomock.Any(), srv).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server"}

--- a/internal/cmd/server/set_rdns_test.go
+++ b/internal/cmd/server/set_rdns_test.go
@@ -32,7 +32,7 @@ func TestSetRDNS(t *testing.T) {
 		ChangeDNSPtr(gomock.Any(), srv, net.ParseIP("127.0.0.1"), hcloud.Ptr("s1.example.com")).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"my-server", "--hostname", "s1.example.com"}

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -75,6 +75,7 @@ var ShutdownCmd = base.Cmd{
 			defer ticker.Stop()
 
 			progress := ui.NewProgress(os.Stderr, "Waiting for server to shut down", ui.ActionResourcesMessage(&hcloud.ActionResource{ID: server.ID, Type: hcloud.ActionResourceTypeServer}))
+			progress.Start()
 			for server.Status != hcloud.ServerStatusOff {
 				if now := <-ticker.C; now.Sub(start) >= timeout {
 					progress.SetError()

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -11,6 +12,7 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/cli/internal/ui"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
@@ -55,7 +57,7 @@ var ShutdownCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 
@@ -63,37 +65,30 @@ var ShutdownCmd = base.Cmd{
 
 		if wait {
 			start := time.Now()
-			errCh := make(chan error)
 
 			interval, _ := cmd.Flags().GetDuration("poll-interval")
 			if interval < time.Second {
 				interval = time.Second
 			}
 
-			go func() {
-				defer close(errCh)
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
 
-				ticker := time.NewTicker(interval)
-				defer ticker.Stop()
-
-				for server.Status != hcloud.ServerStatusOff {
-					if now := <-ticker.C; now.Sub(start) >= timeout {
-						errCh <- errors.New("failed to shut down server")
-						return
-					}
-					server, _, err = s.Client().Server().GetByID(s, server.ID)
-					if err != nil {
-						errCh <- err
-						return
-					}
+			progress := ui.NewProgress(os.Stderr, "Waiting for server to shut down")
+			for server.Status != hcloud.ServerStatusOff {
+				if now := <-ticker.C; now.Sub(start) >= timeout {
+					progress.SetError()
+					return errors.New("failed to shut down server")
 				}
 
-				errCh <- nil
-			}()
-
-			if err := state.DisplayProgressCircle(cmd, errCh, "Waiting for server to shut down"); err != nil {
-				return err
+				server, _, err = s.Client().Server().GetByID(s, server.ID)
+				if err != nil {
+					progress.SetError()
+					return err
+				}
 			}
+
+			progress.SetSuccess()
 
 			cmd.Printf("Server %d shut down\n", server.ID)
 		}

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -74,7 +74,7 @@ var ShutdownCmd = base.Cmd{
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 
-			progress := ui.NewProgress(os.Stderr, "Waiting for server to shut down")
+			progress := ui.NewProgress(os.Stderr, "Waiting for server to shut down", ui.ActionResourcesMessage(&hcloud.ActionResource{ID: server.ID, Type: hcloud.ActionResourceTypeServer}))
 			for server.Status != hcloud.ServerStatusOff {
 				if now := <-ticker.C; now.Sub(start) >= timeout {
 					progress.SetError()

--- a/internal/cmd/server/shutdown.go
+++ b/internal/cmd/server/shutdown.go
@@ -74,8 +74,13 @@ var ShutdownCmd = base.Cmd{
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 
-			progress := ui.NewProgress(os.Stderr, "Waiting for server to shut down", ui.ActionResourcesMessage(&hcloud.ActionResource{ID: server.ID, Type: hcloud.ActionResourceTypeServer}))
+			progress := ui.NewProgress(
+				os.Stderr,
+				ui.FakeActionMessage("Waiting for server to shut down"),
+				ui.ActionResourcesMessage(&hcloud.ActionResource{ID: server.ID, Type: hcloud.ActionResourceTypeServer}),
+			)
 			progress.Start()
+
 			for server.Status != hcloud.ServerStatusOff {
 				if now := <-ticker.C; now.Sub(start) >= timeout {
 					progress.SetError()

--- a/internal/cmd/server/shutdown_test.go
+++ b/internal/cmd/server/shutdown_test.go
@@ -73,7 +73,7 @@ func TestShutdownWait(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{srv.Name, "--wait"})
 
 	expOut := "Sent shutdown signal to server 42\nServer 42 shut down\n"
-	expErrOut := "Waiting for server to shut down ... done\n"
+	expErrOut := "Waiting for server to shut down (server: 42) ... done\n"
 
 	assert.NoError(t, err)
 	assert.Equal(t, expErrOut, errOut)

--- a/internal/cmd/server/shutdown_test.go
+++ b/internal/cmd/server/shutdown_test.go
@@ -31,7 +31,7 @@ func TestShutdown(t *testing.T) {
 
 	fx.Client.ServerClient.EXPECT().
 		Shutdown(gomock.Any(), &srv)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), nil)
 
 	out, errOut, err := fx.Run(cmd, []string{srv.Name})
 
@@ -62,7 +62,7 @@ func TestShutdownWait(t *testing.T) {
 
 	fx.Client.ServerClient.EXPECT().
 		Shutdown(gomock.Any(), &srv)
-	fx.ActionWaiter.EXPECT().ActionProgress(gomock.Any(), gomock.Any(), nil)
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), nil)
 
 	fx.Client.ServerClient.EXPECT().
 		GetByID(gomock.Any(), srv.ID).

--- a/internal/cmd/server/shutdown_test.go
+++ b/internal/cmd/server/shutdown_test.go
@@ -73,7 +73,7 @@ func TestShutdownWait(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{srv.Name, "--wait"})
 
 	expOut := "Sent shutdown signal to server 42\nServer 42 shut down\n"
-	expErrOut := "Waiting for server to shut down (server: 42) ... done\n"
+	expErrOut := "Waiting for server to shut down (server: 42) ...\nWaiting for server to shut down (server: 42) ... done\n"
 
 	assert.NoError(t, err)
 	assert.Equal(t, expErrOut, errOut)

--- a/internal/cmd/util/action.go
+++ b/internal/cmd/util/action.go
@@ -1,0 +1,10 @@
+package util
+
+import "github.com/hetznercloud/hcloud-go/v2/hcloud"
+
+func MergeNextActions(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.Action {
+	all := make([]*hcloud.Action, 0, 1+len(nextActions))
+	all = append(all, action)
+	all = append(all, nextActions...)
+	return all
+}

--- a/internal/cmd/util/action_test.go
+++ b/internal/cmd/util/action_test.go
@@ -3,8 +3,9 @@ package util
 import (
 	"testing"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func TestMergeNextActions(t *testing.T) {

--- a/internal/cmd/util/action_test.go
+++ b/internal/cmd/util/action_test.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeNextActions(t *testing.T) {
+	action := &hcloud.Action{ID: 1}
+	next_actions := []*hcloud.Action{{ID: 2}, {ID: 3}}
+
+	actions := MergeNextActions(action, next_actions)
+
+	assert.Equal(t, []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}}, actions)
+}

--- a/internal/cmd/volume/attach.go
+++ b/internal/cmd/volume/attach.go
@@ -55,7 +55,7 @@ var AttachCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/volume/attach_test.go
+++ b/internal/cmd/volume/attach_test.go
@@ -33,7 +33,7 @@ func TestAttach(t *testing.T) {
 			Automount: hcloud.Ptr(false),
 		}).Return(&hcloud.Action{ID: 321}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--server", "456"})

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -97,10 +97,7 @@ var CreateCmd = base.CreateCmd{
 			return nil, nil, err
 		}
 
-		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
-			return nil, nil, err
-		}
-		if err := s.WaitForActions(cmd, s, result.NextActions...); err != nil {
+		if err := s.WaitForActions(cmd, s, util.MergeNextActions(result.Action, result.NextActions)...); err != nil {
 			return nil, nil, err
 		}
 		cmd.Printf("Volume %d created\n", result.Volume.ID)

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -100,7 +100,7 @@ var CreateCmd = base.CreateCmd{
 		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return nil, nil, err
 		}
-		if err := s.WaitForActions(cmd, s, result.NextActions); err != nil {
+		if err := s.WaitForActions(cmd, s, result.NextActions...); err != nil {
 			return nil, nil, err
 		}
 		cmd.Printf("Volume %d created\n", result.Volume.ID)

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -97,7 +97,7 @@ var CreateCmd = base.CreateCmd{
 			return nil, nil, err
 		}
 
-		if err := s.ActionProgress(cmd, s, result.Action); err != nil {
+		if err := s.WaitForActions(cmd, s, result.Action); err != nil {
 			return nil, nil, err
 		}
 		if err := s.WaitForActions(cmd, s, result.NextActions); err != nil {

--- a/internal/cmd/volume/create_test.go
+++ b/internal/cmd/volume/create_test.go
@@ -41,9 +41,7 @@ func TestCreate(t *testing.T) {
 			NextActions: []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
-	fx.ActionWaiter.EXPECT().
-		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
+		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 321}, {ID: 1}, {ID: 2}, {ID: 3}})
 
 	out, errOut, err := fx.Run(cmd, []string{"--name", "test", "--size", "20", "--location", "fsn1"})
 
@@ -88,9 +86,7 @@ func TestCreateJSON(t *testing.T) {
 			NextActions: []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
-	fx.ActionWaiter.EXPECT().
-		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
+		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 321}, {ID: 1}, {ID: 2}, {ID: 3}})
 
 	jsonOut, out, err := fx.Run(cmd, []string{"-o=json", "--name", "test", "--size", "20", "--location", "fsn1"})
 
@@ -128,9 +124,7 @@ func TestCreateProtection(t *testing.T) {
 			NextActions: []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
-	fx.ActionWaiter.EXPECT().
-		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
+		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 321}, {ID: 1}, {ID: 2}, {ID: 3}})
 	fx.Client.VolumeClient.EXPECT().
 		ChangeProtection(gomock.Any(), v, hcloud.VolumeChangeProtectionOpts{
 			Delete: hcloud.Ptr(true),

--- a/internal/cmd/volume/create_test.go
+++ b/internal/cmd/volume/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 			NextActions: []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
 
@@ -88,7 +88,7 @@ func TestCreateJSON(t *testing.T) {
 			NextActions: []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
 
@@ -128,7 +128,7 @@ func TestCreateProtection(t *testing.T) {
 			NextActions: []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}})
 	fx.Client.VolumeClient.EXPECT().
@@ -137,7 +137,7 @@ func TestCreateProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 123}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123})
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123})
 
 	out, errOut, err := fx.Run(cmd, []string{"--name", "test", "--size", "20", "--location", "fsn1", "--enable-protection", "delete"})
 

--- a/internal/cmd/volume/detach.go
+++ b/internal/cmd/volume/detach.go
@@ -35,7 +35,7 @@ var DetachCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/volume/detach_test.go
+++ b/internal/cmd/volume/detach_test.go
@@ -27,7 +27,7 @@ func TestDetach(t *testing.T) {
 		Detach(gomock.Any(), v).
 		Return(&hcloud.Action{ID: 321}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123"})

--- a/internal/cmd/volume/disable_protection_test.go
+++ b/internal/cmd/volume/disable_protection_test.go
@@ -29,7 +29,7 @@ func TestDisableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"myVolume", "delete"}

--- a/internal/cmd/volume/enable_protection.go
+++ b/internal/cmd/volume/enable_protection.go
@@ -45,7 +45,7 @@ func changeProtection(s state.State, cmd *cobra.Command,
 		return err
 	}
 
-	if err := s.ActionProgress(cmd, s, action); err != nil {
+	if err := s.WaitForActions(cmd, s, action); err != nil {
 		return err
 	}
 

--- a/internal/cmd/volume/enable_protection_test.go
+++ b/internal/cmd/volume/enable_protection_test.go
@@ -29,7 +29,7 @@ func TestEnableProtection(t *testing.T) {
 		}).
 		Return(&hcloud.Action{ID: 789}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 789}).
 		Return(nil)
 
 	args := []string{"myVolume", "delete"}

--- a/internal/cmd/volume/resize.go
+++ b/internal/cmd/volume/resize.go
@@ -39,7 +39,7 @@ var ResizeCmd = base.Cmd{
 			return err
 		}
 
-		if err := s.ActionProgress(cmd, s, action); err != nil {
+		if err := s.WaitForActions(cmd, s, action); err != nil {
 			return err
 		}
 

--- a/internal/cmd/volume/resize_test.go
+++ b/internal/cmd/volume/resize_test.go
@@ -27,7 +27,7 @@ func TestResize(t *testing.T) {
 		Resize(gomock.Any(), v, 42).
 		Return(&hcloud.Action{ID: 321}, nil, nil)
 	fx.ActionWaiter.EXPECT().
-		ActionProgress(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).
 		Return(nil)
 
 	out, errOut, err := fx.Run(cmd, []string{"123", "--size", "42"})

--- a/internal/state/actions.go
+++ b/internal/state/actions.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/ui"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func (c *state) WaitForActions(cmd *cobra.Command, ctx context.Context, actions ...*hcloud.Action) error {
+	if quiet, _ := cmd.Flags().GetBool("quiet"); quiet {
+		return c.Client().Action().WaitFor(ctx, actions...)
+	}
+
+	return waitForActions(c.Client().Action(), ctx, actions...)
+}
+
+func waitForActions(client hcapi2.ActionClient, ctx context.Context, actions ...*hcloud.Action) (err error) {
+	progressGroup := ui.NewProgressGroup(os.Stderr)
+	progressByAction := make(map[int64]ui.Progress, len(actions))
+	for _, action := range actions {
+		progress := progressGroup.Add(waitForActionMessage(action))
+		progressByAction[action.ID] = progress
+	}
+
+	if err = progressGroup.Start(); err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, progressGroup.Stop())
+	}()
+
+	return client.WaitForFunc(ctx, func(update *hcloud.Action) error {
+		switch update.Status {
+		case hcloud.ActionStatusRunning:
+			progressByAction[update.ID].SetCurrent(update.Progress)
+		case hcloud.ActionStatusSuccess:
+			progressByAction[update.ID].SetSuccess()
+		case hcloud.ActionStatusError:
+			progressByAction[update.ID].SetError()
+			return update.Error()
+		}
+
+		return nil
+	}, actions...)
+}
+
+func waitForActionMessage(action *hcloud.Action) string {
+	resources := make([]string, 0, len(action.Resources))
+	for _, resource := range action.Resources {
+		resources = append(resources, fmt.Sprintf("%s: %d", resource.Type, resource.ID))
+	}
+	return fmt.Sprintf("Waiting for action %s to complete (%v)", action.Command, strings.Join(resources, ", "))
+}

--- a/internal/state/actions.go
+++ b/internal/state/actions.go
@@ -3,9 +3,7 @@ package state
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -26,7 +24,10 @@ func waitForActions(client hcapi2.ActionClient, ctx context.Context, actions ...
 	progressGroup := ui.NewProgressGroup(os.Stderr)
 	progressByAction := make(map[int64]ui.Progress, len(actions))
 	for _, action := range actions {
-		progress := progressGroup.Add(waitForActionMessage(action))
+		progress := progressGroup.Add(
+			ui.ActionMessage(action),
+			ui.ActionResourcesMessage(action.Resources...),
+		)
 		progressByAction[action.ID] = progress
 	}
 
@@ -50,12 +51,4 @@ func waitForActions(client hcapi2.ActionClient, ctx context.Context, actions ...
 
 		return nil
 	}, actions...)
-}
-
-func waitForActionMessage(action *hcloud.Action) string {
-	resources := make([]string, 0, len(action.Resources))
-	for _, resource := range action.Resources {
-		resources = append(resources, fmt.Sprintf("%s: %d", resource.Type, resource.ID))
-	}
-	return fmt.Sprintf("Waiting for action %s to complete (%v)", action.Command, strings.Join(resources, ", "))
 }

--- a/internal/state/actions_test.go
+++ b/internal/state/actions_test.go
@@ -14,48 +14,6 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-func TestWaitForActionMessage(t *testing.T) {
-	testCases := []struct {
-		name   string
-		action hcloud.Action
-		want   string
-	}{
-		{
-			name: "create_server",
-			action: hcloud.Action{
-				ID:       1564532131,
-				Command:  "create_server",
-				Status:   hcloud.ActionStatusRunning,
-				Progress: 0,
-				Resources: []*hcloud.ActionResource{
-					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
-				},
-			},
-			want: "Waiting for action create_server to complete (server: 46830545)",
-		},
-		{
-			name: "attach_volume",
-			action: hcloud.Action{
-				ID:       1564532131,
-				Command:  "attach_volume",
-				Status:   hcloud.ActionStatusRunning,
-				Progress: 0,
-				Resources: []*hcloud.ActionResource{
-					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
-					{ID: 46830546, Type: hcloud.ActionResourceTypeVolume},
-				},
-			},
-			want: "Waiting for action attach_volume to complete (server: 46830545, volume: 46830546)",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			msg := waitForActionMessage(&testCase.action)
-			assert.Equal(t, testCase.want, msg)
-		})
-	}
-}
-
 func TestWaitForActionsSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -91,8 +49,8 @@ func TestWaitForActionsSuccess(t *testing.T) {
 
 	assert.Equal(t,
 		strings.Join([]string{
-			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
-			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ... done\n",
+			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
+			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ... done\n",
 		}, ""),
 		stderr,
 	)
@@ -134,8 +92,8 @@ func TestWaitForActionsError(t *testing.T) {
 
 	assert.Equal(t,
 		strings.Join([]string{
-			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
-			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ... failed\n",
+			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
+			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ... failed\n",
 		}, ""),
 		stderr,
 	)

--- a/internal/state/actions_test.go
+++ b/internal/state/actions_test.go
@@ -1,0 +1,170 @@
+package state
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	hcapi2_mock "github.com/hetznercloud/cli/internal/hcapi2/mock"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func TestWaitForActionMessage(t *testing.T) {
+	testCases := []struct {
+		name   string
+		action hcloud.Action
+		want   string
+	}{
+		{
+			name: "create_server",
+			action: hcloud.Action{
+				ID:       1564532131,
+				Command:  "create_server",
+				Status:   hcloud.ActionStatusRunning,
+				Progress: 0,
+				Resources: []*hcloud.ActionResource{
+					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
+				},
+			},
+			want: "Waiting for action create_server to complete (server: 46830545)",
+		},
+		{
+			name: "attach_volume",
+			action: hcloud.Action{
+				ID:       1564532131,
+				Command:  "attach_volume",
+				Status:   hcloud.ActionStatusRunning,
+				Progress: 0,
+				Resources: []*hcloud.ActionResource{
+					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
+					{ID: 46830546, Type: hcloud.ActionResourceTypeVolume},
+				},
+			},
+			want: "Waiting for action attach_volume to complete (server: 46830545, volume: 46830546)",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			msg := waitForActionMessage(&testCase.action)
+			assert.Equal(t, testCase.want, msg)
+		})
+	}
+}
+
+func TestWaitForActionsSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	action := &hcloud.Action{
+		ID:       1564532131,
+		Command:  "attach_volume",
+		Status:   hcloud.ActionStatusRunning,
+		Progress: 0,
+		Resources: []*hcloud.ActionResource{
+			{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
+			{ID: 46830546, Type: hcloud.ActionResourceTypeVolume},
+		},
+	}
+
+	client := hcapi2_mock.NewMockActionClient(ctrl)
+
+	client.EXPECT().
+		WaitForFunc(gomock.Any(), gomock.Any(), action).
+		DoAndReturn(func(ctx context.Context, handleUpdate func(update *hcloud.Action) error, actions ...*hcloud.Action) error {
+			assert.NoError(t, handleUpdate(action))
+			action.Status = hcloud.ActionStatusRunning
+			assert.NoError(t, handleUpdate(action))
+			action.Status = hcloud.ActionStatusSuccess
+			assert.NoError(t, handleUpdate(action))
+
+			return nil
+		})
+
+	stderr := captureStderr(t, func() {
+		waitForActions(client, context.Background(), action)
+	})
+
+	assert.Equal(t,
+		strings.Join([]string{
+			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
+			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ... done\n",
+		}, ""),
+		stderr,
+	)
+}
+
+func TestWaitForActionsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	action := &hcloud.Action{
+		ID:       1564532131,
+		Command:  "attach_volume",
+		Status:   hcloud.ActionStatusRunning,
+		Progress: 0,
+		Resources: []*hcloud.ActionResource{
+			{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
+			{ID: 46830546, Type: hcloud.ActionResourceTypeVolume},
+		},
+	}
+
+	client := hcapi2_mock.NewMockActionClient(ctrl)
+	client.EXPECT().
+		WaitForFunc(gomock.Any(), gomock.Any(), action).
+		DoAndReturn(func(ctx context.Context, handleUpdate func(update *hcloud.Action) error, actions ...*hcloud.Action) error {
+			assert.NoError(t, handleUpdate(action))
+			action.Status = hcloud.ActionStatusRunning
+			assert.NoError(t, handleUpdate(action))
+			action.Status = hcloud.ActionStatusError
+			action.ErrorCode = "action_failed"
+			action.ErrorMessage = "action failed"
+			assert.Error(t, handleUpdate(action))
+
+			return action.Error()
+		})
+
+	stderr := captureStderr(t, func() {
+		waitForActions(client, context.Background(), action)
+	})
+
+	assert.Equal(t,
+		strings.Join([]string{
+			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
+			"Waiting for action attach_volume to complete (server: 46830545, volume: 46830546) ... failed\n",
+		}, ""),
+		stderr,
+	)
+}
+
+func captureStderr(t *testing.T, next func()) string {
+	t.Helper()
+
+	pipeReader, pipeWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stderrOrig := os.Stderr
+	os.Stderr = pipeWriter
+	defer func() {
+		os.Stderr = stderrOrig
+	}()
+
+	next()
+
+	if err := pipeWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stderrOutput, err := io.ReadAll(pipeReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(stderrOutput)
+}

--- a/internal/state/command_helpers.go
+++ b/internal/state/command_helpers.go
@@ -11,8 +11,7 @@ import (
 //go:generate go run github.com/golang/mock/mockgen -package state -destination zz_command_helper_mock.go . ActionWaiter,TokenEnsurer
 
 type ActionWaiter interface {
-	ActionProgress(*cobra.Command, context.Context, *hcloud.Action) error
-	WaitForActions(*cobra.Command, context.Context, []*hcloud.Action) error
+	WaitForActions(*cobra.Command, context.Context, ...*hcloud.Action) error
 }
 
 type TokenEnsurer interface {

--- a/internal/state/helpers.go
+++ b/internal/state/helpers.go
@@ -1,21 +1,9 @@
 package state
 
 import (
-	"context"
 	"errors"
-	"fmt"
-	"os"
 
-	"github.com/cheggaaa/pb/v3"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
-
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-)
-
-const (
-	progressCircleTpl = `{{ cycle . " .  " "  . " "   ." "  . " }}`
-	progressBarTpl    = `{{ etime . }} {{ bar . "" "=" }} {{ percent . }}`
 )
 
 func Wrap(s State, f func(State, *cobra.Command, []string) error) func(*cobra.Command, []string) error {
@@ -24,112 +12,9 @@ func Wrap(s State, f func(State, *cobra.Command, []string) error) func(*cobra.Co
 	}
 }
 
-// StdoutIsTerminal returns whether the CLI is run in a terminal.
-func StdoutIsTerminal() bool {
-	return terminal.IsTerminal(int(os.Stdout.Fd()))
-}
-
-func (c *state) ActionProgress(cmd *cobra.Command, ctx context.Context, action *hcloud.Action) error {
-	return c.ActionsProgresses(cmd, ctx, []*hcloud.Action{action})
-}
-
-func (c *state) ActionsProgresses(cmd *cobra.Command, ctx context.Context, actions []*hcloud.Action) error {
-	progressCh, errCh := c.Client().Action().WatchOverallProgress(ctx, actions)
-
-	if quiet, _ := cmd.Flags().GetBool("quiet"); quiet {
-		return <-errCh
-	}
-
-	if StdoutIsTerminal() {
-		progress := pb.New(100)
-		progress.SetMaxWidth(50) // width of progress bar is too large by default
-		progress.SetTemplateString(progressBarTpl)
-		progress.Start()
-		defer progress.Finish()
-
-		for {
-			select {
-			case err := <-errCh:
-				if err == nil {
-					progress.SetCurrent(100)
-				}
-				return err
-			case p := <-progressCh:
-				progress.SetCurrent(int64(p))
-			}
-		}
-	} else {
-		return <-errCh
-	}
-}
-
 func (c *state) EnsureToken(_ *cobra.Command, _ []string) error {
 	if c.token == "" {
 		return errors.New("no active context or token (see `hcloud context --help`)")
-	}
-	return nil
-}
-
-func (c *state) WaitForActions(cmd *cobra.Command, ctx context.Context, actions []*hcloud.Action) error {
-	for _, action := range actions {
-		resources := make(map[string]int64)
-		for _, resource := range action.Resources {
-			resources[string(resource.Type)] = resource.ID
-		}
-
-		var waitingFor string
-		switch action.Command {
-		default:
-			waitingFor = fmt.Sprintf("Waiting for action %s to have finished", action.Command)
-		case "start_server":
-			waitingFor = fmt.Sprintf("Waiting for server %d to have started", resources["server"])
-		case "attach_volume":
-			waitingFor = fmt.Sprintf("Waiting for volume %d to have been attached to server %d", resources["volume"], resources["server"])
-		}
-
-		_, errCh := c.Client().Action().WatchProgress(ctx, action)
-
-		err := DisplayProgressCircle(cmd, errCh, waitingFor)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func DisplayProgressCircle(cmd *cobra.Command, errCh <-chan error, waitingFor string) error {
-	const (
-		done     = "done"
-		failed   = "failed"
-		ellipsis = " ... "
-	)
-
-	if quiet, _ := cmd.Flags().GetBool("quiet"); quiet {
-		return <-errCh
-	}
-
-	if StdoutIsTerminal() {
-		_, _ = fmt.Fprintln(os.Stderr, waitingFor)
-
-		progress := pb.New(1) // total progress of 1 will do since we use a circle here
-		progress.SetTemplateString(progressCircleTpl)
-		progress.Start()
-		defer progress.Finish()
-
-		if err := <-errCh; err != nil {
-			progress.SetTemplateString(ellipsis + failed)
-			return err
-		}
-		progress.SetTemplateString(ellipsis + done)
-	} else {
-		_, _ = fmt.Fprint(os.Stderr, waitingFor+ellipsis)
-
-		if err := <-errCh; err != nil {
-			_, _ = fmt.Fprintln(os.Stderr, failed)
-			return err
-		}
-		_, _ = fmt.Fprintln(os.Stderr, done)
 	}
 	return nil
 }

--- a/internal/state/zz_command_helper_mock.go
+++ b/internal/state/zz_command_helper_mock.go
@@ -36,32 +36,23 @@ func (m *MockActionWaiter) EXPECT() *MockActionWaiterMockRecorder {
 	return m.recorder
 }
 
-// ActionProgress mocks base method.
-func (m *MockActionWaiter) ActionProgress(arg0 *cobra.Command, arg1 context.Context, arg2 *hcloud.Action) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionProgress", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ActionProgress indicates an expected call of ActionProgress.
-func (mr *MockActionWaiterMockRecorder) ActionProgress(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionProgress", reflect.TypeOf((*MockActionWaiter)(nil).ActionProgress), arg0, arg1, arg2)
-}
-
 // WaitForActions mocks base method.
-func (m *MockActionWaiter) WaitForActions(arg0 *cobra.Command, arg1 context.Context, arg2 []*hcloud.Action) error {
+func (m *MockActionWaiter) WaitForActions(arg0 *cobra.Command, arg1 context.Context, arg2 ...*hcloud.Action) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForActions", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WaitForActions", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WaitForActions indicates an expected call of WaitForActions.
-func (mr *MockActionWaiterMockRecorder) WaitForActions(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockActionWaiterMockRecorder) WaitForActions(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForActions", reflect.TypeOf((*MockActionWaiter)(nil).WaitForActions), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForActions", reflect.TypeOf((*MockActionWaiter)(nil).WaitForActions), varargs...)
 }
 
 // MockTokenEnsurer is a mock of TokenEnsurer interface.

--- a/internal/ui/actions.go
+++ b/internal/ui/actions.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func ActionMessage(action *hcloud.Action) string {
+	return fmt.Sprintf("Waiting for %s to complete", color.New(color.Bold).Sprint(action.Command))
+}
+
+func ActionResourcesMessage(resources ...*hcloud.ActionResource) string {
+	if len(resources) == 0 {
+		return ""
+	}
+
+	items := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		items = append(items, fmt.Sprintf("%s: %d", resource.Type, resource.ID))
+	}
+
+	return fmt.Sprintf("(%v)", strings.Join(items, ", "))
+
+}

--- a/internal/ui/actions.go
+++ b/internal/ui/actions.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 

--- a/internal/ui/actions.go
+++ b/internal/ui/actions.go
@@ -13,6 +13,16 @@ func ActionMessage(action *hcloud.Action) string {
 	return fmt.Sprintf("Waiting for %s to complete", color.New(color.Bold).Sprint(action.Command))
 }
 
+// FakeActionMessage returns the initial value with a unused color to grow the string
+// size.
+//
+// Because the [ActionMessage] function adds 1 color to the returned string. We add the
+// same amount of colors to the [FakeActionMessage], to make sure the padding is
+// correct.
+func FakeActionMessage(value string) string {
+	return color.New(color.Bold).Sprint("") + value
+}
+
 func ActionResourcesMessage(resources ...*hcloud.ActionResource) string {
 	if len(resources) == 0 {
 		return ""

--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -3,8 +3,9 @@ package ui
 import (
 	"testing"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func TestMessages(t *testing.T) {

--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -1,0 +1,67 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessages(t *testing.T) {
+	testCases := []struct {
+		name          string
+		action        *hcloud.Action
+		wantAction    string
+		wantResources string
+	}{
+		{
+			name: "create_server",
+			action: &hcloud.Action{
+				ID:       1564532131,
+				Command:  "create_server",
+				Status:   hcloud.ActionStatusRunning,
+				Progress: 0,
+				Resources: []*hcloud.ActionResource{
+					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
+				},
+			},
+			wantAction:    "Waiting for create_server to complete",
+			wantResources: "(server: 46830545)",
+		},
+		{
+			name: "attach_volume",
+			action: &hcloud.Action{
+				ID:       1564532131,
+				Command:  "attach_volume",
+				Status:   hcloud.ActionStatusRunning,
+				Progress: 0,
+				Resources: []*hcloud.ActionResource{
+					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
+					{ID: 46830546, Type: hcloud.ActionResourceTypeVolume},
+				},
+			},
+			wantAction:    "Waiting for attach_volume to complete",
+			wantResources: "(server: 46830545, volume: 46830546)",
+		},
+		{
+			name: "no resources",
+			action: &hcloud.Action{
+				ID:       1564532131,
+				Command:  "create_server",
+				Status:   hcloud.ActionStatusRunning,
+				Progress: 0,
+			},
+			wantAction:    "Waiting for create_server to complete",
+			wantResources: "",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actionMessage := ActionMessage(testCase.action)
+			actionResourcesMessage := ActionResourcesMessage(testCase.action.Resources...)
+
+			assert.Equal(t, testCase.wantAction, actionMessage)
+			assert.Equal(t, testCase.wantResources, actionResourcesMessage)
+		})
+	}
+}

--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,4 +66,16 @@ func TestMessages(t *testing.T) {
 			assert.Equal(t, testCase.wantResources, actionResourcesMessage)
 		})
 	}
+}
+
+func TestFakeActionMessages(t *testing.T) {
+	actionMessage := ActionMessage(&hcloud.Action{Command: "create_server"})
+	fakeMessage := FakeActionMessage("Some random message")
+
+	// The padding is important
+	actionMessage = fmt.Sprintf("%-60s", actionMessage)
+	fakeMessage = fmt.Sprintf("%-60s", fakeMessage)
+
+	assert.Equal(t, actionMessage, "Waiting for create_server to complete                       ")
+	assert.Equal(t, fakeMessage, "Some random message                                         ")
 }

--- a/internal/ui/helpers.go
+++ b/internal/ui/helpers.go
@@ -1,0 +1,12 @@
+package ui
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// StdoutIsTerminal returns whether the CLI is run in a terminal.
+func StdoutIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -1,0 +1,36 @@
+package ui
+
+import (
+	"io"
+)
+
+type ProgressGroup interface {
+	Add(message string) Progress
+	Start() error
+	Stop() error
+}
+
+type NewProgressGroupType func(output io.Writer) ProgressGroup
+
+func NewProgressGroup(output io.Writer) ProgressGroup {
+	if StdoutIsTerminal() {
+		return newTerminalProgressGroup(output)
+	} else {
+		return newScriptProgressGroup(output)
+	}
+}
+
+type Progress interface {
+	Start()
+	SetCurrent(value int)
+	SetSuccess()
+	SetError()
+}
+
+func NewProgress(output io.Writer, message string) Progress {
+	if StdoutIsTerminal() {
+		return newTerminalProgress(output, message)
+	} else {
+		return newScriptProgress(output, message)
+	}
+}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -5,7 +5,7 @@ import (
 )
 
 type ProgressGroup interface {
-	Add(message string) Progress
+	Add(message string, resources string) Progress
 	Start() error
 	Stop() error
 }
@@ -25,10 +25,10 @@ type Progress interface {
 	SetError()
 }
 
-func NewProgress(output io.Writer, message string) Progress {
+func NewProgress(output io.Writer, message string, resources string) Progress {
 	if StdoutIsTerminal() {
-		return newTerminalProgress(output, message)
+		return newTerminalProgress(output, message, resources)
 	} else {
-		return newScriptProgress(output, message)
+		return newScriptProgress(output, message, resources)
 	}
 }

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -10,8 +10,6 @@ type ProgressGroup interface {
 	Stop() error
 }
 
-type NewProgressGroupType func(output io.Writer) ProgressGroup
-
 func NewProgressGroup(output io.Writer) ProgressGroup {
 	if StdoutIsTerminal() {
 		return newTerminalProgressGroup(output)

--- a/internal/ui/progress_script.go
+++ b/internal/ui/progress_script.go
@@ -14,8 +14,8 @@ func newScriptProgressGroup(output io.Writer) *scriptProgressGroup {
 	return &scriptProgressGroup{output: output}
 }
 
-func (p *scriptProgressGroup) Add(message string) Progress {
-	progress := newScriptProgress(p.output, message)
+func (p *scriptProgressGroup) Add(message string, resources string) Progress {
+	progress := newScriptProgress(p.output, message, resources)
 	p.progress = append(p.progress, progress)
 	return progress
 
@@ -33,24 +33,38 @@ func (p *scriptProgressGroup) Stop() error {
 }
 
 type scriptProgress struct {
-	output  io.Writer
-	message string
+	output    io.Writer
+	message   string
+	resources string
 }
 
-func newScriptProgress(output io.Writer, message string) *scriptProgress {
-	return &scriptProgress{output: output, message: message}
+func newScriptProgress(output io.Writer, message string, resources string) *scriptProgress {
+	return &scriptProgress{output: output, message: message, resources: resources}
+}
+
+func (p *scriptProgress) print(status string) {
+	result := p.message
+	if p.resources != "" {
+		result += fmt.Sprintf(" %s", p.resources)
+	}
+	result += " ..."
+	if status != "" {
+		result += fmt.Sprintf(" %s", status)
+	}
+	fmt.Fprintln(p.output, result)
 }
 
 func (p *scriptProgress) Start() {
-	fmt.Fprintf(p.output, "%s ...\n", p.message)
+	p.print("")
 }
 
-func (p *scriptProgress) SetCurrent(value int) {}
+func (p *scriptProgress) SetCurrent(value int) {
+}
 
 func (p *scriptProgress) SetSuccess() {
-	fmt.Fprintf(p.output, "%s ... done\n", p.message)
+	p.print("done")
 }
 
 func (p *scriptProgress) SetError() {
-	fmt.Fprintf(p.output, "%s ... failed\n", p.message)
+	p.print("failed")
 }

--- a/internal/ui/progress_script.go
+++ b/internal/ui/progress_script.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+)
+
+type scriptProgressGroup struct {
+	output   io.Writer
+	progress []Progress
+}
+
+func newScriptProgressGroup(output io.Writer) *scriptProgressGroup {
+	return &scriptProgressGroup{output: output}
+}
+
+func (p *scriptProgressGroup) Add(message string) Progress {
+	progress := newScriptProgress(p.output, message)
+	p.progress = append(p.progress, progress)
+	return progress
+
+}
+
+func (p *scriptProgressGroup) Start() error {
+	for _, progress := range p.progress {
+		progress.Start()
+	}
+	return nil
+}
+
+func (p *scriptProgressGroup) Stop() error {
+	return nil
+}
+
+type scriptProgress struct {
+	output  io.Writer
+	message string
+}
+
+func newScriptProgress(output io.Writer, message string) *scriptProgress {
+	return &scriptProgress{output: output, message: message}
+}
+
+func (p *scriptProgress) Start() {
+	fmt.Fprintf(p.output, "%s ...\n", p.message)
+}
+
+func (p *scriptProgress) SetCurrent(value int) {}
+
+func (p *scriptProgress) SetSuccess() {
+	fmt.Fprintf(p.output, "%s ... done\n", p.message)
+}
+
+func (p *scriptProgress) SetError() {
+	fmt.Fprintf(p.output, "%s ... failed\n", p.message)
+}

--- a/internal/ui/progress_terminal.go
+++ b/internal/ui/progress_terminal.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"io"
+
+	"github.com/cheggaaa/pb/v3"
+)
+
+type terminalProgressGroup struct {
+	output io.Writer
+	el     *pb.Pool
+}
+
+func newTerminalProgressGroup(output io.Writer) *terminalProgressGroup {
+	return &terminalProgressGroup{output: output, el: pb.NewPool()}
+}
+
+func (p *terminalProgressGroup) Add(message string) Progress {
+	progress := newTerminalProgress(p.output, message)
+	p.el.Add(progress.el)
+	return progress
+}
+
+func (p *terminalProgressGroup) Start() error {
+	return p.el.Start()
+}
+
+func (p *terminalProgressGroup) Stop() error {
+	return p.el.Stop()
+}
+
+const (
+	terminalProgressRunningTpl = `{{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" }} {{ string . "message" }} {{ percent . }}`
+	terminalProgressSuccessTpl = `{{ green "✓" }} {{ string . "message" }} {{ percent . }}`
+	terminalProgressErrorTpl   = `{{ red "✗" }} {{ string . "message" }} {{ percent . }}`
+)
+
+type terminalProgress struct {
+	el *pb.ProgressBar
+}
+
+func newTerminalProgress(output io.Writer, message string) *terminalProgress {
+	p := &terminalProgress{pb.New(100)}
+	p.el.SetWriter(output)
+	p.el.SetTemplateString(terminalProgressRunningTpl)
+	p.el.Set("message", message)
+	return p
+}
+
+func (p *terminalProgress) Start() {
+	p.el.Start()
+}
+
+func (p *terminalProgress) SetCurrent(value int) {
+	p.el.SetCurrent(int64(value))
+}
+
+func (p *terminalProgress) SetSuccess() {
+	p.el.SetCurrent(int64(100))
+	p.el.SetTemplateString(terminalProgressSuccessTpl)
+	p.el.Finish()
+}
+
+func (p *terminalProgress) SetError() {
+	p.el.SetCurrent(100)
+	p.el.SetTemplate(terminalProgressErrorTpl)
+	p.el.Finish()
+}

--- a/internal/ui/progress_terminal.go
+++ b/internal/ui/progress_terminal.go
@@ -30,9 +30,9 @@ func (p *terminalProgressGroup) Stop() error {
 }
 
 const (
-	terminalProgressRunningTpl = `{{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" }} {{ string . "message" }} {{ percent . }}`
-	terminalProgressSuccessTpl = `{{ green "✓" }} {{ string . "message" }} {{ percent . }}`
-	terminalProgressErrorTpl   = `{{ red "✗" }} {{ string . "message" }} {{ percent . }}`
+	terminalProgressRunningTpl = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" }} {{ string . "message" }} {{ percent . }}`
+	terminalProgressSuccessTpl = ` {{ green "✓" }} {{ string . "message" }} {{ percent . }}`
+	terminalProgressErrorTpl   = ` {{ red "✗" }} {{ string . "message" }} {{ percent . }}`
 )
 
 type terminalProgress struct {

--- a/internal/ui/progress_terminal.go
+++ b/internal/ui/progress_terminal.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/cheggaaa/pb/v3"
@@ -15,8 +16,8 @@ func newTerminalProgressGroup(output io.Writer) *terminalProgressGroup {
 	return &terminalProgressGroup{output: output, el: pb.NewPool()}
 }
 
-func (p *terminalProgressGroup) Add(message string) Progress {
-	progress := newTerminalProgress(p.output, message)
+func (p *terminalProgressGroup) Add(message string, resources string) Progress {
+	progress := newTerminalProgress(p.output, message, resources)
 	p.el.Add(progress.el)
 	return progress
 }
@@ -30,20 +31,23 @@ func (p *terminalProgressGroup) Stop() error {
 }
 
 const (
-	terminalProgressRunningTpl = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" }} {{ string . "message" }} {{ percent . }}`
-	terminalProgressSuccessTpl = ` {{ green "✓" }} {{ string . "message" }} {{ percent . }}`
-	terminalProgressErrorTpl   = ` {{ red "✗" }} {{ string . "message" }} {{ percent . }}`
+	terminalProgressTpl = `{{ string . "message" }} {{ percent . "%3.f%%" | magenta }} {{ etime . | magenta }} {{ string . "resources" | magenta }}`
+
+	terminalProgressRunningTpl = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" | magenta }} ` + terminalProgressTpl
+	terminalProgressSuccessTpl = ` {{ green "✓" }} ` + terminalProgressTpl
+	terminalProgressErrorTpl   = ` {{ red "✗" }} ` + terminalProgressTpl
 )
 
 type terminalProgress struct {
 	el *pb.ProgressBar
 }
 
-func newTerminalProgress(output io.Writer, message string) *terminalProgress {
+func newTerminalProgress(output io.Writer, message string, resources string) *terminalProgress {
 	p := &terminalProgress{pb.New(100)}
 	p.el.SetWriter(output)
 	p.el.SetTemplateString(terminalProgressRunningTpl)
-	p.el.Set("message", message)
+	p.el.Set("message", fmt.Sprintf("%-60s", message))
+	p.el.Set("resources", resources)
 	return p
 }
 

--- a/internal/ui/progress_terminal.go
+++ b/internal/ui/progress_terminal.go
@@ -31,9 +31,9 @@ func (p *terminalProgressGroup) Stop() error {
 }
 
 const (
-	terminalProgressTpl = `{{ string . "message" }} {{ percent . "%3.f%%" | magenta }} {{ etime . | magenta }} {{ string . "resources" | magenta }}`
+	terminalProgressTpl = `{{ string . "message" }} {{ percent . "%3.f%%" | blue }} {{ etime . | blue }} {{ string . "resources" | blue }}`
 
-	terminalProgressRunningTpl = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" | magenta }} ` + terminalProgressTpl
+	terminalProgressRunningTpl = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" | blue }} ` + terminalProgressTpl
 	terminalProgressSuccessTpl = ` {{ green "✓" }} ` + terminalProgressTpl
 	terminalProgressErrorTpl   = ` {{ red "✗" }} ` + terminalProgressTpl
 )

--- a/internal/ui/progress_terminal.go
+++ b/internal/ui/progress_terminal.go
@@ -31,11 +31,11 @@ func (p *terminalProgressGroup) Stop() error {
 }
 
 const (
-	terminalProgressTpl = `{{ string . "message" }} {{ percent . "%3.f%%" | blue }} {{ etime . | blue }} {{ string . "resources" | blue }}`
+	termProgressRunning = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" | blue }} ` + termProgress
+	termProgressSuccess = ` {{ green "✓" }} ` + termProgress
+	termProgressError   = ` {{ red "✗" }} ` + termProgress
 
-	terminalProgressRunningTpl = ` {{ cycle . "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏" | blue }} ` + terminalProgressTpl
-	terminalProgressSuccessTpl = ` {{ green "✓" }} ` + terminalProgressTpl
-	terminalProgressErrorTpl   = ` {{ red "✗" }} ` + terminalProgressTpl
+	termProgress = `{{ string . "message" }} {{ percent . "%3.f%%" | blue }} {{ etime . | blue }} {{ string . "resources" | blue }}`
 )
 
 type terminalProgress struct {
@@ -45,7 +45,7 @@ type terminalProgress struct {
 func newTerminalProgress(output io.Writer, message string, resources string) *terminalProgress {
 	p := &terminalProgress{pb.New(100)}
 	p.el.SetWriter(output)
-	p.el.SetTemplateString(terminalProgressRunningTpl)
+	p.el.SetTemplateString(termProgressRunning)
 	p.el.Set("message", fmt.Sprintf("%-60s", message))
 	p.el.Set("resources", resources)
 	return p
@@ -61,12 +61,12 @@ func (p *terminalProgress) SetCurrent(value int) {
 
 func (p *terminalProgress) SetSuccess() {
 	p.el.SetCurrent(int64(100))
-	p.el.SetTemplateString(terminalProgressSuccessTpl)
+	p.el.SetTemplateString(termProgressSuccess)
 	p.el.Finish()
 }
 
 func (p *terminalProgress) SetError() {
 	p.el.SetCurrent(100)
-	p.el.SetTemplate(terminalProgressErrorTpl)
+	p.el.SetTemplate(termProgressError)
 	p.el.Finish()
 }

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressGroup(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+
+	progressGroup := NewProgressGroup(buffer)
+	progress1 := progressGroup.Add("progress 1")
+	progress2 := progressGroup.Add("progress 2")
+	progress3 := progressGroup.Add("progress 3")
+
+	if err := progressGroup.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	progress1.SetSuccess()
+	progress3.SetError()
+	progress2.SetSuccess()
+
+	if err := progressGroup.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t,
+		`progress 1 ...
+progress 2 ...
+progress 3 ...
+progress 1 ... done
+progress 3 ... failed
+progress 2 ... done
+`,
+		buffer.String())
+}
+
+func TestProgress(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+
+	progress1 := NewProgress(buffer, "progress 1")
+	progress1.Start()
+	progress1.SetSuccess()
+
+	assert.Equal(t,
+		`progress 1 ...
+progress 1 ... done
+`,
+		buffer.String())
+}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -11,9 +11,9 @@ func TestProgressGroup(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)
 
 	progressGroup := NewProgressGroup(buffer)
-	progress1 := progressGroup.Add("progress 1")
-	progress2 := progressGroup.Add("progress 2")
-	progress3 := progressGroup.Add("progress 3")
+	progress1 := progressGroup.Add("progress 1", "")
+	progress2 := progressGroup.Add("progress 2", "")
+	progress3 := progressGroup.Add("progress 3", "")
 
 	if err := progressGroup.Start(); err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ progress 2 ... done
 func TestProgress(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)
 
-	progress1 := NewProgress(buffer, "progress 1")
+	progress1 := NewProgress(buffer, "progress 1", "")
 	progress1.Start()
 	progress1.SetSuccess()
 


### PR DESCRIPTION
This replaces the 2 previous actions progress display with a single consistent one, that leverage the new `hcloud.ActionWaiter` functions.

![Screenshot from 2024-05-08 16-03-01](https://github.com/hetznercloud/cli/assets/19195485/4c106811-9aac-4038-a6f7-f8895c2b122d)
![Screenshot from 2024-05-08 16-03-04](https://github.com/hetznercloud/cli/assets/19195485/2909b6e7-c396-48c8-9270-2fbcf37d4d1d)


The progress features have been extracted in a dedicated `ui` package to split the actions waiting and the progress concerns.