### PR TITLE
test(e2e): add back check for uniqueness_error in network test

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -28,8 +28,7 @@ func TestNetwork(t *testing.T) {
 
 	_, err = createNetwork(t, networkName, "--ip-range", "10.0.1.0/24")
 	require.Error(t, err)
-	// TODO: API currently returns service_error instead of uniqueness_error. Add this back in once this is fixed.
-	// assert.Regexp(t, `^name is already used \(uniqueness_error, [0-9a-f]+\)$`, err.Error())
+	assert.Regexp(t, `^name is already used \(uniqueness_error, [0-9a-f]+\)$`, err.Error())
 
 	t.Run("enable-protection", func(t *testing.T) {
 		t.Run("non-existing-protection", func(t *testing.T) {


### PR DESCRIPTION
The underlying issue in the API was fixed and we can now add the test back again.