### PR TITLE
fix: ineffective poll interval option

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -117,7 +117,7 @@ func (c *state) newClient() (hcapi2.Client, error) {
 	}
 
 	if pollInterval > 0 {
-		opts = append(opts, hcloud.WithBackoffFunc(hcloud.ConstantBackoff(pollInterval)))
+		opts = append(opts, hcloud.WithPollBackoffFunc(hcloud.ConstantBackoff(pollInterval)))
 	}
 
 	return hcapi2.NewClient(opts...), nil


### PR DESCRIPTION
 The hcloud client option name was using the retry back off option instead of the poll back off option.
