### PR TITLE
fix: network list server count format

### DIFF
--- a/internal/cmd/network/list.go
+++ b/internal/cmd/network/list.go
@@ -41,7 +41,7 @@ var ListCmd = base.ListCmd{
 			AddFieldFn("servers", output.FieldFn(func(obj interface{}) string {
 				network := obj.(*hcloud.Network)
 				serverCount := len(network.Servers)
-				if serverCount <= 1 {
+				if serverCount == 1 {
 					return fmt.Sprintf("%v server", serverCount)
 				}
 				return fmt.Sprintf("%v servers", serverCount)


### PR DESCRIPTION
The server count would previously show "0 server" instead of "0 servers"