### PR TITLE
refactor: use randutil from hcloud-go

### DIFF
--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
 )
 
 const fingerprintRegex = `[0-9A-F]{2}(:[0-9A-F]{2}){31}`
@@ -45,7 +46,7 @@ func TestCertificate(t *testing.T) {
 		}
 
 		// random subdomain
-		certDomain = fmt.Sprintf("%s.%s", randomHex(4), certDomain)
+		certDomain = fmt.Sprintf("%s.%s", randutil.GenerateID(), certDomain)
 
 		certName := withSuffix("test-certificate-managed")
 		certID, err := createCertificate(t, certName, hcloud.CertificateTypeManaged, "--type", "managed", "--domain", certDomain)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,8 +4,6 @@ package e2e
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"testing"
@@ -16,6 +14,7 @@ import (
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/cli/internal/state/config"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
 )
 
 var client = hcloud.NewClient(hcloud.WithToken(os.Getenv("HCLOUD_TOKEN")))
@@ -55,15 +54,6 @@ func runCommand(t *testing.T, args ...string) (string, error) {
 	return buf.String(), err
 }
 
-func randomHex(n int) string {
-	b := make([]byte, n)
-	_, err := rand.Read(b)
-	if err != nil {
-		panic(err)
-	}
-	return hex.EncodeToString(b)
-}
-
 func withSuffix(s string) string {
-	return fmt.Sprintf("%s-%s", s, randomHex(4))
+	return fmt.Sprintf("%s-%s", s, randutil.GenerateID())
 }


### PR DESCRIPTION
This PR uses the new feature from https://github.com/hetznercloud/hcloud-go/pull/580