### PR TITLE
fix: inconsistent base for size units in description

### DIFF
--- a/internal/cmd/loadbalancertype/describe.go
+++ b/internal/cmd/loadbalancertype/describe.go
@@ -47,7 +47,7 @@ var DescribeCmd = base.DescribeCmd{
 				cmd.Printf("    Hourly:\t\t%s\n", util.GrossPrice(price.Hourly))
 				cmd.Printf("    Monthly:\t\t%s\n", util.GrossPrice(price.Monthly))
 				cmd.Printf("    Included Traffic:\t%s\n", humanize.IBytes(price.IncludedTraffic))
-				cmd.Printf("    Additional Traffic:\t%s per TB\n", util.GrossPrice(price.PerTBTraffic))
+				cmd.Printf("    Additional Traffic:\t%s per TiB\n", util.GrossPrice(price.PerTBTraffic))
 				cmd.Printf("\n")
 			}
 		}

--- a/internal/cmd/loadbalancertype/describe_test.go
+++ b/internal/cmd/loadbalancertype/describe_test.go
@@ -94,7 +94,7 @@ Pricings per Location:
     Hourly:		€ 1.0000
     Monthly:		€ 2.0000
     Included Traffic:	639 KiB
-    Additional Traffic:	€ 3.0000 per TB
+    Additional Traffic:	€ 3.0000 per TiB
 
 `
 

--- a/internal/cmd/servertype/describe.go
+++ b/internal/cmd/servertype/describe.go
@@ -50,7 +50,7 @@ var DescribeCmd = base.DescribeCmd{
 				cmd.Printf("    Hourly:\t\t%s\n", util.GrossPrice(price.Hourly))
 				cmd.Printf("    Monthly:\t\t%s\n", util.GrossPrice(price.Monthly))
 				cmd.Printf("    Included Traffic:\t%s\n", humanize.IBytes(price.IncludedTraffic))
-				cmd.Printf("    Additional Traffic:\t%s per TB\n", util.GrossPrice(price.PerTBTraffic))
+				cmd.Printf("    Additional Traffic:\t%s per TiB\n", util.GrossPrice(price.PerTBTraffic))
 				cmd.Printf("\n")
 			}
 		}

--- a/internal/cmd/servertype/describe_test.go
+++ b/internal/cmd/servertype/describe_test.go
@@ -97,7 +97,7 @@ Pricings per Location:
     Hourly:		€ 1.0000
     Monthly:		€ 2.0000
     Included Traffic:	639 KiB
-    Additional Traffic:	€ 3.0000 per TB
+    Additional Traffic:	€ 3.0000 per TiB
 
 `
 


### PR DESCRIPTION
This PR changes `€/TB` to `€/TiB`, which more accurately reflects how traffic is actually billed. It is now also consistent with the unit for included traffic.

Closes #838