### PR TITLE
ci: fix version string for preview builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
           output: true
 
 snapshot:
-  version_template: "{{ .Version }}-dev+{{ .ShortCommit }}"
+  version_template: "{{ .Version }}"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
This fixes the version string of snapshots to instead of this:
```hcloud 1.50.0-dev+07d1b93-dev+07d1b93```
Look like this:
```hcloud 1.50.0-dev+07d1b93```