### PR TITLE
fix(primary-ip): change protection commands do not allow protection levels

### DIFF
--- a/internal/cmd/primaryip/disable_protection.go
+++ b/internal/cmd/primaryip/disable_protection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 )
@@ -15,6 +16,7 @@ var DisableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
 			Use:   "disable-protection <primary-ip> [<protection-level>...]", // optional because of backwards compatibility
+			Args:  util.ValidateLenient,
 			Short: "Disable Protection for a Primary IP",
 			ValidArgsFunction: cmpl.SuggestArgs(
 				cmpl.SuggestCandidatesF(client.PrimaryIP().Names),

--- a/internal/cmd/primaryip/disable_protection_test.go
+++ b/internal/cmd/primaryip/disable_protection_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-func TestEnable(t *testing.T) {
+func TestDisableProtection(t *testing.T) {
 	fx := testutil.NewFixture(t)
 	defer fx.Finish()
 
@@ -45,6 +45,36 @@ func TestEnable(t *testing.T) {
 
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
 	out, errOut, err := fx.Run(cmd, []string{"13"})
+
+	expOut := "Resource protection disabled for primary IP 13\n"
+
+	assert.NoError(t, err)
+	assert.Empty(t, errOut)
+	assert.Equal(t, expOut, out)
+}
+
+func TestDisableDeleteProtection(t *testing.T) {
+	fx := testutil.NewFixture(t)
+	defer fx.Finish()
+
+	cmd := primaryip.DisableProtectionCmd.CobraCommand(fx.State())
+	action := &hcloud.Action{ID: 1}
+	ip := &hcloud.PrimaryIP{ID: 13}
+
+	fx.ExpectEnsureToken()
+	fx.Client.PrimaryIPClient.EXPECT().
+		Get(gomock.Any(), "13").
+		Return(ip, nil, nil)
+	fx.Client.PrimaryIPClient.EXPECT().
+		ChangeProtection(gomock.Any(), hcloud.PrimaryIPChangeProtectionOpts{
+			ID:     13,
+			Delete: false,
+		}).
+		Return(action, nil, nil)
+
+	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), action).Return(nil)
+
+	out, errOut, err := fx.Run(cmd, []string{"13", "delete"})
 
 	expOut := "Resource protection disabled for primary IP 13\n"
 

--- a/internal/cmd/primaryip/enable_protection.go
+++ b/internal/cmd/primaryip/enable_protection.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -57,6 +58,7 @@ var EnableProtectionCmd = base.Cmd{
 	BaseCobraCommand: func(client hcapi2.Client) *cobra.Command {
 		cmd := &cobra.Command{
 			Use:   "enable-protection <primary-ip> [<protection-level>...]", // optional because of backwards compatibility
+			Args:  util.ValidateLenient,
 			Short: "Enable Protection for a Primary IP",
 			ValidArgsFunction: cmpl.SuggestArgs(
 				cmpl.SuggestCandidatesF(client.PrimaryIP().Names),


### PR DESCRIPTION
Since the protections level support for Primary IPs was added later, they are optional so that the command is backwards compatible. This meant that the usage validation was not working properly. This PR fixes this and adds tests.