### PR TITLE
refactor: order by key when printing labels

### DIFF
--- a/internal/cmd/certificate/describe.go
+++ b/internal/cmd/certificate/describe.go
@@ -46,7 +46,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Certificate]{
 		if len(cert.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range cert.Labels {
+			for key, value := range util.IterateInOrder(cert.Labels) {
 				cmd.Printf("  %s:\t%s\n", key, value)
 			}
 		}

--- a/internal/cmd/firewall/describe.go
+++ b/internal/cmd/firewall/describe.go
@@ -33,7 +33,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Firewall]{
 		if len(firewall.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range firewall.Labels {
+			for key, value := range util.IterateInOrder(firewall.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/floatingip/describe.go
+++ b/internal/cmd/floatingip/describe.go
@@ -58,7 +58,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.FloatingIP]{
 		if len(floatingIP.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range floatingIP.Labels {
+			for key, value := range util.IterateInOrder(floatingIP.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/image/describe.go
+++ b/internal/cmd/image/describe.go
@@ -70,7 +70,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Image]{
 		if len(image.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range image.Labels {
+			for key, value := range util.IterateInOrder(image.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/loadbalancer/describe.go
+++ b/internal/cmd/loadbalancer/describe.go
@@ -154,7 +154,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.LoadBalancer]{
 		if len(loadBalancer.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range loadBalancer.Labels {
+			for key, value := range util.IterateInOrder(loadBalancer.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/network/describe.go
+++ b/internal/cmd/network/describe.go
@@ -62,7 +62,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Network]{
 		if len(network.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range network.Labels {
+			for key, value := range util.IterateInOrder(network.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/placementgroup/describe.go
+++ b/internal/cmd/placementgroup/describe.go
@@ -31,7 +31,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.PlacementGroup]{
 		if len(placementGroup.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range placementGroup.Labels {
+			for key, value := range util.IterateInOrder(placementGroup.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/primaryip/describe.go
+++ b/internal/cmd/primaryip/describe.go
@@ -53,7 +53,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.PrimaryIP]{
 		if len(primaryIP.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range primaryIP.Labels {
+			for key, value := range util.IterateInOrder(primaryIP.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/server/describe.go
+++ b/internal/cmd/server/describe.go
@@ -182,7 +182,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Server]{
 		if len(server.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range server.Labels {
+			for key, value := range util.IterateInOrder(server.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/sshkey/describe.go
+++ b/internal/cmd/sshkey/describe.go
@@ -34,7 +34,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.SSHKey]{
 		if len(sshKey.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range sshKey.Labels {
+			for key, value := range util.IterateInOrder(sshKey.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}

--- a/internal/cmd/util/util_test.go
+++ b/internal/cmd/util/util_test.go
@@ -454,3 +454,28 @@ func TestPrice(t *testing.T) {
 		})
 	}
 }
+
+func TestSortLabels(t *testing.T) {
+	labels := map[string]string{
+		"c": "baz",
+		"a": "foo",
+		"z": "qux",
+		"b": "bar",
+	}
+	expected := [][]string{
+		{"a", "foo"},
+		{"b", "bar"},
+		{"c", "baz"},
+		{"z", "qux"},
+	}
+
+	i := 0
+	for k, v := range util.IterateInOrder(labels) {
+		require.Less(t, i, 4)
+		exp := expected[i]
+		i++
+
+		assert.Equal(t, exp[0], k, "key not equal")
+		assert.Equal(t, exp[1], v, "value not equal")
+	}
+}

--- a/internal/cmd/volume/describe.go
+++ b/internal/cmd/volume/describe.go
@@ -49,7 +49,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Volume]{
 		if len(volume.Labels) == 0 {
 			cmd.Print("  No labels\n")
 		} else {
-			for key, value := range volume.Labels {
+			for key, value := range util.IterateInOrder(volume.Labels) {
 				cmd.Printf("  %s: %s\n", key, value)
 			}
 		}


### PR DESCRIPTION
This PR adds sorting of labels by their keys, which is useful for testing, since iteration order over maps in Go is undefined by default.
It uses the Go 1.23 iteration feature. ~~If we want to use this, we should probably bump the Go version in a separate PR.~~