### PR TITLE
feat: new APIs for traffic pricings 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/goccy/go-yaml v1.12.0
 	github.com/golang/mock v1.6.0
 	github.com/guptarohit/asciigraph v0.7.1
-	github.com/hetznercloud/hcloud-go/v2 v2.11.0
+	github.com/hetznercloud/hcloud-go/v2 v2.12.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/guptarohit/asciigraph v0.7.1 h1:K+JWbRc04XEfv8BSZgNuvhCmpbvX4+9NYd/Ux
 github.com/guptarohit/asciigraph v0.7.1/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hetznercloud/hcloud-go/v2 v2.11.0 h1:U1wD58/trMnKO6aHy2i2aguT5USwWbzC2hWj3r2sidE=
-github.com/hetznercloud/hcloud-go/v2 v2.11.0/go.mod h1:dhix40Br3fDiBhwaSG/zgaYOFFddpfBm/6R1Zz0IiF0=
+github.com/hetznercloud/hcloud-go/v2 v2.12.0 h1:nOgfNTo0gyXZJJdM8mo/XH5MO/e80wAEpldRzdWayhY=
+github.com/hetznercloud/hcloud-go/v2 v2.12.0/go.mod h1:dhix40Br3fDiBhwaSG/zgaYOFFddpfBm/6R1Zz0IiF0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jedib0t/go-pretty/v6 v6.5.9 h1:ACteMBRrrmm1gMsXe9PSTOClQ63IXDUt03H5U+UV8OU=

--- a/internal/cmd/loadbalancertype/describe.go
+++ b/internal/cmd/loadbalancertype/describe.go
@@ -1,6 +1,7 @@
 package loadbalancertype
 
 import (
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
@@ -42,9 +43,12 @@ var DescribeCmd = base.DescribeCmd{
 		if pricings != nil {
 			cmd.Printf("Pricings per Location:\n")
 			for _, price := range pricings {
-				cmd.Printf("  - Location:\t%s\n", price.Location.Name)
-				cmd.Printf("    Hourly:\t%s\n", util.GrossPrice(price.Hourly))
-				cmd.Printf("    Monthly:\t%s\n", util.GrossPrice(price.Monthly))
+				cmd.Printf("  - Location:\t\t%s\n", price.Location.Name)
+				cmd.Printf("    Hourly:\t\t%s\n", util.GrossPrice(price.Hourly))
+				cmd.Printf("    Monthly:\t\t%s\n", util.GrossPrice(price.Monthly))
+				cmd.Printf("    Included Traffic:\t%s\n", humanize.IBytes(price.IncludedTraffic))
+				cmd.Printf("    Additional Traffic:\t%s per TB\n", util.GrossPrice(price.PerTBTraffic))
+				cmd.Printf("\n")
 			}
 		}
 

--- a/internal/cmd/loadbalancertype/describe_test.go
+++ b/internal/cmd/loadbalancertype/describe_test.go
@@ -49,6 +49,11 @@ func TestDescribe(t *testing.T) {
 							Gross:    "7.0000",
 							Currency: "EUR",
 						},
+						IncludedTraffic: 6543210,
+						PerTBTraffic: hcloud.Price{
+							Gross:    "8.0000",
+							Currency: "EUR",
+						},
 					}},
 				},
 				{
@@ -63,6 +68,11 @@ func TestDescribe(t *testing.T) {
 						},
 						Monthly: hcloud.Price{
 							Gross:    "2.0000",
+							Currency: "EUR",
+						},
+						IncludedTraffic: 654321,
+						PerTBTraffic: hcloud.Price{
+							Gross:    "3.0000",
 							Currency: "EUR",
 						},
 					}},
@@ -80,9 +90,12 @@ Max Connections:		10000
 Max Targets:			25
 Max assigned Certificates:	10
 Pricings per Location:
