### PR TITLE
fix: do not indent last empty line

### DIFF
--- a/internal/cmd/server/describe.go
+++ b/internal/cmd/server/describe.go
@@ -39,7 +39,10 @@ var DescribeCmd = base.DescribeCmd[*hcloud.Server]{
 		cmd.Printf("  Memory:\t%v GB\n", server.ServerType.Memory)
 		cmd.Printf("  Disk:\t\t%d GB\n", server.PrimaryDiskSize)
 		cmd.Printf("  Storage Type:\t%s\n", server.ServerType.StorageType)
-		cmd.Print(util.PrefixLines(util.DescribeDeprecation(server.ServerType), "  "))
+
+		if text := util.DescribeDeprecation(server.ServerType); text != "" {
+			cmd.Print(util.PrefixLines(text, "  "))
+		}
 
 		cmd.Printf("Public Net:\n")
 		cmd.Printf("  IPv4:\n")

--- a/internal/cmd/server/describe_test.go
+++ b/internal/cmd/server/describe_test.go
@@ -91,7 +91,7 @@ Server Type:	cax11 (ID: 45)
   Memory:	4 GB
   Disk:		0 GB
   Storage Type:	local
-  Public Net:
+Public Net:
   IPv4:
     No Primary IPv4
   IPv6:

--- a/internal/cmd/util/util.go
+++ b/internal/cmd/util/util.go
@@ -163,13 +163,13 @@ func LabelsToString(labels map[string]string) string {
 
 // PrefixLines will prefix all individual lines in the text with the passed prefix.
 func PrefixLines(text, prefix string) string {
-	var lines []string
-
-	for _, line := range strings.Split(text, "\n") {
-		lines = append(lines, prefix+line)
+	var tail string
+	if len(text) > 0 && text[len(text)-1] == '\n' {
+		text = text[:len(text)-1]
+		tail = "\n"
 	}
 
-	return strings.Join(lines, "\n")
+	return prefix + strings.ReplaceAll(text, "\n", "\n"+prefix) + tail
 }
 
 func DescribeFormat(w io.Writer, object interface{}, format string) error {

--- a/internal/cmd/util/util_test.go
+++ b/internal/cmd/util/util_test.go
@@ -186,7 +186,11 @@ func TestLabelsToString(t *testing.T) {
 }
 
 func TestPrefixLines(t *testing.T) {
+	assert.Equal(t, "  ", util.PrefixLines("", "  "))
+	assert.Equal(t, "  \n", util.PrefixLines("\n", "  "))
 	assert.Equal(t, "  foo\n  bar", util.PrefixLines("foo\nbar", "  "))
+	assert.Equal(t, "  foo\n  bar\n", util.PrefixLines("foo\nbar\n", "  "))
+	assert.Equal(t, "  foo\n  bar\n  \n", util.PrefixLines("foo\nbar\n\n", "  "))
 }
 
 func TestDescribeFormat(t *testing.T) {


### PR DESCRIPTION
Fixes the server describe output:

```
Server Type:    cpx11 (ID: 22)
  Name:         cpx11
  Cores:        2
  Public Net:
  IPv4:
```

With:

```
Server Type:    cpx11 (ID: 22)
  Name:         cpx11
  Cores:        2
Public Net:
  IPv4:
```