### PR TITLE
fix(primary-ip): labels ignored in create command

### DIFF
--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -45,6 +45,7 @@ var CreateCmd = base.CreateCmd{
 		name, _ := cmd.Flags().GetString("name")
 		assigneeID, _ := cmd.Flags().GetInt64("assignee-id")
 		datacenter, _ := cmd.Flags().GetString("datacenter")
+		labels, _ := cmd.Flags().GetStringToString("label")
 		protection, _ := cmd.Flags().GetStringSlice("enable-protection")
 		autoDelete, _ := cmd.Flags().GetBool("auto-delete")
 
@@ -58,6 +59,7 @@ var CreateCmd = base.CreateCmd{
 			Name:         name,
 			AssigneeType: "server",
 			Datacenter:   datacenter,
+			Labels:       labels,
 		}
 		if assigneeID != 0 {
 			createOpts.AssigneeID = &assigneeID

--- a/internal/cmd/primaryip/create_test.go
+++ b/internal/cmd/primaryip/create_test.go
@@ -31,6 +31,7 @@ func TestCreate(t *testing.T) {
 				Name:         "my-ip",
 				Type:         "ipv4",
 				Datacenter:   "fsn1-dc14",
+				Labels:       map[string]string{"foo": "bar"},
 				AssigneeType: "server",
 				AutoDelete:   hcloud.Ptr(true),
 			},
@@ -42,6 +43,7 @@ func TestCreate(t *testing.T) {
 					IP:         net.ParseIP("192.168.2.1"),
 					Type:       hcloud.PrimaryIPTypeIPv4,
 					AutoDelete: true,
+					Labels:     map[string]string{"foo": "bar"},
 				},
 				Action: &hcloud.Action{ID: 321},
 			},
@@ -52,7 +54,7 @@ func TestCreate(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
-	out, errOut, err := fx.Run(cmd, []string{"--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14", "--auto-delete"})
+	out, errOut, err := fx.Run(cmd, []string{"--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14", "--auto-delete", "--label", "foo=bar"})
 
 	expOut := `Primary IP 1 created
 IPv4: 192.168.2.1
@@ -79,6 +81,7 @@ func TestCreateJSON(t *testing.T) {
 				Name:         "my-ip",
 				Type:         "ipv4",
 				Datacenter:   "fsn1-dc14",
+				Labels:       map[string]string{"foo": "bar"},
 				AssigneeType: "server",
 				AutoDelete:   hcloud.Ptr(true),
 			},
@@ -96,7 +99,7 @@ func TestCreateJSON(t *testing.T) {
 						Location: &hcloud.Location{ID: 1, Name: "fsn1"},
 					},
 					Created:      time.Date(2016, 1, 30, 23, 50, 0, 0, time.UTC),
-					Labels:       make(map[string]string),
+					Labels:       map[string]string{"foo": "bar"},
 					AutoDelete:   true,
 					AssigneeID:   1,
 					AssigneeType: "server",
@@ -108,7 +111,7 @@ func TestCreateJSON(t *testing.T) {
 	fx.ActionWaiter.EXPECT().
 		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321})
 
-	jsonOut, out, err := fx.Run(cmd, []string{"-o=json", "--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14", "--auto-delete"})
+	jsonOut, out, err := fx.Run(cmd, []string{"-o=json", "--name=my-ip", "--type=ipv4", "--datacenter=fsn1-dc14", "--auto-delete", "--label", "foo=bar"})
 
 	expOut := "Primary IP 1 created\n"
 

--- a/internal/cmd/primaryip/testdata/create_response.json
+++ b/internal/cmd/primaryip/testdata/create_response.json
@@ -28,7 +28,9 @@
     "dns_ptr": [],
     "id": 1,
     "ip": "192.168.2.1",
-    "labels": {},
+    "labels": {
+      "foo": "bar"
+    },
     "name": "my-ip",
     "protection": {
       "delete": false


### PR DESCRIPTION
This PR adds the missing functionality to add labels when creating a Primary IP and also adds it to the unit tests.

Fixes #883