### PR TITLE
fix: ignore firewall rule description when looking for a rule to delete

### DIFF
--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -2,7 +2,6 @@ package firewall
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -56,7 +55,7 @@ var DeleteRuleCmd = base.Cmd{
 
 		var rules = make([]hcloud.FirewallRule, 0)
 		for _, existingRule := range firewall.Rules {
-			if !reflect.DeepEqual(existingRule, *rule) {
+			if !EqualFirewallRule(existingRule, *rule) {
 				rules = append(rules, existingRule)
 			}
 		}

--- a/internal/cmd/firewall/validation.go
+++ b/internal/cmd/firewall/validation.go
@@ -3,6 +3,9 @@ package firewall
 import (
 	"fmt"
 	"net"
+	"reflect"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func ValidateFirewallIP(ip string) (*net.IPNet, error) {
@@ -15,4 +18,11 @@ func ValidateFirewallIP(ip string) (*net.IPNet, error) {
 	}
 
 	return n, nil
+}
+
+func EqualFirewallRule(a, b hcloud.FirewallRule) bool {
+	a.Description = nil
+	b.Description = nil
+
+	return reflect.DeepEqual(a, b)
 }

--- a/internal/cmd/firewall/validation_test.go
+++ b/internal/cmd/firewall/validation_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/cli/internal/cmd/firewall"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func TestValidateFirewallIP(t *testing.T) {
@@ -64,4 +65,13 @@ func TestValidateFirewallIP(t *testing.T) {
 			assert.NotNil(t, net)
 		})
 	}
+}
+
+func TestEqualFirewallRule(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		assert.True(t, firewall.EqualFirewallRule(
+			hcloud.FirewallRule{Description: hcloud.Ptr("a")},
+			hcloud.FirewallRule{Description: hcloud.Ptr("b")},
+		))
+	})
 }


### PR DESCRIPTION
We now ignore firewall rule description when searching a rule to delete in the existing rules.

This allows the users to delete a rule without having to pass the description of the rule.