### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ ID       NAME                    STATUS    IPV4
 ### Create a server
 
 ```
-$ hcloud server create --name test --image debian-9 --type cx11 --ssh-key demo
+$ hcloud server create --name test --image debian-9 --type cx22 --ssh-key demo
    7s [====================================================================] 100%
 Server 325211 created
 ```

--- a/internal/cmd/datacenter/describe_test.go
+++ b/internal/cmd/datacenter/describe_test.go
@@ -60,29 +60,24 @@ func TestDescribeWithTypes(t *testing.T) {
 
 	serverTypes := []*hcloud.ServerType{
 		{
-			ID:          1,
-			Name:        "cx11",
-			Description: "CX11",
-		},
-		{
 			ID:          3,
-			Name:        "cx21",
-			Description: "CX21",
+			Name:        "cx22",
+			Description: "CX22",
 		},
 		{
 			ID:          5,
-			Name:        "cx31",
-			Description: "CX31",
+			Name:        "cx32",
+			Description: "CX32",
 		},
 		{
 			ID:          7,
-			Name:        "cx41",
-			Description: "CX41",
+			Name:        "cx42",
+			Description: "CX42",
 		},
 		{
 			ID:          9,
-			Name:        "cx51",
-			Description: "CX51",
+			Name:        "cx52",
+			Description: "CX52",
 		},
 	}
 
@@ -124,37 +119,31 @@ Location:
   Longitude:	0.000000
 Server Types:
   Available:
-  - ID:		 1
-    Name:	 cx11
-    Description: CX11
   - ID:		 3
-    Name:	 cx21
-    Description: CX21
+    Name:	 cx22
+    Description: CX22
   - ID:		 5
-    Name:	 cx31
-    Description: CX31
+    Name:	 cx32
+    Description: CX32
   - ID:		 7
-    Name:	 cx41
-    Description: CX41
+    Name:	 cx42
+    Description: CX42
   - ID:		 9
-    Name:	 cx51
-    Description: CX51
+    Name:	 cx52
+    Description: CX52
   Supported:
-  - ID:		 1
-    Name:	 cx11
-    Description: CX11
   - ID:		 3
-    Name:	 cx21
-    Description: CX21
+    Name:	 cx22
+    Description: CX22
   - ID:		 5
-    Name:	 cx31
-    Description: CX31
+    Name:	 cx32
+    Description: CX32
   - ID:		 7
-    Name:	 cx41
-    Description: CX41
+    Name:	 cx42
+    Description: CX42
   - ID:		 9
-    Name:	 cx51
-    Description: CX51
+    Name:	 cx52
+    Description: CX52
 `
 
 	assert.NoError(t, err)

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -27,7 +27,7 @@ func TestCreate(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	fx.Client.ServerTypeClient.EXPECT().
-		Get(gomock.Any(), "cx11").
+		Get(gomock.Any(), "cx22").
 		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) {
 		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 123}, {ID: 234}}).
 		Return(nil)
 
-	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
+	args := []string{"--name", "cli-test", "--type", "cx22", "--image", "ubuntu-20.04"}
 	out, errOut, err := fx.Run(cmd, args)
 
 	assert.NoError(t, err)
@@ -103,7 +103,7 @@ func TestCreateJSON(t *testing.T) {
 		},
 		ServerType: &hcloud.ServerType{
 			ID:           1,
-			Name:         "cx11",
+			Name:         "cx22",
 			Cores:        1,
 			CPUType:      "shared",
 			Memory:       2,
@@ -137,7 +137,7 @@ func TestCreateJSON(t *testing.T) {
 	}
 
 	fx.Client.ServerTypeClient.EXPECT().
-		Get(gomock.Any(), "cx11").
+		Get(gomock.Any(), "cx22").
 		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
@@ -160,7 +160,7 @@ func TestCreateJSON(t *testing.T) {
 		WaitForActions(gomock.Any(), gomock.Any(), []*hcloud.Action{{ID: 123}, {ID: 234}}).
 		Return(nil)
 
-	args := []string{"-o=json", "--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04"}
+	args := []string{"-o=json", "--name", "cli-test", "--type", "cx22", "--image", "ubuntu-20.04"}
 	jsonOut, out, err := fx.Run(cmd, args)
 
 	expOut := "Server 1234 created\n"
@@ -180,7 +180,7 @@ func TestCreateProtectionBackup(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	fx.Client.ServerTypeClient.EXPECT().
-		Get(gomock.Any(), "cx11").
+		Get(gomock.Any(), "cx22").
 		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
@@ -239,7 +239,7 @@ func TestCreateProtectionBackup(t *testing.T) {
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 42}).Return(nil)
 
-	args := []string{"--name", "cli-test", "--type", "cx11", "--image", "ubuntu-20.04", "--enable-protection", "rebuild,delete", "--enable-backup"}
+	args := []string{"--name", "cli-test", "--type", "cx22", "--image", "ubuntu-20.04", "--enable-protection", "rebuild,delete", "--enable-backup"}
 	out, errOut, err := fx.Run(cmd, args)
 
 	assert.NoError(t, err)

--- a/internal/cmd/server/testdata/create_response.json
+++ b/internal/cmd/server/testdata/create_response.json
@@ -96,7 +96,7 @@
       "id": 1,
       "included_traffic": 0,
       "memory": 2,
-      "name": "cx11",
+      "name": "cx22",
       "prices": null,
       "storage_type": "local"
     },


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated