### PR TITLE
ci: fix goreleaser ko config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,7 +44,6 @@ kos:
     platforms:
       - linux/amd64
       - linux/arm64
-    base_import_paths: true
     base_image: alpine
     bare: true
     labels:


### PR DESCRIPTION
We accidentally used the `bare` and `base_import_paths` option at the same time, which disabled the `bare` option. This added extra nesting after `KO_DOCKER_REPO`, causing the push to Docker Hub to fail.