-  - Location:	Falkenstein
-    Hourly:	€ 1.0000
-    Monthly:	€ 2.0000
+  - Location:		Falkenstein
+    Hourly:		€ 1.0000
+    Monthly:		€ 2.0000
+    Included Traffic:	639 KiB
+    Additional Traffic:	€ 3.0000 per TB
+
 `
 
 	assert.NoError(t, err)

--- a/internal/cmd/servertype/describe.go
+++ b/internal/cmd/servertype/describe.go
@@ -1,6 +1,7 @@
 package servertype
 
 import (
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
@@ -35,7 +36,6 @@ var DescribeCmd = base.DescribeCmd{
 		cmd.Printf("Memory:\t\t\t%.1f GB\n", serverType.Memory)
 		cmd.Printf("Disk:\t\t\t%d GB\n", serverType.Disk)
 		cmd.Printf("Storage Type:\t\t%s\n", serverType.StorageType)
-		cmd.Printf("Included Traffic:\t%d TB\n", serverType.IncludedTraffic/util.Tebibyte)
 		cmd.Printf(util.DescribeDeprecation(serverType))
 
 		pricings, err := fullPricingInfo(s, serverType)
@@ -46,9 +46,12 @@ var DescribeCmd = base.DescribeCmd{
 		if pricings != nil {
 			cmd.Printf("Pricings per Location:\n")
 			for _, price := range pricings {
-				cmd.Printf("  - Location:\t%s\n", price.Location.Name)
-				cmd.Printf("    Hourly:\t%s\n", util.GrossPrice(price.Hourly))
-				cmd.Printf("    Monthly:\t%s\n", util.GrossPrice(price.Monthly))
+				cmd.Printf("  - Location:\t\t%s\n", price.Location.Name)
+				cmd.Printf("    Hourly:\t\t%s\n", util.GrossPrice(price.Hourly))
+				cmd.Printf("    Monthly:\t\t%s\n", util.GrossPrice(price.Monthly))
+				cmd.Printf("    Included Traffic:\t%s\n", humanize.IBytes(price.IncludedTraffic))
+				cmd.Printf("    Additional Traffic:\t%s per TB\n", util.GrossPrice(price.PerTBTraffic))
+				cmd.Printf("\n")
 			}
 		}
 

--- a/internal/cmd/servertype/describe_test.go
+++ b/internal/cmd/servertype/describe_test.go
@@ -50,6 +50,11 @@ func TestDescribe(t *testing.T) {
 							Gross:    "7.0000",
 							Currency: "EUR",
 						},
+						IncludedTraffic: 6543210,
+						PerTBTraffic: hcloud.Price{
+							Gross:    "8.0000",
+							Currency: "EUR",
+						},
 					}},
 				},
 				{
@@ -64,6 +69,11 @@ func TestDescribe(t *testing.T) {
 						},
 						Monthly: hcloud.Price{
 							Gross:    "2.0000",
+							Currency: "EUR",
+						},
+						IncludedTraffic: 654321,
+						PerTBTraffic: hcloud.Price{
+							Gross:    "3.0000",
 							Currency: "EUR",
 						},
 					}},
@@ -82,11 +92,13 @@ Architecture:
 Memory:			4.0 GB
 Disk:			40 GB
 Storage Type:		local
-Included Traffic:	0 TB
 Pricings per Location:
-  - Location:	Falkenstein
-    Hourly:	€ 1.0000
-    Monthly:	€ 2.0000
+  - Location:		Falkenstein
+    Hourly:		€ 1.0000
+    Monthly:		€ 2.0000
+    Included Traffic:	639 KiB
+    Additional Traffic:	€ 3.0000 per TB
+
 `
 
 	assert.NoError(t, err)

