### PR TITLE
feat(server): add default-ssh-keys option

### DIFF
--- a/internal/cmd/config/helptext/preferences.txt
+++ b/internal/cmd/config/helptext/preferences.txt
@@ -1,19 +1,22 @@
-┌───────────────┬──────────────────────┬──────────┬───────────────┬──────────────────────┬─────────────────┐
-│ OPTION        │ DESCRIPTION          │ TYPE     │ CONFIG KEY    │ ENVIRONMENT VARIABLE │ FLAG            │
-├───────────────┼──────────────────────┼──────────┼───────────────┼──────────────────────┼─────────────────┤
-│ debug         │ Enable debug output  │ boolean  │ debug         │ HCLOUD_DEBUG         │ --debug         │
-├───────────────┼──────────────────────┼──────────┼───────────────┼──────────────────────┼─────────────────┤
-│ debug-file    │ File to write debug  │ string   │ debug_file    │ HCLOUD_DEBUG_FILE    │ --debug-file    │
-│               │ output to            │          │               │                      │                 │
-├───────────────┼──────────────────────┼──────────┼───────────────┼──────────────────────┼─────────────────┤
-│ endpoint      │ Hetzner Cloud API    │ string   │ endpoint      │ HCLOUD_ENDPOINT      │ --endpoint      │
-│               │ endpoint             │          │               │                      │                 │
-├───────────────┼──────────────────────┼──────────┼───────────────┼──────────────────────┼─────────────────┤
-│ poll-interval │ Interval at which to │ duration │ poll_interval │ HCLOUD_POLL_INTERVAL │ --poll-interval │
-│               │ poll information,    │          │               │                      │                 │
-│               │ for example action   │          │               │                      │                 │
-│               │ progress             │          │               │                      │                 │
-├───────────────┼──────────────────────┼──────────┼───────────────┼──────────────────────┼─────────────────┤
-│ quiet         │ If true, only print  │ boolean  │ quiet         │ HCLOUD_QUIET         │ --quiet         │
-│               │ error messages       │          │               │                      │                 │
-└───────────────┴──────────────────────┴──────────┴───────────────┴──────────────────────┴─────────────────┘
+┌──────────────────┬──────────────────────┬─────────────┬──────────────────┬─────────────────────────┬─────────────────┐
+│ OPTION           │ DESCRIPTION          │ TYPE        │ CONFIG KEY       │ ENVIRONMENT VARIABLE    │ FLAG            │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
+│ debug            │ Enable debug output  │ boolean     │ debug            │ HCLOUD_DEBUG            │ --debug         │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
+│ debug-file       │ File to write debug  │ string      │ debug_file       │ HCLOUD_DEBUG_FILE       │ --debug-file    │
+│                  │ output to            │             │                  │                         │                 │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
+│ default-ssh-keys │ Default SSH keys for │ string list │ default_ssh_keys │ HCLOUD_DEFAULT_SSH_KEYS │                 │
+│                  │ new servers          │             │                  │                         │                 │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
+│ endpoint         │ Hetzner Cloud API    │ string      │ endpoint         │ HCLOUD_ENDPOINT         │ --endpoint      │
+│                  │ endpoint             │             │                  │                         │                 │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
+│ poll-interval    │ Interval at which to │ duration    │ poll_interval    │ HCLOUD_POLL_INTERVAL    │ --poll-interval │
+│                  │ poll information,    │             │                  │                         │                 │
+│                  │ for example action   │             │                  │                         │                 │
+│                  │ progress             │             │                  │                         │                 │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
+│ quiet            │ If true, only print  │ boolean     │ quiet            │ HCLOUD_QUIET            │ --quiet         │
+│                  │ error messages       │             │                  │                         │                 │
+└──────────────────┴──────────────────────┴─────────────┴──────────────────┴─────────────────────────┴─────────────────┘

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/cli/internal/state/config"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/actionutils"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -352,6 +353,10 @@ func createOptsFromFlags(
 		if err != nil {
 			return
 		}
+	}
+
+	if !flags.Changed("ssh-key") && config.OptionDefaultSSHKeys.Changed(s.Config()) {
+		sshKeys = config.OptionDefaultSSHKeys.Get(s.Config())
 	}
 
 	for _, sshKeyIDOrName := range sshKeys {

--- a/internal/state/config/options.go
+++ b/internal/state/config/options.go
@@ -134,6 +134,14 @@ var (
 		DefaultPreferenceFlags,
 		nil,
 	)
+
+	OptionDefaultSSHKeys = newOpt(
+		"default-ssh-keys",
+		"Default SSH keys for new servers",
+		[]string{},
+		(DefaultPreferenceFlags&^OptionFlagPFlag)|OptionFlagSlice,
+		nil,
+	)
 )
 
 type Option[T any] struct {


### PR DESCRIPTION
This PR adds the `default-ssh-keys` option which allows you to define a list of SSH keys to be used as defaults for the `hcloud server create` command.