### PR TITLE
feat(load-balancer): allow specifying network on create

### DIFF
--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -45,7 +45,7 @@ var CreateCmd = base.CreateCmd{
 		cmd.Flags().StringSlice("enable-protection", []string{}, "Enable protection (delete) (default: none)")
 		_ = cmd.RegisterFlagCompletionFunc("enable-protection", cmpl.SuggestCandidates("delete"))
 
-		cmd.Flags().String("network", "", "Name or ID of the network the Load Balancer should be attached to on creation")
+		cmd.Flags().String("network", "", "Name or ID of the Network the Load Balancer should be attached to on creation")
 		_ = cmd.RegisterFlagCompletionFunc("network", cmpl.SuggestCandidatesF(client.Network().Names))
 
 		return cmd


### PR DESCRIPTION
This PR adds the ability to automatically attach a Load Balancer to a network after creation using the `--network` flag.

See #1004