### PR TITLE
fix(image): only use numerical IDs for label auto-completion

### DIFF
--- a/internal/hcapi2/image.go
+++ b/internal/hcapi2/image.go
@@ -51,7 +51,7 @@ func (c *imageClient) LabelKeys(id string) []string {
 		return nil
 	}
 	img, _, err := c.GetByID(context.Background(), imgID)
-	if err != nil || len(img.Labels) == 0 {
+	if err != nil || img == nil || len(img.Labels) == 0 {
 		return nil
 	}
 	return labelKeys(img.Labels)


### PR DESCRIPTION
We currently use the deprecated `Get` method here. Instead we can just parse an integer and use that as the ID, since you can only get or update labels on images you can modify (snapshots and backups), which only have numerical IDs and no names anyway.