### PR TITLE
feat(server-type): add deprecated column to list command

### DIFF
--- a/internal/cmd/servertype/list.go
+++ b/internal/cmd/servertype/list.go
@@ -49,6 +49,13 @@ var ListCmd = base.ListCmd{
 			AddFieldFn("traffic", func(obj interface{}) string {
 				serverType := obj.(*hcloud.ServerType)
 				return fmt.Sprintf("%d TB", serverType.IncludedTraffic/util.Tebibyte)
+			}).
+			AddFieldFn("deprecated", func(obj interface{}) string {
+				serverType := obj.(*hcloud.ServerType)
+				if !serverType.IsDeprecated() {
+					return "-"
+				}
+				return util.Datetime(serverType.UnavailableAfter())
 			})
 	},
 


### PR DESCRIPTION
Adds a new column to `hcloud server-type list -o=columns=deprecated` that shows the time when the resource is going to be made unavailable. This matches the current behavior in `hcloud image list`.