### PR TITLE
feat(context): add unset commmand

### DIFF
--- a/internal/cmd/context/context.go
+++ b/internal/cmd/context/context.go
@@ -18,6 +18,7 @@ func NewCommand(s state.State) *cobra.Command {
 	cmd.AddCommand(
 		NewCreateCommand(s),
 		NewActiveCommand(s),
+		NewUnsetCommand(s),
 		NewUseCommand(s),
 		NewDeleteCommand(s),
 		NewListCommand(s),

--- a/internal/cmd/context/unset.go
+++ b/internal/cmd/context/unset.go
@@ -1,0 +1,29 @@
+package context
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/hetznercloud/cli/internal/cmd/cmpl"
+	"github.com/hetznercloud/cli/internal/cmd/util"
+	"github.com/hetznercloud/cli/internal/state"
+)
+
+func NewUnsetCommand(s state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "unset",
+		Short:                 "Unset used context",
+		Args:                  util.Validate,
+		ValidArgsFunction:     cmpl.SuggestNothing(),
+		TraverseChildren:      true,
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		RunE:                  state.Wrap(s, runUnset),
+	}
+	return cmd
+}
+
+func runUnset(s state.State, _ *cobra.Command, _ []string) error {
+	cfg := s.Config()
+	cfg.SetActiveContext(nil)
+	return cfg.Write(nil)
+}

--- a/internal/cmd/context/unset_test.go
+++ b/internal/cmd/context/unset_test.go
@@ -1,0 +1,57 @@
+package context_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hetznercloud/cli/internal/cmd/context"
+	"github.com/hetznercloud/cli/internal/testutil"
+)
+
+func TestUnset(t *testing.T) {
+	// Make sure we don't have any environment variables set that could interfere with the test
+	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("HCLOUD_CONTEXT", "")
+
+	testConfig := `active_context = "my-context"
+
+[[contexts]]
+  name = "my-context"
+  token = "super secret token"
+
+[[contexts]]
+  name = "my-other-context"
+  token = "another super secret token"
+
+[[contexts]]
+  name = "my-third-context"
+  token = "yet another super secret token"
+`
+
+	expOut := `active_context = ""
+
+[[contexts]]
+  name = "my-context"
+  token = "super secret token"
+
+[[contexts]]
+  name = "my-other-context"
+  token = "another super secret token"
+
+[[contexts]]
+  name = "my-third-context"
+  token = "yet another super secret token"
+`
+
+	fx := testutil.NewFixtureWithConfigFile(t, []byte(testConfig))
+	defer fx.Finish()
+
+	cmd := context.NewUnsetCommand(fx.State())
+	out, errOut, err := fx.Run(cmd, []string{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "", errOut)
+	assert.Equal(t, expOut, out)
+}


### PR DESCRIPTION
This PR adds the `hcloud context unset` command, which allows unsetting the currently active context.

Fixes https://github.com/hetznercloud/cli/issues/992