### PR TITLE
feat: build with Go 1.23

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ cache:
 
 build:
   stage: build
-  image: golang:1.21
+  image: golang:1.23
   script:
     - go env
     - go mod download
@@ -31,21 +31,21 @@ test:lint:
 
 test:tidy:
   stage: test
-  image: golang:1.21
+  image: golang:1.23
   script:
     - go mod tidy -v
     - git diff --exit-code
 
 test:generate:
   stage: test
-  image: golang:1.21
+  image: golang:1.23
   script:
     - go generate ./...
     - git diff --exit-code
 
 test:unit:
   stage: test
-  image: golang:1.21
+  image: golang:1.23
   script:
     - go test -v -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
     - go get github.com/boumenot/gocover-cobertura

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hetznercloud/cli
 
-go 1.21
+go 1.23
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Since Go 1.21 is not supported anymore, we should upgrade our Go version. The CLI is a standalone application, so we can skip Go 1.22 and use 1.23.