### PR TITLE
ci: allow use of replace directives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
     - wrapcheck # Very annoying to wrap errors everywhere
     # preset import
     - depguard
+    # we want to allow the use of replace directives in go.mod files
+    - gomoddirectives
 
 linters-settings:
   gci:


### PR DESCRIPTION
We need to disable the `gomoddirectives` linter if we want to allow replace directives in our go.mod.