### PR TITLE
ci: keep goreleaser from untagging prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,3 +97,4 @@ archives:
 
 release:
   draft: false
+  prerelease: auto


### PR DESCRIPTION
By default `release.prerelease` is set to `false`, which led to GoReleaser untagging our prereleases.