### PR TITLE
fix: track progress if the terminal width allows it

### DIFF
--- a/internal/state/actions_test.go
+++ b/internal/state/actions_test.go
@@ -49,8 +49,8 @@ func TestWaitForActionsSuccess(t *testing.T) {
 
 	assert.Equal(t,
 		strings.Join([]string{
-			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
-			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ... done\n",
+			"Waiting for attach_volume (server: 46830545, volume: 46830546) ...\n",
+			"Waiting for attach_volume (server: 46830545, volume: 46830546) ... done\n",
 		}, ""),
 		stderr,
 	)
@@ -92,8 +92,8 @@ func TestWaitForActionsError(t *testing.T) {
 
 	assert.Equal(t,
 		strings.Join([]string{
-			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ...\n",
-			"Waiting for attach_volume to complete (server: 46830545, volume: 46830546) ... failed\n",
+			"Waiting for attach_volume (server: 46830545, volume: 46830546) ...\n",
+			"Waiting for attach_volume (server: 46830545, volume: 46830546) ... failed\n",
 		}, ""),
 		stderr,
 	)

--- a/internal/ui/actions.go
+++ b/internal/ui/actions.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ActionMessage(action *hcloud.Action) string {
-	return fmt.Sprintf("Waiting for %s to complete", color.New(color.Bold).Sprint(action.Command))
+	return fmt.Sprintf("Waiting for %s", color.New(color.Bold).Sprint(action.Command))
 }
 
 // FakeActionMessage returns the initial value with a unused color to grow the string

--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -27,7 +27,7 @@ func TestMessages(t *testing.T) {
 					{ID: 46830545, Type: hcloud.ActionResourceTypeServer},
 				},
 			},
-			wantAction:    "Waiting for create_server to complete",
+			wantAction:    "Waiting for create_server",
 			wantResources: "(server: 46830545)",
 		},
 		{
@@ -42,7 +42,7 @@ func TestMessages(t *testing.T) {
 					{ID: 46830546, Type: hcloud.ActionResourceTypeVolume},
 				},
 			},
-			wantAction:    "Waiting for attach_volume to complete",
+			wantAction:    "Waiting for attach_volume",
 			wantResources: "(server: 46830545, volume: 46830546)",
 		},
 		{
@@ -53,7 +53,7 @@ func TestMessages(t *testing.T) {
 				Status:   hcloud.ActionStatusRunning,
 				Progress: 0,
 			},
-			wantAction:    "Waiting for create_server to complete",
+			wantAction:    "Waiting for create_server",
 			wantResources: "",
 		},
 	}
@@ -73,9 +73,9 @@ func TestFakeActionMessages(t *testing.T) {
 	fakeMessage := FakeActionMessage("Some random message")
 
 	// The padding is important
-	actionMessage = fmt.Sprintf("%-60s", actionMessage)
-	fakeMessage = fmt.Sprintf("%-60s", fakeMessage)
+	actionMessage = fmt.Sprintf("%-40s", actionMessage)
+	fakeMessage = fmt.Sprintf("%-40s", fakeMessage)
 
-	assert.Equal(t, actionMessage, "Waiting for create_server to complete                       ")
-	assert.Equal(t, fakeMessage, "Some random message                                         ")
+	assert.Equal(t, "Waiting for create_server               ", actionMessage)
+	assert.Equal(t, "Some random message                     ", fakeMessage)
 }

--- a/internal/ui/helpers.go
+++ b/internal/ui/helpers.go
@@ -10,3 +10,13 @@ import (
 func StdoutIsTerminal() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
+
+// TerminalWidth returns the width of the terminal.
+func TerminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 0
+	}
+
+	return width
+}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -11,7 +11,7 @@ type ProgressGroup interface {
 }
 
 func NewProgressGroup(output io.Writer) ProgressGroup {
-	if StdoutIsTerminal() {
+	if StdoutIsTerminal() && TerminalWidth() > 80 {
 		return newTerminalProgressGroup(output)
 	} else {
 		return newScriptProgressGroup(output)
@@ -26,7 +26,7 @@ type Progress interface {
 }
 
 func NewProgress(output io.Writer, message string, resources string) Progress {
-	if StdoutIsTerminal() {
+	if StdoutIsTerminal() && TerminalWidth() > 80 {
 		return newTerminalProgress(output, message, resources)
 	} else {
 		return newScriptProgress(output, message, resources)

--- a/internal/ui/progress_terminal.go
+++ b/internal/ui/progress_terminal.go
@@ -46,7 +46,7 @@ func newTerminalProgress(output io.Writer, message string, resources string) *te
 	p := &terminalProgress{pb.New(100)}
 	p.el.SetWriter(output)
 	p.el.SetTemplateString(termProgressRunning)
-	p.el.Set("message", fmt.Sprintf("%-60s", message))
+	p.el.Set("message", fmt.Sprintf("%-40s", message))
 	p.el.Set("resources", resources)
 	return p
 }


### PR DESCRIPTION
- Reduce the width of the actions messages (remove 'to complete')
- Only print progress when the terminal width is bigger than 80.
- Reduce the padding when printing the actions messages

Fixes #767 