### PR TITLE
docs: improve binary download command for linux setup

### DIFF
--- a/docs/tutorials/setup-hcloud-cli.md
+++ b/docs/tutorials/setup-hcloud-cli.md
@@ -19,7 +19,7 @@ On a 64-bit Linux system, it could look something like this:
 
 ```bash
 curl -sSLO https://github.com/hetznercloud/cli/releases/download/v1.51.0/hcloud-linux-amd64.tar.gz
-sudo tar -C /usr/local/bin -xzf hcloud-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin --no-same-owner -xzf hcloud-linux-amd64.tar.gz hcloud
 rm hcloud-linux-amd64.tar.gz
 ```
 


### PR DESCRIPTION
- Make archive download silent 
- Do not extract docs or LICENSE
- Do not preserve the owner of the file in the archive