### PR TITLE
fix(image): only accept numerical ids for update, delete, label

### DIFF
--- a/internal/cmd/image/delete.go
+++ b/internal/cmd/image/delete.go
@@ -1,6 +1,9 @@
 package image
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
@@ -14,8 +17,12 @@ var DeleteCmd = base.DeleteCmd{
 	ResourceNamePlural:   "images",
 	ShortDescription:     "Delete an image",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Image().Names },
-	Fetch: func(s state.State, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
-		return s.Client().Image().Get(s, idOrName)
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+		id, err := strconv.ParseInt(idOrName, 10, 64)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid snapshot or backup ID %q", idOrName)
+		}
+		return s.Client().Image().GetByID(s, id)
 	},
 	Delete: func(s state.State, cmd *cobra.Command, resource interface{}) (*hcloud.Action, error) {
 		image := resource.(*hcloud.Image)

--- a/internal/cmd/image/delete_test.go
+++ b/internal/cmd/image/delete_test.go
@@ -1,6 +1,7 @@
 package image_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,20 +20,19 @@ func TestDelete(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	img := &hcloud.Image{
-		ID:   123,
-		Name: "test",
+		ID: 123,
 	}
 
 	fx.Client.ImageClient.EXPECT().
-		Get(gomock.Any(), "test").
+		GetByID(gomock.Any(), img.ID).
 		Return(img, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		Delete(gomock.Any(), img).
 		Return(nil, nil)
 
-	out, errOut, err := fx.Run(cmd, []string{"test"})
+	out, errOut, err := fx.Run(cmd, []string{"123"})
 
-	expOut := "image test deleted\n"
+	expOut := "image 123 deleted\n"
 
 	assert.NoError(t, err)
 	assert.Empty(t, errOut)
@@ -48,33 +48,30 @@ func TestDeleteMultiple(t *testing.T) {
 
 	images := []*hcloud.Image{
 		{
-			ID:   123,
-			Name: "test1",
+			ID: 123,
 		},
 		{
-			ID:   456,
-			Name: "test2",
+			ID: 456,
 		},
 		{
-			ID:   789,
-			Name: "test3",
+			ID: 789,
 		},
 	}
 
-	var names []string
+	var ids []string
 	for _, img := range images {
-		names = append(names, img.Name)
+		ids = append(ids, strconv.FormatInt(img.ID, 10))
 		fx.Client.ImageClient.EXPECT().
-			Get(gomock.Any(), img.Name).
+			GetByID(gomock.Any(), img.ID).
 			Return(img, nil, nil)
 		fx.Client.ImageClient.EXPECT().
 			Delete(gomock.Any(), img).
 			Return(nil, nil)
 	}
 
-	out, errOut, err := fx.Run(cmd, names)
+	out, errOut, err := fx.Run(cmd, ids)
 
 	assert.NoError(t, err)
 	assert.Empty(t, errOut)
-	assert.Equal(t, "images test1, test2, test3 deleted\n", out)
+	assert.Equal(t, "images 123, 456, 789 deleted\n", out)
 }

--- a/internal/cmd/image/labels.go
+++ b/internal/cmd/image/labels.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/hcapi2"
@@ -16,7 +17,11 @@ var LabelCmds = base.LabelCmds{
 	NameSuggestions:        func(c hcapi2.Client) func() []string { return c.Image().Names },
 	LabelKeySuggestions:    func(c hcapi2.Client) func(idOrName string) []string { return c.Image().LabelKeys },
 	FetchLabels: func(s state.State, idOrName string) (map[string]string, int64, error) {
-		image, _, err := s.Client().Image().Get(s, idOrName)
+		id, err := strconv.ParseInt(idOrName, 10, 64)
+		if err != nil {
+			return nil, 0, fmt.Errorf("invalid snapshot or backup ID %q", idOrName)
+		}
+		image, _, err := s.Client().Image().GetByID(s, id)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/internal/cmd/image/labels_test.go
+++ b/internal/cmd/image/labels_test.go
@@ -19,7 +19,7 @@ func TestLabelAdd(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	fx.Client.ImageClient.EXPECT().
-		Get(gomock.Any(), "123").
+		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.Image{ID: 123}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		Update(gomock.Any(), &hcloud.Image{ID: 123}, hcloud.ImageUpdateOpts{
@@ -45,7 +45,7 @@ func TestLabelRemove(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	fx.Client.ImageClient.EXPECT().
-		Get(gomock.Any(), "123").
+		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.Image{
 			ID: 123,
 			Labels: map[string]string{

--- a/internal/cmd/image/update.go
+++ b/internal/cmd/image/update.go
@@ -1,6 +1,9 @@
 package image
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -15,8 +18,12 @@ var UpdateCmd = base.UpdateCmd{
 	ResourceNameSingular: "Image",
 	ShortDescription:     "Update an image",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Image().Names },
-	Fetch: func(s state.State, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
-		return s.Client().Image().Get(s, idOrName)
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+		id, err := strconv.ParseInt(idOrName, 10, 64)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid snapshot or backup ID %q", idOrName)
+		}
+		return s.Client().Image().GetByID(s, id)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("description", "", "Image description")

--- a/internal/cmd/image/update_test.go
+++ b/internal/cmd/image/update_test.go
@@ -19,7 +19,7 @@ func TestUpdateDescription(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	fx.Client.ImageClient.EXPECT().
-		Get(gomock.Any(), "123").
+		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.Image{ID: 123}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		Update(gomock.Any(), &hcloud.Image{ID: 123}, hcloud.ImageUpdateOpts{
@@ -43,7 +43,7 @@ func TestUpdateType(t *testing.T) {
 	fx.ExpectEnsureToken()
 
 	fx.Client.ImageClient.EXPECT().
-		Get(gomock.Any(), "123").
+		GetByID(gomock.Any(), int64(123)).
 		Return(&hcloud.Image{ID: 123}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		Update(gomock.Any(), &hcloud.Image{ID: 123}, hcloud.ImageUpdateOpts{


### PR DESCRIPTION
Since `Image().Get()` is deprecated, we should switch to an alternative.

All the modifying calls for images are only allowed for `type=backup` and `type=snapshot`. These types cannot have names, so the user is required to pass in an ID in anyway. The easiest alternative is `Image().GetByID()`.