### PR TITLE
test(e2e): fix snapshot describe

### DIFF
--- a/test/e2e/combined_test.go
+++ b/test/e2e/combined_test.go
@@ -291,7 +291,7 @@ func TestCombined(t *testing.T) {
 					Lit("Image size:").Whitespace().FileSize().Newline().
 					Lit("Disk size:").Whitespace().FileSize().Newline().
 					Lit("OS flavor:").Whitespace().Identifier().Newline().
-					Lit("OS version:").Whitespace().Lit("-").Newline().
+					Lit("OS version:").Whitespace().Identifier().Newline().
 					Lit("Architecture:").Whitespace().OneOfLit("x86", "arm").Newline().
 					Lit("Rapid deploy:").Whitespace().Lit("no").Newline().
 					Lit("Protection:").Newline().


### PR DESCRIPTION
In the past, the API did not return OS versions for snapshots. This is now fixed.