### PR TITLE
feat: add plural command aliases

### DIFF
--- a/internal/cmd/certificate/certificate.go
+++ b/internal/cmd/certificate/certificate.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "certificate",
+		Aliases:               []string{"certificates"},
 		Short:                 "Manage Certificates",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/datacenter/datacenter.go
+++ b/internal/cmd/datacenter/datacenter.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "datacenter",
+		Aliases:               []string{"datacenters"},
 		Short:                 "View Datacenters",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/firewall/firewall.go
+++ b/internal/cmd/firewall/firewall.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "firewall",
+		Aliases:               []string{"firewalls"},
 		Short:                 "Manage Firewalls",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/floatingip/floatingip.go
+++ b/internal/cmd/floatingip/floatingip.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "floating-ip",
+		Aliases:               []string{"floating-ips"},
 		Short:                 "Manage Floating IPs",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/image/image.go
+++ b/internal/cmd/image/image.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "image",
+		Aliases:               []string{"images"},
 		Short:                 "Manage Images",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/iso/iso.go
+++ b/internal/cmd/iso/iso.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "iso",
+		Aliases:               []string{"isos"},
 		Short:                 "View ISOs",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/loadbalancer/load_balancer.go
+++ b/internal/cmd/loadbalancer/load_balancer.go
@@ -11,7 +11,7 @@ func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "load-balancer",
 		Short:                 "Manage Load Balancers",
-		Aliases:               []string{"loadbalancer"},
+		Aliases:               []string{"loadbalancer", "load-balancers", "loadbalancers"},
 		Args:                  util.Validate,
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,

--- a/internal/cmd/location/location.go
+++ b/internal/cmd/location/location.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "location",
+		Aliases:               []string{"locations"},
 		Short:                 "View Locations",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/network/network.go
+++ b/internal/cmd/network/network.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "network",
+		Aliases:               []string{"networks"},
 		Short:                 "Manage Networks",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/placementgroup/placementgroup.go
+++ b/internal/cmd/placementgroup/placementgroup.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "placement-group",
+		Aliases:               []string{"placement-groups"},
 		Short:                 "Manage Placement Groups",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/primaryip/primaryip.go
+++ b/internal/cmd/primaryip/primaryip.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "primary-ip",
+		Aliases:               []string{"primary-ips"},
 		Short:                 "Manage Primary IPs",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/server/server.go
+++ b/internal/cmd/server/server.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "server",
+		Aliases:               []string{"servers"},
 		Short:                 "Manage Servers",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/sshkey/sshkey.go
+++ b/internal/cmd/sshkey/sshkey.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "ssh-key",
+		Aliases:               []string{"ssh-keys"},
 		Short:                 "Manage SSH Keys",
 		Args:                  util.Validate,
 		TraverseChildren:      true,

--- a/internal/cmd/volume/volume.go
+++ b/internal/cmd/volume/volume.go
@@ -10,6 +10,7 @@ import (
 func NewCommand(s state.State) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "volume",
+		Aliases:               []string{"volumes"},
 		Short:                 "Manage Volumes",
 		Args:                  util.Validate,
 		TraverseChildren:      true,


### PR DESCRIPTION
Fixes #1083

We might want to add some aliases for longer resource names as well, like `certificate` -> `cert` or `load-balancer` -> `lb`