### PR TITLE
fix: duplicate usage output

### DIFF
--- a/internal/state/config/config.go
+++ b/internal/state/config/config.go
@@ -85,6 +85,7 @@ func (cfg *config) reset() {
 	cfg.v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	cfg.fs = pflag.NewFlagSet("hcloud", pflag.ContinueOnError)
+	cfg.fs.Usage = func() {} // disable usage output
 	for _, o := range Options {
 		o.addToFlagSet(cfg.fs)
 	}


### PR DESCRIPTION
When a `*pflag.FlagSet` is parsed, it outputs a usage string if the `--help` flag is included. Since Cobra already does this, this behavior needs to be disabled or the usage will be printed twice.

---

Since #736 hasn't been release yet, this fix shouldn't appear in the changelog.

BEGIN_COMMIT_OVERRIDE
chore: fix duplicate usage output
END_COMMIT_OVERRIDE