### PR TITLE
revert: fix: ignore firewall rule description when looking for a rule to delete

### DIFF
--- a/internal/cmd/firewall/delete_rule.go
+++ b/internal/cmd/firewall/delete_rule.go
@@ -2,6 +2,7 @@ package firewall
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -55,7 +56,7 @@ var DeleteRuleCmd = base.Cmd{
 
 		var rules = make([]hcloud.FirewallRule, 0)
 		for _, existingRule := range firewall.Rules {
-			if !EqualFirewallRule(existingRule, *rule) {
+			if !reflect.DeepEqual(existingRule, *rule) {
 				rules = append(rules, existingRule)
 			}
 		}

--- a/internal/cmd/firewall/validation.go
+++ b/internal/cmd/firewall/validation.go
@@ -3,9 +3,6 @@ package firewall
 import (
 	"fmt"
 	"net"
-	"reflect"
-
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func ValidateFirewallIP(ip string) (*net.IPNet, error) {
@@ -18,11 +15,4 @@ func ValidateFirewallIP(ip string) (*net.IPNet, error) {
 	}
 
 	return n, nil
-}
-
-func EqualFirewallRule(a, b hcloud.FirewallRule) bool {
-	a.Description = nil
-	b.Description = nil
-
-	return reflect.DeepEqual(a, b)
 }

--- a/internal/cmd/firewall/validation_test.go
+++ b/internal/cmd/firewall/validation_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/cli/internal/cmd/firewall"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
 func TestValidateFirewallIP(t *testing.T) {
@@ -65,13 +64,4 @@ func TestValidateFirewallIP(t *testing.T) {
 			assert.NotNil(t, net)
 		})
 	}
-}
-
-func TestEqualFirewallRule(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		assert.True(t, firewall.EqualFirewallRule(
-			hcloud.FirewallRule{Description: hcloud.Ptr("a")},
-			hcloud.FirewallRule{Description: hcloud.Ptr("b")},
-		))
-	})
 }


### PR DESCRIPTION
This reverts commit 4535f26bad3436248585cea4fbec90a5262a20f6 (#961)

Two firewall rules with only a different description does not raise any validation error in the backend. Therefor, we must be able to target duplicate rules with different descriptions. Users must provide the description to be able to delete a rule.