### PR TITLE
feat: improve toml formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hetznercloud/cli
 go 1.21
 
 require (
+	github.com/BurntSushi/toml v1.3.2
 	github.com/boumenot/gocover-cobertura v1.2.0
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/dustin/go-humanize v1.0.1
@@ -13,7 +14,6 @@ require (
 	github.com/guptarohit/asciigraph v0.7.1
 	github.com/hetznercloud/hcloud-go/v2 v2.9.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
-	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
@@ -35,6 +35,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/cmd/config/add_test.go
+++ b/internal/cmd/config/add_test.go
@@ -32,30 +32,27 @@ func TestAdd(t *testing.T) {
 	)
 	defer deleteNestedArrayOption()
 
-	testConfig := `active_context = 'test_context'
+	testConfig := `active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `
 
 	type testCase struct {
@@ -74,30 +71,27 @@ poll_interval = 1234000000
 			args:   []string{"array-option", "a", "b", "c"},
 			config: testConfig,
 			expOut: `Added '[a b c]' to 'array-option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3', 'a', 'b', 'c']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3", "a", "b", "c"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -105,30 +99,27 @@ poll_interval = 1234000000
 			args:   []string{"nested.array-option", "a", "b", "c"},
 			config: testConfig,
 			expOut: `Added '[a b c]' to 'nested.array-option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3', 'a', 'b', 'c']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3", "a", "b", "c"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -136,31 +127,28 @@ poll_interval = 1234000000
 			args:   []string{"--global", "array-option", "a", "b", "c"},
 			config: testConfig,
 			expOut: `Added '[a b c]' to 'array-option' globally
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-array_option = ['a', 'b', 'c']
-debug = true
-poll_interval = 1234000000
+  array_option = ["a", "b", "c"]
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -169,31 +157,28 @@ poll_interval = 1234000000
 			config: testConfig,
 			expErr: "Warning: some values were already present or duplicate\n",
 			expOut: `Added '[a b c]' to 'array-option' globally
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-array_option = ['a', 'b', 'c']
-debug = true
-poll_interval = 1234000000
+  array_option = ["a", "b", "c"]
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -207,31 +192,28 @@ poll_interval = 1234000000
 			args:   []string{"array-option", "I", "II", "III"},
 			config: testConfig,
 			expOut: `Added '[I II III]' to 'array-option' in context 'other_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-array_option = ['I', 'II', 'III']
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    array_option = ["I", "II", "III"]
+    poll_interval = "1.234s"
 `,
 		},
 	}

--- a/internal/cmd/config/remove_test.go
+++ b/internal/cmd/config/remove_test.go
@@ -32,30 +32,27 @@ func TestRemove(t *testing.T) {
 	)
 	defer deleteNestedArrayOption()
 
-	testConfig := `active_context = 'test_context'
+	testConfig := `active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `
 
 	type testCase struct {
@@ -75,30 +72,27 @@ poll_interval = 1234000000
 			args:   []string{"array-option", "2", "3"},
 			config: testConfig,
 			expOut: `Removed '[2 3]' from 'array-option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -106,29 +100,26 @@ poll_interval = 1234000000
 			args:   []string{"array-option", "1", "2", "3"},
 			config: testConfig,
 			expOut: `Removed '[1 2 3]' from 'array-option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1', '2', '3']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1", "2", "3"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -143,30 +134,27 @@ poll_interval = 1234000000
 			args:   []string{"nested.array-option", "2", "3"},
 			config: testConfig,
 			expOut: `Removed '[2 3]' from 'nested.array-option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-array_option = ['1']
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      array_option = ["1"]
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -174,27 +162,25 @@ poll_interval = 1234000000
 			args:   []string{"nested.array-option", "1", "2", "3"},
 			config: testConfig,
 			expOut: `Removed '[1 2 3]' from 'nested.array-option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['1', '2', '3']
-endpoint = 'https://test-endpoint.com'
-quiet = true
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["1", "2", "3"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{

--- a/internal/cmd/config/set_test.go
+++ b/internal/cmd/config/set_test.go
@@ -41,26 +41,24 @@ func TestSet(t *testing.T) {
 	)
 	defer deleteArrayOption()
 
-	testConfig := `active_context = 'test_context'
+	testConfig := `active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `
 
 	type testCase struct {
@@ -80,27 +78,25 @@ poll_interval = 1234000000
 			args:   []string{"debug-file", "debug.log"},
 			config: testConfig,
 			expOut: `Set 'debug-file' to 'debug.log' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-debug_file = 'debug.log'
-endpoint = 'https://test-endpoint.com'
-quiet = true
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    debug_file = "debug.log"
+    endpoint = "https://test-endpoint.com"
+    quiet = true
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -116,27 +112,25 @@ poll_interval = 1234000000
 			args:   []string{"debug", "false"},
 			config: testConfig,
 			expOut: `Set 'debug' to 'false' in context 'other_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-debug = false
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    debug = false
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -144,26 +138,24 @@ poll_interval = 1234000000
 			args:   []string{"--global", "poll-interval", "50ms"},
 			config: testConfig,
 			expOut: `Set 'poll-interval' to '50ms' globally
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 50000000
+  debug = true
+  poll_interval = "50ms"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -171,29 +163,26 @@ poll_interval = 1234000000
 			args:   []string{"nested.option", "bar"},
 			config: testConfig,
 			expOut: `Set 'nested.option' to 'bar' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-option = 'bar'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      option = "bar"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -201,30 +190,27 @@ poll_interval = 1234000000
 			args:   []string{"deeply.nested.option", "bar"},
 			config: testConfig,
 			expOut: `Set 'deeply.nested.option' to 'bar' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -232,27 +218,25 @@ poll_interval = 1234000000
 			args:   []string{"array-option", "a", "b", "c"},
 			config: testConfig,
 			expOut: `Set 'array-option' to '[a b c]' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-array_option = ['a', 'b', 'c']
-endpoint = 'https://test-endpoint.com'
-quiet = true
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    array_option = ["a", "b", "c"]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -273,10 +257,10 @@ poll_interval = 1234000000
 			name: "set in empty config global",
 			args: []string{"debug", "false", "--global"},
 			expOut: `Set 'debug' to 'false' globally
-active_context = ''
+active_context = ""
 
 [preferences]
-debug = false
+  debug = false
 `,
 		},
 	}

--- a/internal/cmd/config/unset_test.go
+++ b/internal/cmd/config/unset_test.go
@@ -32,33 +32,29 @@ func TestUnset(t *testing.T) {
 	)
 	defer deleteDeeplyNestedOption()
 
-	testConfig := `active_context = 'test_context'
+	testConfig := `active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
-
-[contexts.preferences.nested]
-option = 'foo'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
+    [contexts.preferences.nested]
+      option = "foo"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `
 
 	type testCase struct {
@@ -78,32 +74,28 @@ poll_interval = 1234000000
 			args:   []string{"quiet"},
 			config: testConfig,
 			expOut: `Unset 'quiet' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
-
-[contexts.preferences.nested]
-option = 'foo'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
+    [contexts.preferences.nested]
+      option = "foo"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -119,30 +111,27 @@ poll_interval = 1234000000
 			args:   []string{"poll-interval"},
 			config: testConfig,
 			expOut: `Unset 'poll-interval' in context 'other_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
-
-[contexts.preferences.nested]
-option = 'foo'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
+    [contexts.preferences.nested]
+      option = "foo"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
+  name = "other_context"
+  token = "another super secret token"
 `,
 		},
 		{
@@ -150,32 +139,28 @@ token = 'another super secret token'
 			args:   []string{"debug", "--global"},
 			config: testConfig,
 			expOut: `Unset 'debug' globally
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-poll_interval = 1234000000
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
-
-[contexts.preferences.nested]
-option = 'foo'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
+    [contexts.preferences.nested]
+      option = "foo"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -191,33 +176,29 @@ poll_interval = 1234000000
 			config: testConfig,
 			expErr: "Warning: key 'debug-file' was not set\n",
 			expOut: `Unset 'debug-file' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
-
-[contexts.preferences.nested]
-option = 'foo'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
+    [contexts.preferences.nested]
+      option = "foo"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -225,30 +206,27 @@ poll_interval = 1234000000
 			args:   []string{"nested.option"},
 			config: testConfig,
 			expOut: `Unset 'nested.option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.deeply]
-[contexts.preferences.deeply.nested]
-option = 'bar'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.deeply]
+      [contexts.preferences.deeply.nested]
+        option = "bar"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 		{
@@ -256,29 +234,26 @@ poll_interval = 1234000000
 			args:   []string{"deeply.nested.option"},
 			config: testConfig,
 			expOut: `Unset 'deeply.nested.option' in context 'test_context'
-active_context = 'test_context'
+active_context = "test_context"
 
 [preferences]
-debug = true
-poll_interval = 1234000000
+  debug = true
+  poll_interval = "1.234s"
 
 [[contexts]]
-name = 'test_context'
-token = 'super secret token'
-
-[contexts.preferences]
-endpoint = 'https://test-endpoint.com'
-quiet = true
-
-[contexts.preferences.nested]
-option = 'foo'
+  name = "test_context"
+  token = "super secret token"
+  [contexts.preferences]
+    endpoint = "https://test-endpoint.com"
+    quiet = true
+    [contexts.preferences.nested]
+      option = "foo"
 
 [[contexts]]
-name = 'other_context'
-token = 'another super secret token'
-
-[contexts.preferences]
-poll_interval = 1234000000
+  name = "other_context"
+  token = "another super secret token"
+  [contexts.preferences]
+    poll_interval = "1.234s"
 `,
 		},
 	}

--- a/internal/state/config/config.go
+++ b/internal/state/config/config.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pelletier/go-toml/v2"
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 

--- a/internal/state/config/preferences.go
+++ b/internal/state/config/preferences.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pelletier/go-toml/v2"
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
This PR changes the TOML library from `pelletier/go-toml/v2` to `BurntSushi/toml`. This improves the formatting of TOML files by using indents and also uses `time.Duration`'s string values instead of writing nanoseconds into the config file.

### Config format example

Before:
```toml
active_context = 'test_context'

[preferences]
debug = true
poll_interval = 1234000000

[[contexts]]
name = 'test_context'
token = 'super secret token'

[contexts.preferences]
array_option = ['1', '2', '3']
endpoint = 'https://test-endpoint.com'
quiet = true

[contexts.preferences.nested]
array_option = ['1', '2', '3']

[[contexts]]
name = 'other_context'
token = 'another super secret token'

[contexts.preferences]
poll_interval = 1234000000
```

After:
```toml
active_context = "test_context"

[preferences]
  debug = true
  poll_interval = "1.234s"

[[contexts]]
  name = "test_context"
  token = "super secret token"
  [contexts.preferences]
    array_option = ["1", "2", "3"]
    endpoint = "https://test-endpoint.com"
    quiet = true
    [contexts.preferences.nested]
      array_option = ["1", "2", "3"]

[[contexts]]
  name = "other_context"
  token = "another super secret token"
  [contexts.preferences]
    poll_interval = "1.234s"
```

Contexts are now grouped together instead of there being exactly one newline between every section, regardless of being in another context or not. Also, nested sections are now indented, which helps with understanding the structure.

### Binary size
Before:
```
➜  cli git:(21e342b) GOARCH=amd64 GOOS=linux go build -o hcloud cmd/hcloud/main.go
➜  cli git:(21e342b) wc -c hcloud                                                 
 20606086 hcloud
```

After:
```
➜  cli git:(d336765) GOARCH=amd64 GOOS=linux go build -o hcloud cmd/hcloud/main.go
➜  cli git:(d336765) wc -c hcloud 
 20890490 hcloud
```

The binary size increases by ~1.4%, which is negligible.
