### PR TITLE
chore: replace deprecated goreleaser config property

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
           output: true
 
 snapshot:
-  name_template: "{{ .Version }}-dev+{{ .ShortCommit }}"
+  version_template: "{{ .Version }}-dev+{{ .ShortCommit }}"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
```
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
```