--- a/internal/cmd/servertype/list.go
+++ b/internal/cmd/servertype/list.go
@@ -17,7 +17,7 @@ import (
 var ListCmd = base.ListCmd{
 	ResourceNamePlural: "Server Types",
 	JSONKeyGetByName:   "server_types",
-	DefaultColumns:     []string{"id", "name", "cores", "cpu_type", "architecture", "memory", "disk", "storage_type", "traffic"},
+	DefaultColumns:     []string{"id", "name", "cores", "cpu_type", "architecture", "memory", "disk", "storage_type"},
 	SortOption:         nil, // Server Types do not support sorting
 
 	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
@@ -47,8 +47,9 @@ var ListCmd = base.ListCmd{
 				return fmt.Sprintf("%d GB", serverType.Disk)
 			})).
 			AddFieldFn("traffic", func(obj interface{}) string {
-				serverType := obj.(*hcloud.ServerType)
-				return fmt.Sprintf("%d TB", serverType.IncludedTraffic/util.Tebibyte)
+				// Was deprecated and traffic is now set per location, only available through describe.
+				// Field was kept to avoid returning errors if people explicitly request the column.
+				return "-"
 			}).
 			AddFieldFn("deprecated", func(obj interface{}) string {
 				serverType := obj.(*hcloud.ServerType)

--- a/internal/cmd/servertype/list_test.go
+++ b/internal/cmd/servertype/list_test.go
@@ -31,22 +31,21 @@ func TestList(t *testing.T) {
 		).
 		Return([]*hcloud.ServerType{
 			{
-				ID:              123,
-				Name:            "test",
-				Cores:           2,
-				CPUType:         hcloud.CPUTypeShared,
-				Architecture:    hcloud.ArchitectureARM,
-				Memory:          8.0,
-				Disk:            80,
-				StorageType:     hcloud.StorageTypeLocal,
-				IncludedTraffic: 20 * util.Tebibyte,
+				ID:           123,
+				Name:         "test",
+				Cores:        2,
+				CPUType:      hcloud.CPUTypeShared,
+				Architecture: hcloud.ArchitectureARM,
+				Memory:       8.0,
+				Disk:         80,
+				StorageType:  hcloud.StorageTypeLocal,
 			},
 		}, nil)
 
 	out, errOut, err := fx.Run(cmd, []string{})
 
-	expOut := `ID    NAME   CORES   CPU TYPE   ARCHITECTURE   MEMORY   DISK    STORAGE TYPE   TRAFFIC
-123   test   2       shared     arm            8.0 GB   80 GB   local          20 TB
+	expOut := `ID    NAME   CORES   CPU TYPE   ARCHITECTURE   MEMORY   DISK    STORAGE TYPE
+123   test   2       shared     arm            8.0 GB   80 GB   local
 `
 
 	assert.NoError(t, err)

--- a/internal/cmd/servertype/list_test.go
+++ b/internal/cmd/servertype/list_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hetznercloud/cli/internal/cmd/servertype"
-	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/testutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )


### PR DESCRIPTION
The API has been updated to provide a better insight and more flexibility for displaying the pricing of traffic for servers and load balancers.

In addition to the new fields, the old fields are deprecated and will be set to `null` in the API on 2024-08-05.

In the CLI this mostly affects the `hcloud server-type list` command, where we have previously shown a column `traffic`. This is no longer possible, because there is no single included traffic for a server type, and instead this depends on the location. We have set the field to `-`  and removed it from the default columns. The information is still available in `hcloud server-type describe <server-type-name>`, now in the "Pricing" section of the output.

This also affects the JSON and YAML output of both `hcloud server-type list` and `hcloud server-type describe` as we use the API schema for this.

You can learn more about this change in [our changelog](https://docs.hetzner.cloud/changelog#2024-07-25-cloud-api-returns-traffic-information-in-different-format).

### release-please Info

BEGIN_COMMIT_OVERRIDE
feat(server-type): show traffic details for each location in describe output
feat(load-balancer-type): show traffic details for each location in describe output
fix(server-type): remove deprecated traffic column
END_COMMIT_OVERRIDE