### PR TITLE
ci: improve goreleaser pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,42 +3,28 @@ before:
     - go mod tidy
 
 builds:
-  - id: hcloud-build
-    main: ./cmd/hcloud/main.go
-    binary: hcloud
-    ldflags:
-      - -w
-      - -X {{ .ModulePath }}/internal/version.version={{ .Version }}
-      - -X {{ .ModulePath }}/internal/version.versionPrerelease={{- if .IsSnapshot -}}dev+{{ .ShortCommit }}{{- end -}}
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - freebsd
-      - windows
-      - linux
-    goarch:
-      - amd64
-      - arm
-      - arm64
-      - "386"
-    goarm:
-      - "6"
-      - "7"
+  - <<: &build_defaults
+      main: ./cmd/hcloud/main.go
+      binary: hcloud
+      flags:
+        - -trimpath
+      ldflags:
+        - -s
+        - -w
+        - -X {{ .ModulePath }}/internal/version.version={{ .Version }}
+        - -X {{ .ModulePath }}/internal/version.versionPrerelease={{- if .IsSnapshot -}}dev+{{ .ShortCommit }}{{- end -}}
+      env:
+        - CGO_ENABLED=0
 
-  - id: hcloud-build-darwin
-    main: ./cmd/hcloud/main.go
-    binary: hcloud
-    ldflags:
-      - -w
-      - -X {{ .ModulePath }}/internal/version.version={{ .Version }}
-      - -X {{ .ModulePath }}/internal/version.versionPrerelease={{- if .IsSnapshot -}}dev+{{ .ShortCommit }}{{- end -}}
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    id: hcloud-build
+    goos: [freebsd, windows, linux]
+    goarch: [amd64, arm, arm64, "386"]
+    goarm: ["6", "7"]
+
+  - <<: *build_defaults
+    id: hcloud-build-darwin
+    goos: [darwin]
+    goarch: [amd64, arm64]
     hooks:
       post:
         - cmd: >


### PR DESCRIPTION
This PR improves the goreleaser pipeline in the following ways:
- It utilizes the [YAML merge key](https://yaml.org/type/merge.html) to reduce code duplication
- It adds the `-s` ldflag to reduce binary size: [Omit the symbol table and debug information.](https://pkg.go.dev/cmd/link)
- It adds the `-trimpath` flag to trim absolute file paths from build output

Binary size of `linux/amd64` build on:
- 069fffe48bb09f23edcade9e73f351a8b361a2a5: 14192497 B
- d0dfda9dd855c25a6815019f8dc72c07dff69fb6: 12738712 B

-> File size reduction is about 10%.