### PR TITLE
refactor: add type for cobra completion func

### DIFF
--- a/internal/cmd/cmpl/suggestions.go
+++ b/internal/cmd/cmpl/suggestions.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type ValidArgsFunction func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
 // SuggestCandidates returns a function that selects all items from the list of
 // candidates cs which have the prefix toComplete. If toComplete is empty cs is
 // returned.
@@ -13,7 +15,7 @@ import (
 // The returned function is mainly intended to be passed to
 // cobra/Command.RegisterFlagCompletionFunc or assigned  to
 // cobra/Command.ValidArgsFunction.
-func SuggestCandidates(cs ...string) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func SuggestCandidates(cs ...string) ValidArgsFunction {
 	return SuggestCandidatesF(func() []string {
 		return cs
 	})
@@ -23,9 +25,7 @@ func SuggestCandidates(cs ...string) func(*cobra.Command, []string, string) ([]s
 // to obtain a list of completion candidates. Once the list of candidates is
 // obtained the function returned by SuggestCandidatesF behaves like the
 // function returned by SuggestCandidates.
-func SuggestCandidatesF(
-	cf func() []string,
-) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func SuggestCandidatesF(cf func() []string) ValidArgsFunction {
 	return SuggestCandidatesCtx(func(*cobra.Command, []string) []string {
 		return cf()
 	})
@@ -37,10 +37,8 @@ func SuggestCandidatesF(
 // depend on a previously selected item like a server.
 //
 // Once the list of candidates is obtained the function returned by
-// SuggestCandidatesF behaves like the function returned by SuggestCandidates.
-func SuggestCandidatesCtx(
-	cf func(*cobra.Command, []string) []string,
-) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+// SuggestCandidatesCtx behaves like the function returned by SuggestCandidates.
+func SuggestCandidatesCtx(cf func(*cobra.Command, []string) []string) ValidArgsFunction {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		cs := cf(cmd, args)
 		if toComplete == "" {
@@ -60,7 +58,7 @@ func SuggestCandidatesCtx(
 }
 
 // SuggestNothing returns a function that provides no suggestions.
-func SuggestNothing() func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func SuggestNothing() ValidArgsFunction {
 	return func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -75,9 +73,7 @@ func SuggestNothing() func(*cobra.Command, []string, string) ([]string, cobra.Sh
 // calls the function at vfs[4] if it exists. To skip suggestions for an
 // argument in the middle of a list of arguments pass either nil or
 // SuggestNothing. Using SuggestNothing is preferred.
-func SuggestArgs(
-	vfs ...func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective),
-) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func SuggestArgs(vfs ...ValidArgsFunction) ValidArgsFunction {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// Number of argument to suggest. args contains the already present
 		// command line arguments.
@@ -95,8 +91,7 @@ func SuggestArgs(
 
 // NoFileCompletion returns a function that provides completion suggestions without
 // file completion.
-func NoFileCompletion(f func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)) func(
-	*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func NoFileCompletion(f ValidArgsFunction) ValidArgsFunction {
 	return func(command *cobra.Command, i []string, s string) ([]string, cobra.ShellCompDirective) {
 		candidates, _ := f(command, i, s)
 		return candidates, cobra.ShellCompDirectiveNoFileComp

--- a/internal/cmd/cmpl/suggestions_test.go
+++ b/internal/cmd/cmpl/suggestions_test.go
@@ -44,7 +44,7 @@ func TestSuggestCandidates(t *testing.T) {
 func TestSuggestArgs(t *testing.T) {
 	tests := []struct {
 		name string
-		vfs  []func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)
+		vfs  []cmpl.ValidArgsFunction
 		args []string
 		sug  []string
 		d    cobra.ShellCompDirective
@@ -58,14 +58,14 @@ func TestSuggestArgs(t *testing.T) {
 		},
 		{
 			name: "suggest the only argument",
-			vfs: []func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective){
+			vfs: []cmpl.ValidArgsFunction{
 				cmpl.SuggestCandidates("aaaa"),
 			},
 			sug: []string{"aaaa"},
 		},
 		{
 			name: "suggest the second of three possible arguments",
-			vfs: []func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective){
+			vfs: []cmpl.ValidArgsFunction{
 				cmpl.SuggestCandidates("aaaa"),
 				cmpl.SuggestCandidates("bbbb"),
 				cmpl.SuggestCandidates("cccc"),
@@ -75,7 +75,7 @@ func TestSuggestArgs(t *testing.T) {
 		},
 		{
 			name: "skip suggestions using SuggestNothing",
-			vfs: []func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective){
+			vfs: []cmpl.ValidArgsFunction{
 				cmpl.SuggestCandidates("aaaa"),
 				cmpl.SuggestNothing(),
 				cmpl.SuggestCandidates("cccc"),
@@ -84,7 +84,7 @@ func TestSuggestArgs(t *testing.T) {
 		},
 		{
 			name: "skip suggestions using nil",
-			vfs: []func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective){
+			vfs: []cmpl.ValidArgsFunction{
 				cmpl.SuggestCandidates("aaaa"),
 				nil,
 				cmpl.SuggestCandidates("cccc"),


### PR DESCRIPTION
Makes the code more readable by giving a keyword to the recurring type.