### PR TITLE
ci: include docs in archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,6 +94,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - docs/**/*
 
 release:
   draft: false


### PR DESCRIPTION
Since we link to our docs in the README we should include them in the archive as well.