### PR TITLE
feat: drop support for go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hetznercloud/cli
 
-go 1.21
+go 1.22
 
 toolchain go1.23.3
 


### PR DESCRIPTION
Drop support for go 1.21 (we already build with go 1.23).