### PR TITLE
refactor: tablewriter that can handle unicode

### DIFF
--- a/internal/cmd/all/list_test.go
+++ b/internal/cmd/all/list_test.go
@@ -179,12 +179,12 @@ func TestListAll(t *testing.T) {
 	expOut := `SERVERS
 ---
 ID    NAME        STATUS    IPV4        IPV6   PRIVATE NET   DATACENTER   AGE
-123   my server   running   192.0.2.1   -      -             hel1-dc2     3d
+123   my server   running   192.0.2.1   -      -             hel1-dc2     3d 
 
 IMAGES
 ---
 ID   TYPE     NAME   DESCRIPTION   ARCHITECTURE   IMAGE SIZE   DISK SIZE   CREATED                        DEPRECATED
-1    backup   test   -             arm            -            20 GB       Wed Aug 20 12:00:00 UTC 2036   -
+1    backup   test   -             arm            -            20 GB       Wed Aug 20 12:00:00 UTC 2036   -         
 
 PLACEMENT GROUPS
 ---
@@ -194,12 +194,12 @@ ID    NAME   SERVERS     TYPE     AGE
 PRIMARY IPS
 ---
 ID    TYPE   NAME   IP          ASSIGNEE   DNS   AUTO DELETE   AGE
-123   ipv4   test   127.0.0.1   -          -     no            2h
+123   ipv4   test   127.0.0.1   -          -     no            2h 
 
 ISOS
 ---
 ID    NAME   DESCRIPTION   TYPE      ARCHITECTURE
-123   test   -             private   arm
+123   test   -             private   arm         
 
 VOLUMES
 ---
@@ -209,12 +209,12 @@ ID    NAME   SIZE    SERVER   LOCATION   AGE
 LOAD BALANCER
 ---
 ID    NAME     HEALTH    IPV4        IPV6   TYPE   LOCATION   NETWORK ZONE   AGE
-123   foobar   healthy   192.0.2.1   ::     lb11   fsn1       eu-central     5h
+123   foobar   healthy   192.0.2.1   ::     lb11   fsn1       eu-central     5h 
 
 FLOATING IPS
 ---
 ID    TYPE   NAME   DESCRIPTION   IP          HOME   SERVER   DNS   AGE
-123   ipv4   test   -             127.0.0.1   fsn1   -        -     1d
+123   ipv4   test   -             127.0.0.1   fsn1   -        -     1d 
 
 NETWORKS
 ---
@@ -223,7 +223,7 @@ ID    NAME       IP RANGE       SERVERS    AGE
 
 FIREWALLS
 ---
-ID    NAME   RULES COUNT   APPLIED TO COUNT
+ID    NAME   RULES COUNT   APPLIED TO COUNT             
 123   test   5 Rules       2 Servers | 0 Label Selectors
 
 CERTIFICATES
@@ -234,7 +234,7 @@ ID    NAME   TYPE      DOMAIN NAMES   NOT VALID AFTER                AGE
 SSH KEYS
 ---
 ID    NAME   FINGERPRINT   AGE
-123   test   -             2h
+123   test   -             2h 
 
 `
 

--- a/internal/cmd/base/list_test.go
+++ b/internal/cmd/base/list_test.go
@@ -94,8 +94,12 @@ func TestList(t *testing.T) {
 	const resourceSchema = `[{"id": 123, "name": "test"}, {"id": 456, "name": "test2"}, {"id": 789, "name": "test3"}]`
 	testutil.TestCommand(t, fakeListCmd, map[string]testutil.TestCase{
 		"no flags": {
-			Args:   []string{"list"},
-			ExpOut: "ID    NAME\n123   test\n456   test2\n789   test3\n",
+			Args: []string{"list"},
+			ExpOut: `ID    NAME 
+123   test 
+456   test2
+789   test3
+`,
 		},
 		"json": {
 			Args:       []string{"list", "-o=json"},
@@ -108,8 +112,12 @@ func TestList(t *testing.T) {
 			ExpOutType: testutil.DataTypeYAML,
 		},
 		"quiet": {
-			Args:   []string{"list", "--quiet"},
-			ExpOut: "ID    NAME\n123   test\n456   test2\n789   test3\n",
+			Args: []string{"list", "--quiet"},
+			ExpOut: `ID    NAME 
+123   test 
+456   test2
+789   test3
+`,
 		},
 		"json quiet": {
 			Args:       []string{"list", "-o=json", "--quiet"},

--- a/internal/cmd/config/list_test.go
+++ b/internal/cmd/config/list_test.go
@@ -58,52 +58,52 @@ func TestList(t *testing.T) {
 		{
 			name: "default",
 			args: []string{},
-			expOut: `KEY                    VALUE
-context                test_context
-debug                  yes
-deeply.nested.option   bar
+			expOut: `KEY                    VALUE                    
+context                test_context             
+debug                  yes                      
+deeply.nested.option   bar                      
 endpoint               https://test-endpoint.com
-poll-interval          1.234s
-quiet                  yes
-token                  [redacted]
+poll-interval          1.234s                   
+quiet                  yes                      
+token                  [redacted]               
 `,
 		},
 		{
 			name: "only key",
 			args: []string{"-o=columns=key"},
-			expOut: `KEY
-context
-debug
+			expOut: `KEY                 
+context             
+debug               
 deeply.nested.option
-endpoint
-poll-interval
-quiet
-token
+endpoint            
+poll-interval       
+quiet               
+token               
 `,
 		},
 		{
 			name: "no header",
 			args: []string{"-o=noheader"},
-			expOut: `context                test_context
-debug                  yes
-deeply.nested.option   bar
+			expOut: `context                test_context             
+debug                  yes                      
+deeply.nested.option   bar                      
 endpoint               https://test-endpoint.com
-poll-interval          1.234s
-quiet                  yes
-token                  [redacted]
+poll-interval          1.234s                   
+quiet                  yes                      
+token                  [redacted]               
 `,
 		},
 		{
 			name: "allow sensitive",
 			args: []string{"--allow-sensitive"},
-			expOut: `KEY                    VALUE
-context                test_context
-debug                  yes
-deeply.nested.option   bar
+			expOut: `KEY                    VALUE                    
+context                test_context             
+debug                  yes                      
+deeply.nested.option   bar                      
 endpoint               https://test-endpoint.com
-poll-interval          1.234s
-quiet                  yes
-token                  super secret token
+poll-interval          1.234s                   
+quiet                  yes                      
+token                  super secret token       
 `,
 		},
 		{

--- a/internal/cmd/context/list_test.go
+++ b/internal/cmd/context/list_test.go
@@ -44,8 +44,8 @@ token = "yet another super secret token"
 			name:   "default",
 			args:   []string{},
 			config: testConfig,
-			expOut: `ACTIVE   NAME
-*        my-context
+			expOut: `ACTIVE   NAME            
+*        my-context      
          my-other-context
          my-third-context
 `,
@@ -59,7 +59,7 @@ token = "yet another super secret token"
 			name:   "no header",
 			args:   []string{"-o=noheader"},
 			config: testConfig,
-			expOut: `*   my-context
+			expOut: `*   my-context      
     my-other-context
     my-third-context
 `,
@@ -68,7 +68,7 @@ token = "yet another super secret token"
 			name:   "no header only name",
 			args:   []string{"-o=noheader", "-o=columns=name"},
 			config: testConfig,
-			expOut: `my-context
+			expOut: `my-context      
 my-other-context
 my-third-context
 `,
@@ -83,8 +83,8 @@ my-third-context
 			postRun: func() {
 				_ = os.Unsetenv("HCLOUD_CONTEXT")
 			},
-			expOut: `ACTIVE   NAME
-         my-context
+			expOut: `ACTIVE   NAME            
+         my-context      
 *        my-other-context
          my-third-context
 `,

--- a/internal/cmd/datacenter/list_test.go
+++ b/internal/cmd/datacenter/list_test.go
@@ -42,7 +42,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID   NAME        DESCRIPTION                   LOCATION
-4    fsn1-dc14   Falkenstein 1 virtual DC 14   fsn1
+4    fsn1-dc14   Falkenstein 1 virtual DC 14   fsn1    
 `
 
 	require.NoError(t, err)

--- a/internal/cmd/firewall/list_test.go
+++ b/internal/cmd/firewall/list_test.go
@@ -43,7 +43,7 @@ func TestList(t *testing.T) {
 
 	out, errOut, err := fx.Run(cmd, []string{})
 
-	expOut := `ID    NAME   RULES COUNT   APPLIED TO COUNT
+	expOut := `ID    NAME   RULES COUNT   APPLIED TO COUNT             
 123   test   5 Rules       2 Servers | 0 Label Selectors
 `
 

--- a/internal/cmd/image/list_test.go
+++ b/internal/cmd/image/list_test.go
@@ -46,7 +46,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    TYPE     NAME   DESCRIPTION   ARCHITECTURE   IMAGE SIZE   DISK SIZE   CREATED                        DEPRECATED
-123   system   test   -             x86            20.00 GB     15 GB       Wed Aug 20 12:00:00 UTC 2036   -
+123   system   test   -             x86            20.00 GB     15 GB       Wed Aug 20 12:00:00 UTC 2036   -         
 `
 
 	require.NoError(t, err)

--- a/internal/cmd/iso/list_test.go
+++ b/internal/cmd/iso/list_test.go
@@ -43,7 +43,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   DESCRIPTION   TYPE     ARCHITECTURE
-123   test   Test ISO      public   x86
+123   test   Test ISO      public   x86         
 `
 
 	require.NoError(t, err)

--- a/internal/cmd/loadbalancertype/list_test.go
+++ b/internal/cmd/loadbalancertype/list_test.go
@@ -43,7 +43,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   DESCRIPTION   MAX SERVICES   MAX CONNECTIONS   MAX TARGETS
-123   test   -             12             100               5
+123   test   -             12             100               5          
 `
 
 	require.NoError(t, err)

--- a/internal/cmd/location/list_test.go
+++ b/internal/cmd/location/list_test.go
@@ -42,7 +42,7 @@ func TestList(t *testing.T) {
 
 	out, errOut, err := fx.Run(cmd, []string{})
 
-	expOut := `ID   NAME   DESCRIPTION   NETWORK ZONE   COUNTRY   CITY
+	expOut := `ID   NAME   DESCRIPTION   NETWORK ZONE   COUNTRY   CITY       
 1    fsn1   -             eu-central     DE        Falkenstein
 `
 

--- a/internal/cmd/servertype/list_test.go
+++ b/internal/cmd/servertype/list_test.go
@@ -46,7 +46,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   CORES   CPU TYPE   ARCHITECTURE   MEMORY   DISK    STORAGE TYPE
-123   test   2       shared     arm            8.0 GB   80 GB   local
+123   test   2       shared     arm            8.0 GB   80 GB   local       
 `
 
 	require.NoError(t, err)
@@ -90,9 +90,9 @@ func TestListColumnDeprecated(t *testing.T) {
 
 	out, errOut, err := fx.Run(cmd, []string{"-o=columns=id,name,deprecated"})
 
-	expOut := `ID    NAME         DEPRECATED
+	expOut := `ID    NAME         DEPRECATED                  
 123   deprecated   Thu Aug 20 12:00:00 UTC 2037
-124   current      -
+124   current      -                           
 `
 
 	require.NoError(t, err)

--- a/internal/cmd/sshkey/list_test.go
+++ b/internal/cmd/sshkey/list_test.go
@@ -41,7 +41,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   FINGERPRINT   AGE
-123   test   -             1h
+123   test   -             1h 
 `
 
 	require.NoError(t, err)

--- a/internal/cmd/volume/list_test.go
+++ b/internal/cmd/volume/list_test.go
@@ -47,7 +47,7 @@ func TestList(t *testing.T) {
 	out, errOut, err := fx.Run(cmd, []string{})
 
 	expOut := `ID    NAME   SIZE    SERVER     LOCATION   AGE
-123   test   50 GB   myServer   fsn1       1h
+123   test   50 GB   myServer   fsn1       1h 
 `
 
 	require.NoError(t, err)

--- a/internal/testutil/cmd.go
+++ b/internal/testutil/cmd.go
@@ -35,6 +35,8 @@ const (
 )
 
 func (dt DataType) test(t *testing.T, expected string, actual string, _ ...any) {
+	t.Helper()
+
 	switch dt {
 	case DataTypeJSON:
 		assert.JSONEq(t, expected, actual)

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -120,7 +120,7 @@ func runCertificateTestSuite(t *testing.T, certName string, certID int64, certTy
 				Raw(fingerprintRegex).Whitespace().
 				OneOf("completed", "n/a").Whitespace().
 				Lit("n/a").Whitespace().
-				Age().Newline().
+				Age().OptionalWhitespace().Newline().
 				End(),
 			out,
 		)

--- a/test/e2e/datacenter_test.go
+++ b/test/e2e/datacenter_test.go
@@ -19,8 +19,8 @@ func TestDatacenter(t *testing.T) {
 			require.NoError(t, err)
 			assert.Regexp(t,
 				NewRegex().Start().
-					SeparatedByWhitespace("ID", "NAME", "DESCRIPTION", "LOCATION").Newline().
-					AnyTimes(NewRegex().Int().Whitespace().Identifier().Whitespace().AnyString().Whitespace().LocationName().Newline()).
+					SeparatedByWhitespace("ID", "NAME", "DESCRIPTION", "LOCATION").OptionalWhitespace().Newline().
+					AnyTimes(NewRegex().Int().Whitespace().Identifier().Whitespace().AnyString().Whitespace().LocationName().OptionalWhitespace().Newline()).
 					End(),
 				out,
 			)

--- a/test/e2e/floatingip_test.go
+++ b/test/e2e/floatingip_test.go
@@ -157,7 +157,7 @@ func TestFloatingIP(t *testing.T) {
 						Lit("delete").Whitespace().
 						Lit("foo=bar").Whitespace().
 						UnixDate().Whitespace().
-						Age().Newline().
+						Age().OptionalWhitespace().Newline().
 						End(),
 					out,
 				)
@@ -300,8 +300,8 @@ func TestFloatingIP(t *testing.T) {
 			require.NoError(t, err)
 			assert.Regexp(t,
 				NewRegex().Start().
-					SeparatedByWhitespace("IP", "DNS").Newline().
-					Lit(ipStr).Lit("/64").Whitespace().Lit("2 entries").Newline().
+					SeparatedByWhitespace("IP", "DNS").OptionalWhitespace().Newline().
+					Lit(ipStr).Lit("/64").Whitespace().Lit("2 entries").OptionalWhitespace().Newline().
 					End(),
 				out,
 			)

--- a/test/e2e/iso_test.go
+++ b/test/e2e/iso_test.go
@@ -29,7 +29,7 @@ func TestISO(t *testing.T) {
 						Identifier().Whitespace().
 						AnyString().Whitespace().
 						OneOfLit("public", "private").Whitespace().
-						OneOf("arm", "x86").Newline()).
+						OneOf("arm", "x86").OptionalWhitespace().Newline()).
 					End(),
 				out,
 			)

--- a/test/e2e/load_balancer_type_test.go
+++ b/test/e2e/load_balancer_type_test.go
@@ -30,7 +30,7 @@ func TestLoadBalancerType(t *testing.T) {
 						AnyString().Whitespace().
 						Int().Whitespace().
 						Int().Whitespace().
-						Int().Newline()).
+						Int().OptionalWhitespace().Newline()).
 					End(),
 				out,
 			)

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -55,12 +55,12 @@ func TestNetwork(t *testing.T) {
 		require.NoError(t, err)
 		assert.Regexp(t,
 			NewRegex().Start().
-				SeparatedByWhitespace("SERVERS", "IP", "RANGE", "LABELS", "PROTECTION", "CREATED", "AGE").Newline().
+				SeparatedByWhitespace("SERVERS", "IP", "RANGE", "LABELS", "PROTECTION", "CREATED", "AGE").OptionalWhitespace().Newline().
 				Lit("0 servers").Whitespace().
 				Lit("10.0.0.0/24").Whitespace().
 				Lit("delete").Whitespace().
 				UnixDate().Whitespace().
-				Age().Newline().End(),
+				Age().OptionalWhitespace().Newline().End(),
 			out,
 		)
 	})

--- a/test/e2e/placement_group_test.go
+++ b/test/e2e/placement_group_test.go
@@ -62,13 +62,13 @@ func TestPlacementGroup(t *testing.T) {
 
 			assert.Regexp(t,
 				NewRegex().Start().
-					SeparatedByWhitespace("ID", "NAME", "SERVERS", "TYPE", "CREATED", "AGE").Newline().
+					SeparatedByWhitespace("ID", "NAME", "SERVERS", "TYPE", "CREATED", "AGE").OptionalWhitespace().Newline().
 					Int().Whitespace().
 					Raw(`new-test-placement-group-[0-9a-f]{8}`).Whitespace().
 					Lit("0 servers").Whitespace().
 					Lit("spread").Whitespace().
 					UnixDate().Whitespace().
-					Age().Newline().End(),
+					Age().OptionalWhitespace().Newline().End(),
 				out,
 			)
 		})

--- a/test/e2e/sshkey_test.go
+++ b/test/e2e/sshkey_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,14 +53,14 @@ func TestSSHKey(t *testing.T) {
 			require.NoError(t, err)
 			assert.Regexp(t,
 				NewRegex().Start().
-					SeparatedByWhitespace("ID", "NAME", "FINGERPRINT", "PUBLIC KEY", "LABELS", "CREATED", "AGE").Newline().
+					SeparatedByWhitespace("ID", "NAME", "FINGERPRINT", "PUBLIC KEY", "LABELS", "CREATED", "AGE").OptionalWhitespace().Newline().
 					Lit(strconv.FormatInt(sshKeyID, 10)).Whitespace().
 					Lit(sshKeyName).Whitespace().
 					Lit(fingerprint).Whitespace().
 					Lit(pubKey).Whitespace().
 					Lit("baz=qux, foo=bar").Whitespace().
 					UnixDate().Whitespace().
-					Age().Newline().
+					Age().OptionalWhitespace().Newline().
 					End(),
 				out,
 			)
@@ -106,7 +107,7 @@ func TestSSHKey(t *testing.T) {
 			Lit("Name:").Whitespace().Lit(sshKeyName).Newline().
 			Lit("Created:").Whitespace().UnixDate().Lit(" (").HumanizeTime().Lit(")").Newline().
 			Lit("Fingerprint:").Whitespace().Lit(fingerprint).Newline().
-			Lit("Public Key:").Newline().Lit(pubKey).
+			Lit("Public Key:").Newline().Lit(pubKey).Newline().
 			Lit("Labels:").Newline().
 			Lit("  foo:").Whitespace().Lit("bar").Newline().
 			End(),
@@ -160,5 +161,5 @@ func generateSSHKey() (string, string, error) {
 		return "", "", err
 	}
 
-	return string(pub), fingerprint, nil
+	return strings.TrimSpace(string(pub)), fingerprint, nil
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -101,6 +101,10 @@ func (r RegexBuilder) Whitespace() RegexBuilder {
 	return r.Raw(`\s+`)
 }
 
+func (r RegexBuilder) OptionalWhitespace() RegexBuilder {
+	return r.Raw(`\s*`)
+}
+
 func (r RegexBuilder) Newline() RegexBuilder {
 	return r.Raw("\n")
 }


### PR DESCRIPTION
The previously used `text/tabwriter` does not even attempt to handle Unicode characters that may have a default width != 0. This causes issues in tables where any column has such a Unicode character (like emojis), as the alignment for that row would be broken.

We already use the new package for generating our docs, so this "only" moves it from tools to production dependency.

I tried to copy the previous style as much as possible and left the surrounding code as is. There is some potential for simplification because the new package can handle a lot of the column/view logic for us.