### PR TITLE
fix: `quiet` option sometimes only working as a flag

### DIFF
--- a/internal/cmd/base/describe.go
+++ b/internal/cmd/base/describe.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
+	"github.com/hetznercloud/cli/internal/state/config"
 )
 
 // DescribeCmd allows defining commands for describing a resource.
@@ -54,7 +55,10 @@ func (dc *DescribeCmd) CobraCommand(s state.State) *cobra.Command {
 func (dc *DescribeCmd) Run(s state.State, cmd *cobra.Command, args []string) error {
 	outputFlags := output.FlagsForCommand(cmd)
 
-	quiet, _ := cmd.Flags().GetBool("quiet")
+	quiet, err := config.OptionQuiet.Get(s.Config())
+	if err != nil {
+		return err
+	}
 
 	isSchema := outputFlags.IsSet("json") || outputFlags.IsSet("yaml")
 	if isSchema && !quiet {

--- a/internal/state/actions.go
+++ b/internal/state/actions.go
@@ -8,12 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state/config"
 	"github.com/hetznercloud/cli/internal/ui"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func (c *state) WaitForActions(cmd *cobra.Command, ctx context.Context, actions ...*hcloud.Action) error {
-	if quiet, _ := cmd.Flags().GetBool("quiet"); quiet {
+	quiet, err := config.OptionQuiet.Get(c.Config())
+	if err != nil {
+		return err
+	}
+	if quiet {
 		return c.Client().Action().WaitFor(ctx, actions...)
 	}
 


### PR DESCRIPTION
In some places, the old `Flags().GetBool()` was used instead of actually using the option. That causes the `quiet` option to be ignored in these places if it is set via the config file or environment variables.