### PR TITLE
docs(server): update ssh command usage string

### DIFF
--- a/internal/cmd/server/ssh.go
+++ b/internal/cmd/server/ssh.go
@@ -21,7 +21,7 @@ var SSHPath = "ssh"
 var SSHCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
-			Use:                   "ssh [options] <server> [command...]",
+			Use:                   "ssh [options] <server> [--] [ssh options] [command [argument...]]",
 			Short:                 "Spawn an SSH connection for the server",
 			Args:                  util.ValidateLenient,
 			ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(client.Server().Names)),


### PR DESCRIPTION
The current usage string creates confusion about whether it is possible to pass flags to the ssh binary or not (See #782). The new usage strings explicitly states that this is possible. It also states that it is possible to use a double dash (`--`) to separate hcloud flags from ssh flags.
