### PR TITLE
ci: only count coverage for internal package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           version: v2025.5.9
 
       - name: Run tests
-        run: go test -coverpkg=./... -coverprofile=coverage.txt -v -race ./...
+        run: go test -coverpkg=./internal/... -coverprofile=coverage.txt -v -race ./...
 
       - name: Upload coverage reports to Codecov
         if: >
@@ -70,7 +70,7 @@ jobs:
       - uses: hetznercloud/tps-action@main
 
       - name: Run tests
-        run: go test -tags e2e -coverpkg=./... -coverprofile=coverage.txt -v -race ./test/e2e
+        run: go test -tags e2e -coverpkg=./internal/... -coverprofile=coverage.txt -v -race ./test/e2e
         env:
           # Domain must be available in the account running the tests. This domain is
           # available in the account running the public integration tests.


### PR DESCRIPTION
Currently we count code coverage when testing (using the `-coverpkg`) across the entire repository and all of its subdirectories. This caused problems in one of our CI jobs, where a Go installation was placed inside of the repository in a hidden folder, causing `-coverpkg` to also cover the entire Go source.
Since all of the code that needs testing is located in the `internal` package, we should restrict our tests to only cover that package.