### PR TITLE
feat(certificate): allow retrying managed certificate issuance

### DIFF
--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -23,6 +23,7 @@ func NewCommand(s state.State) *cobra.Command {
 		LabelCmds.RemoveCobraCommand(s),
 		DeleteCmd.CobraCommand(s),
 		DescribeCmd.CobraCommand(s),
+		RetryCmd.CobraCommand(s),
 	)
 
 	return cmd

--- a/internal/cmd/certificate/retry.go
+++ b/internal/cmd/certificate/retry.go
@@ -1,0 +1,44 @@
+package certificate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/cmd/base"
+	"github.com/hetznercloud/cli/internal/hcapi2"
+	"github.com/hetznercloud/cli/internal/state"
+)
+
+var RetryCmd = base.Cmd{
+	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
+		return &cobra.Command{
+			Use:                   "retry <certificate>",
+			Short:                 "Retry a managed certificate's issuance",
+			TraverseChildren:      true,
+			DisableFlagsInUseLine: true,
+		}
+	},
+	Run: func(s state.State, cmd *cobra.Command, args []string) error {
+		idOrName := args[0]
+		certificate, _, err := s.Client().Certificate().Get(s, idOrName)
+		if err != nil {
+			return err
+		}
+		if certificate == nil {
+			return fmt.Errorf("certificate not found: %s", idOrName)
+		}
+
+		action, _, err := s.Client().Certificate().RetryIssuance(s, certificate)
+		if err != nil {
+			return err
+		}
+
+		if err := s.WaitForActions(cmd, s, action); err != nil {
+			return err
+		}
+
+		cmd.Printf("Retried issuance of certificate %s\n", certificate.Name)
+		return nil
+	},
+}

--- a/internal/cmd/certificate/retry_test.go
+++ b/internal/cmd/certificate/retry_test.go
@@ -1,0 +1,44 @@
+package certificate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/cli/internal/cmd/certificate"
+	"github.com/hetznercloud/cli/internal/testutil"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func TestRetry(t *testing.T) {
+	fx := testutil.NewFixture(t)
+	defer fx.Finish()
+
+	time.Local = time.UTC
+
+	cmd := certificate.RetryCmd.CobraCommand(fx.State())
+
+	cert := &hcloud.Certificate{
+		ID:   123,
+		Name: "my-test-cert",
+	}
+
+	fx.ExpectEnsureToken()
+	fx.Client.CertificateClient.EXPECT().
+		Get(gomock.Any(), "123").
+		Return(cert, nil, nil)
+	fx.Client.CertificateClient.EXPECT().
+		RetryIssuance(gomock.Any(), cert).
+		Return(&hcloud.Action{ID: 456}, nil, nil)
+	fx.ActionWaiter.EXPECT().
+		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 456}).
+		Return(nil)
+
+	out, errOut, err := fx.Run(cmd, []string{"123"})
+
+	assert.NoError(t, err)
+	assert.Empty(t, errOut)
+	assert.Equal(t, "Retried issuance of certificate my-test-cert\n", out)
+}


### PR DESCRIPTION
Somehow this API call didn't have a corresponding command in the CLI, so this PR adds it.