### PR TITLE
feat: add support for Hetzner API

### DIFF
--- a/docs/reference/manual/hcloud.md
+++ b/docs/reference/manual/hcloud.md
@@ -9,14 +9,15 @@ A command-line interface for Hetzner Cloud
 ### Options
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-  -h, --help                     help for hcloud
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+  -h, --help                      help for hcloud
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_all.md
+++ b/docs/reference/manual/hcloud_all.md
@@ -11,13 +11,14 @@ Commands that apply to all resources
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_all_list.md
+++ b/docs/reference/manual/hcloud_all_list.md
@@ -36,13 +36,14 @@ hcloud all list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate.md
+++ b/docs/reference/manual/hcloud_certificate.md
@@ -11,13 +11,14 @@ Manage Certificates
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_add-label.md
+++ b/docs/reference/manual/hcloud_certificate_add-label.md
@@ -16,13 +16,14 @@ hcloud certificate add-label [--overwrite] <certificate> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_create.md
+++ b/docs/reference/manual/hcloud_certificate_create.md
@@ -22,13 +22,14 @@ hcloud certificate create [options] --name <name> (--type managed --domain <doma
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_delete.md
+++ b/docs/reference/manual/hcloud_certificate_delete.md
@@ -15,13 +15,14 @@ hcloud certificate delete <certificate>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_describe.md
+++ b/docs/reference/manual/hcloud_certificate_describe.md
@@ -16,13 +16,14 @@ hcloud certificate describe [options] <certificate>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_list.md
+++ b/docs/reference/manual/hcloud_certificate_list.md
@@ -40,13 +40,14 @@ hcloud certificate list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_remove-label.md
+++ b/docs/reference/manual/hcloud_certificate_remove-label.md
@@ -16,13 +16,14 @@ hcloud certificate remove-label <certificate> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_retry.md
+++ b/docs/reference/manual/hcloud_certificate_retry.md
@@ -15,13 +15,14 @@ hcloud certificate retry <certificate>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_certificate_update.md
+++ b/docs/reference/manual/hcloud_certificate_update.md
@@ -16,13 +16,14 @@ hcloud certificate update [options] <certificate>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_completion.md
+++ b/docs/reference/manual/hcloud_completion.md
@@ -77,13 +77,14 @@ hcloud completion <shell>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config.md
+++ b/docs/reference/manual/hcloud_config.md
@@ -46,31 +46,33 @@ Since the above options are not preferences, they cannot be modified with 'hclou
 Following options are preferences and can be used with set/unset/add/remove:
 
 ```
-┌──────────────────┬──────────────────────┬─────────────┬──────────────────┬─────────────────────────┬─────────────────┐
-│ OPTION           │ DESCRIPTION          │ TYPE        │ CONFIG KEY       │ ENVIRONMENT VARIABLE    │ FLAG            │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ debug            │ Enable debug output  │ boolean     │ debug            │ HCLOUD_DEBUG            │ --debug         │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ debug-file       │ File to write debug  │ string      │ debug_file       │ HCLOUD_DEBUG_FILE       │ --debug-file    │
-│                  │ output to            │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ default-ssh-keys │ Default SSH Keys for │ string list │ default_ssh_keys │ HCLOUD_DEFAULT_SSH_KEYS │                 │
-│                  │ new Servers          │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ endpoint         │ Hetzner Cloud API    │ string      │ endpoint         │ HCLOUD_ENDPOINT         │ --endpoint      │
-│                  │ endpoint             │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ poll-interval    │ Interval at which to │ duration    │ poll_interval    │ HCLOUD_POLL_INTERVAL    │ --poll-interval │
-│                  │ poll information,    │             │                  │                         │                 │
-│                  │ for example action   │             │                  │                         │                 │
-│                  │ progress             │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ quiet            │ If true, only print  │ boolean     │ quiet            │ HCLOUD_QUIET            │ --quiet         │
-│                  │ error messages       │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ sort.<resource>  │ Default sorting for  │ string list │ sort.<resource>  │ HCLOUD_SORT_<RESOURCE>  │                 │
-│                  │ resource             │             │                  │                         │                 │
-└──────────────────┴──────────────────────┴─────────────┴──────────────────┴─────────────────────────┴─────────────────┘
+┌──────────────────┬──────────────────────┬─────────────┬──────────────────┬─────────────────────────┬────────────────────┐
+│ OPTION           │ DESCRIPTION          │ TYPE        │ CONFIG KEY       │ ENVIRONMENT VARIABLE    │ FLAG               │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ debug            │ Enable debug output  │ boolean     │ debug            │ HCLOUD_DEBUG            │ --debug            │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ debug-file       │ File to write debug  │ string      │ debug_file       │ HCLOUD_DEBUG_FILE       │ --debug-file       │
+│                  │ output to            │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ default-ssh-keys │ Default SSH Keys for │ string list │ default_ssh_keys │ HCLOUD_DEFAULT_SSH_KEYS │                    │
+│                  │ new Servers          │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ endpoint         │ Hetzner Cloud API    │ string      │ endpoint         │ HCLOUD_ENDPOINT         │ --endpoint         │
+│                  │ endpoint             │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ hetzner-endpoint │ Hetzner API endpoint │ string      │ hetzner_endpoint │ HETZNER_ENDPOINT        │ --hetzner-endpoint │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ poll-interval    │ Interval at which to │ duration    │ poll_interval    │ HCLOUD_POLL_INTERVAL    │ --poll-interval    │
+│                  │ poll information,    │             │                  │                         │                    │
+│                  │ for example action   │             │                  │                         │                    │
+│                  │ progress             │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ quiet            │ If true, only print  │ boolean     │ quiet            │ HCLOUD_QUIET            │ --quiet            │
+│                  │ error messages       │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ sort.<resource>  │ Default sorting for  │ string list │ sort.<resource>  │ HCLOUD_SORT_<RESOURCE>  │                    │
+│                  │ resource             │             │                  │                         │                    │
+└──────────────────┴──────────────────────┴─────────────┴──────────────────┴─────────────────────────┴────────────────────┘
 ```
 
 Options will be persisted in the configuration file. To find out where your configuration file is located
@@ -86,13 +88,14 @@ on disk, run 'hcloud config get config'.
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config_add.md
+++ b/docs/reference/manual/hcloud_config_add.md
@@ -20,13 +20,14 @@ hcloud config add <key> <value>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config_get.md
+++ b/docs/reference/manual/hcloud_config_get.md
@@ -21,13 +21,14 @@ hcloud config get <key>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config_list.md
+++ b/docs/reference/manual/hcloud_config_list.md
@@ -19,13 +19,14 @@ hcloud config list
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config_remove.md
+++ b/docs/reference/manual/hcloud_config_remove.md
@@ -20,13 +20,14 @@ hcloud config remove <key> <value>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config_set.md
+++ b/docs/reference/manual/hcloud_config_set.md
@@ -20,13 +20,14 @@ hcloud config set <key> <value>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_config_unset.md
+++ b/docs/reference/manual/hcloud_config_unset.md
@@ -20,13 +20,14 @@ hcloud config unset <key>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context.md
+++ b/docs/reference/manual/hcloud_context.md
@@ -11,13 +11,14 @@ Manage contexts
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_active.md
+++ b/docs/reference/manual/hcloud_context_active.md
@@ -15,13 +15,14 @@ hcloud context active
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_create.md
+++ b/docs/reference/manual/hcloud_context_create.md
@@ -15,13 +15,14 @@ hcloud context create <name>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_delete.md
+++ b/docs/reference/manual/hcloud_context_delete.md
@@ -15,13 +15,14 @@ hcloud context delete <context>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_list.md
+++ b/docs/reference/manual/hcloud_context_list.md
@@ -28,13 +28,14 @@ hcloud context list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_rename.md
+++ b/docs/reference/manual/hcloud_context_rename.md
@@ -15,13 +15,14 @@ hcloud context rename <context> <name>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_unset.md
+++ b/docs/reference/manual/hcloud_context_unset.md
@@ -15,13 +15,14 @@ hcloud context unset
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_context_use.md
+++ b/docs/reference/manual/hcloud_context_use.md
@@ -15,13 +15,14 @@ hcloud context use <context>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_datacenter.md
+++ b/docs/reference/manual/hcloud_datacenter.md
@@ -11,13 +11,14 @@ View Datacenters
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_datacenter_describe.md
+++ b/docs/reference/manual/hcloud_datacenter_describe.md
@@ -16,13 +16,14 @@ hcloud datacenter describe [options] <datacenter>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_datacenter_list.md
+++ b/docs/reference/manual/hcloud_datacenter_list.md
@@ -32,13 +32,14 @@ hcloud datacenter list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall.md
+++ b/docs/reference/manual/hcloud_firewall.md
@@ -11,13 +11,14 @@ Manage Firewalls
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_add-label.md
+++ b/docs/reference/manual/hcloud_firewall_add-label.md
@@ -16,13 +16,14 @@ hcloud firewall add-label [--overwrite] <firewall> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_add-rule.md
+++ b/docs/reference/manual/hcloud_firewall_add-rule.md
@@ -21,13 +21,14 @@ hcloud firewall add-rule [options] (--direction in --source-ips <ips> | --direct
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_apply-to-resource.md
+++ b/docs/reference/manual/hcloud_firewall_apply-to-resource.md
@@ -18,13 +18,14 @@ hcloud firewall apply-to-resource (--type server --server <server> | --type labe
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_create.md
+++ b/docs/reference/manual/hcloud_firewall_create.md
@@ -19,13 +19,14 @@ hcloud firewall create [options] --name <name>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_delete-rule.md
+++ b/docs/reference/manual/hcloud_firewall_delete-rule.md
@@ -21,13 +21,14 @@ hcloud firewall delete-rule [options] (--direction in --source-ips <ips> | --dir
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_delete.md
+++ b/docs/reference/manual/hcloud_firewall_delete.md
@@ -15,13 +15,14 @@ hcloud firewall delete <firewall>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_describe.md
+++ b/docs/reference/manual/hcloud_firewall_describe.md
@@ -16,13 +16,14 @@ hcloud firewall describe [options] <firewall>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_list.md
+++ b/docs/reference/manual/hcloud_firewall_list.md
@@ -32,13 +32,14 @@ hcloud firewall list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_remove-from-resource.md
+++ b/docs/reference/manual/hcloud_firewall_remove-from-resource.md
@@ -18,13 +18,14 @@ hcloud firewall remove-from-resource (--type server --server <server> | --type l
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_remove-label.md
+++ b/docs/reference/manual/hcloud_firewall_remove-label.md
@@ -16,13 +16,14 @@ hcloud firewall remove-label <firewall> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_replace-rules.md
+++ b/docs/reference/manual/hcloud_firewall_replace-rules.md
@@ -16,13 +16,14 @@ hcloud firewall replace-rules --rules-file <file> <firewall>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_firewall_update.md
+++ b/docs/reference/manual/hcloud_firewall_update.md
@@ -16,13 +16,14 @@ hcloud firewall update [options] <firewall>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip.md
+++ b/docs/reference/manual/hcloud_floating-ip.md
@@ -11,13 +11,14 @@ Manage Floating IPs
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_add-label.md
+++ b/docs/reference/manual/hcloud_floating-ip_add-label.md
@@ -16,13 +16,14 @@ hcloud floating-ip add-label [--overwrite] <floating-ip> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_assign.md
+++ b/docs/reference/manual/hcloud_floating-ip_assign.md
@@ -15,13 +15,14 @@ hcloud floating-ip assign <floating-ip> <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_create.md
+++ b/docs/reference/manual/hcloud_floating-ip_create.md
@@ -23,13 +23,14 @@ hcloud floating-ip create [options] --type <ipv4|ipv6> (--home-location <locatio
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_delete.md
+++ b/docs/reference/manual/hcloud_floating-ip_delete.md
@@ -15,13 +15,14 @@ hcloud floating-ip delete <floating-ip>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_describe.md
+++ b/docs/reference/manual/hcloud_floating-ip_describe.md
@@ -16,13 +16,14 @@ hcloud floating-ip describe [options] <floating-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_disable-protection.md
+++ b/docs/reference/manual/hcloud_floating-ip_disable-protection.md
@@ -15,13 +15,14 @@ hcloud floating-ip disable-protection <floating-ip> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_enable-protection.md
+++ b/docs/reference/manual/hcloud_floating-ip_enable-protection.md
@@ -15,13 +15,14 @@ hcloud floating-ip enable-protection <floating-ip> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_list.md
+++ b/docs/reference/manual/hcloud_floating-ip_list.md
@@ -41,13 +41,14 @@ hcloud floating-ip list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_remove-label.md
+++ b/docs/reference/manual/hcloud_floating-ip_remove-label.md
@@ -16,13 +16,14 @@ hcloud floating-ip remove-label <floating-ip> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_set-rdns.md
+++ b/docs/reference/manual/hcloud_floating-ip_set-rdns.md
@@ -18,13 +18,14 @@ hcloud floating-ip set-rdns [--ip <ip>] (--hostname <hostname> | --reset) <float
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_unassign.md
+++ b/docs/reference/manual/hcloud_floating-ip_unassign.md
@@ -15,13 +15,14 @@ hcloud floating-ip unassign <floating-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_floating-ip_update.md
+++ b/docs/reference/manual/hcloud_floating-ip_update.md
@@ -17,13 +17,14 @@ hcloud floating-ip update [options] <floating-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image.md
+++ b/docs/reference/manual/hcloud_image.md
@@ -11,13 +11,14 @@ Manage Images
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_add-label.md
+++ b/docs/reference/manual/hcloud_image_add-label.md
@@ -16,13 +16,14 @@ hcloud image add-label [--overwrite] <image> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_delete.md
+++ b/docs/reference/manual/hcloud_image_delete.md
@@ -15,13 +15,14 @@ hcloud image delete <image>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_describe.md
+++ b/docs/reference/manual/hcloud_image_describe.md
@@ -17,13 +17,14 @@ hcloud image describe [options] <image>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_disable-protection.md
+++ b/docs/reference/manual/hcloud_image_disable-protection.md
@@ -15,13 +15,14 @@ hcloud image disable-protection <image> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_enable-protection.md
+++ b/docs/reference/manual/hcloud_image_enable-protection.md
@@ -15,13 +15,14 @@ hcloud image enable-protection <image> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_list.md
+++ b/docs/reference/manual/hcloud_image_list.md
@@ -48,13 +48,14 @@ hcloud image list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_remove-label.md
+++ b/docs/reference/manual/hcloud_image_remove-label.md
@@ -16,13 +16,14 @@ hcloud image remove-label <image> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_image_update.md
+++ b/docs/reference/manual/hcloud_image_update.md
@@ -17,13 +17,14 @@ hcloud image update [options] <image>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_iso.md
+++ b/docs/reference/manual/hcloud_iso.md
@@ -11,13 +11,14 @@ View ISOs
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_iso_describe.md
+++ b/docs/reference/manual/hcloud_iso_describe.md
@@ -16,13 +16,14 @@ hcloud iso describe [options] <iso>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_iso_list.md
+++ b/docs/reference/manual/hcloud_iso_list.md
@@ -36,13 +36,14 @@ hcloud iso list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer-type.md
+++ b/docs/reference/manual/hcloud_load-balancer-type.md
@@ -11,13 +11,14 @@ View Load Balancer Types
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer-type_describe.md
+++ b/docs/reference/manual/hcloud_load-balancer-type_describe.md
@@ -16,13 +16,14 @@ hcloud load-balancer-type describe [options] <load-balancer-type>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer-type_list.md
+++ b/docs/reference/manual/hcloud_load-balancer-type_list.md
@@ -35,13 +35,14 @@ hcloud load-balancer-type list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer.md
+++ b/docs/reference/manual/hcloud_load-balancer.md
@@ -11,13 +11,14 @@ Manage Load Balancers
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_add-label.md
+++ b/docs/reference/manual/hcloud_load-balancer_add-label.md
@@ -16,13 +16,14 @@ hcloud load-balancer add-label [--overwrite] <load-balancer> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_add-service.md
+++ b/docs/reference/manual/hcloud_load-balancer_add-service.md
@@ -34,13 +34,14 @@ hcloud load-balancer add-service [options] (--protocol http | --protocol tcp --l
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_add-target.md
+++ b/docs/reference/manual/hcloud_load-balancer_add-target.md
@@ -19,13 +19,14 @@ hcloud load-balancer add-target [options] (--server <server> | --label-selector 
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_attach-to-network.md
+++ b/docs/reference/manual/hcloud_load-balancer_attach-to-network.md
@@ -17,13 +17,14 @@ hcloud load-balancer attach-to-network [--ip <ip>] --network <network> <load-bal
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_change-algorithm.md
+++ b/docs/reference/manual/hcloud_load-balancer_change-algorithm.md
@@ -16,13 +16,14 @@ hcloud load-balancer change-algorithm --algorithm-type <round_robin|least_connec
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_change-type.md
+++ b/docs/reference/manual/hcloud_load-balancer_change-type.md
@@ -15,13 +15,14 @@ hcloud load-balancer change-type <load-balancer> <load-balancer-type>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_create.md
+++ b/docs/reference/manual/hcloud_load-balancer_create.md
@@ -24,13 +24,14 @@ hcloud load-balancer create [options] --name <name> --type <type>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_delete-service.md
+++ b/docs/reference/manual/hcloud_load-balancer_delete-service.md
@@ -16,13 +16,14 @@ hcloud load-balancer delete-service --listen-port <1-65535> <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_delete.md
+++ b/docs/reference/manual/hcloud_load-balancer_delete.md
@@ -15,13 +15,14 @@ hcloud load-balancer delete <load-balancer>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_describe.md
+++ b/docs/reference/manual/hcloud_load-balancer_describe.md
@@ -17,13 +17,14 @@ hcloud load-balancer describe [options] <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_detach-from-network.md
+++ b/docs/reference/manual/hcloud_load-balancer_detach-from-network.md
@@ -16,13 +16,14 @@ hcloud load-balancer detach-from-network --network <network> <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_disable-protection.md
+++ b/docs/reference/manual/hcloud_load-balancer_disable-protection.md
@@ -15,13 +15,14 @@ hcloud load-balancer disable-protection <load-balancer> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_disable-public-interface.md
+++ b/docs/reference/manual/hcloud_load-balancer_disable-public-interface.md
@@ -15,13 +15,14 @@ hcloud load-balancer disable-public-interface <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_enable-protection.md
+++ b/docs/reference/manual/hcloud_load-balancer_enable-protection.md
@@ -15,13 +15,14 @@ hcloud load-balancer enable-protection <load-balancer> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_enable-public-interface.md
+++ b/docs/reference/manual/hcloud_load-balancer_enable-public-interface.md
@@ -15,13 +15,14 @@ hcloud load-balancer enable-public-interface <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_list.md
+++ b/docs/reference/manual/hcloud_load-balancer_list.md
@@ -40,13 +40,14 @@ hcloud load-balancer list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_metrics.md
+++ b/docs/reference/manual/hcloud_load-balancer_metrics.md
@@ -19,13 +19,14 @@ hcloud load-balancer metrics [options] (--type <open_connections|connections_per
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_remove-label.md
+++ b/docs/reference/manual/hcloud_load-balancer_remove-label.md
@@ -16,13 +16,14 @@ hcloud load-balancer remove-label <load-balancer> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_remove-target.md
+++ b/docs/reference/manual/hcloud_load-balancer_remove-target.md
@@ -18,13 +18,14 @@ hcloud load-balancer remove-target [options] <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_set-rdns.md
+++ b/docs/reference/manual/hcloud_load-balancer_set-rdns.md
@@ -18,13 +18,14 @@ hcloud load-balancer set-rdns [--ip <ip>] (--hostname <hostname> | --reset) <loa
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_update-service.md
+++ b/docs/reference/manual/hcloud_load-balancer_update-service.md
@@ -34,13 +34,14 @@ hcloud load-balancer update-service [options] --listen-port <1-65535> <load-bala
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_load-balancer_update.md
+++ b/docs/reference/manual/hcloud_load-balancer_update.md
@@ -16,13 +16,14 @@ hcloud load-balancer update [options] <load-balancer>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_location.md
+++ b/docs/reference/manual/hcloud_location.md
@@ -11,13 +11,14 @@ View Locations
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_location_describe.md
+++ b/docs/reference/manual/hcloud_location_describe.md
@@ -16,13 +16,14 @@ hcloud location describe [options] <location>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_location_list.md
+++ b/docs/reference/manual/hcloud_location_list.md
@@ -36,13 +36,14 @@ hcloud location list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network.md
+++ b/docs/reference/manual/hcloud_network.md
@@ -11,13 +11,14 @@ Manage Networks
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_add-label.md
+++ b/docs/reference/manual/hcloud_network_add-label.md
@@ -16,13 +16,14 @@ hcloud network add-label [--overwrite] <network> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_add-route.md
+++ b/docs/reference/manual/hcloud_network_add-route.md
@@ -17,13 +17,14 @@ hcloud network add-route --destination <destination> --gateway <ip> <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_add-subnet.md
+++ b/docs/reference/manual/hcloud_network_add-subnet.md
@@ -19,13 +19,14 @@ hcloud network add-subnet [options] --type <cloud|server|vswitch> --network-zone
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_change-ip-range.md
+++ b/docs/reference/manual/hcloud_network_change-ip-range.md
@@ -16,13 +16,14 @@ hcloud network change-ip-range --ip-range <ip-range> <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_create.md
+++ b/docs/reference/manual/hcloud_network_create.md
@@ -21,13 +21,14 @@ hcloud network create [options] --name <name> --ip-range <ip-range>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_delete.md
+++ b/docs/reference/manual/hcloud_network_delete.md
@@ -15,13 +15,14 @@ hcloud network delete <network>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_describe.md
+++ b/docs/reference/manual/hcloud_network_describe.md
@@ -16,13 +16,14 @@ hcloud network describe [options] <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_disable-protection.md
+++ b/docs/reference/manual/hcloud_network_disable-protection.md
@@ -15,13 +15,14 @@ hcloud network disable-protection <network> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_enable-protection.md
+++ b/docs/reference/manual/hcloud_network_enable-protection.md
@@ -15,13 +15,14 @@ hcloud network enable-protection <network> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_expose-routes-to-vswitch.md
+++ b/docs/reference/manual/hcloud_network_expose-routes-to-vswitch.md
@@ -20,13 +20,14 @@ hcloud network expose-routes-to-vswitch [--disable] <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_list.md
+++ b/docs/reference/manual/hcloud_network_list.md
@@ -37,13 +37,14 @@ hcloud network list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_remove-label.md
+++ b/docs/reference/manual/hcloud_network_remove-label.md
@@ -16,13 +16,14 @@ hcloud network remove-label <network> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_remove-route.md
+++ b/docs/reference/manual/hcloud_network_remove-route.md
@@ -17,13 +17,14 @@ hcloud network remove-route --destination <destination> --gateway <ip> <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_remove-subnet.md
+++ b/docs/reference/manual/hcloud_network_remove-subnet.md
@@ -16,13 +16,14 @@ hcloud network remove-subnet --ip-range <ip-range> <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_network_update.md
+++ b/docs/reference/manual/hcloud_network_update.md
@@ -18,13 +18,14 @@ hcloud network update [options] <network>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group.md
+++ b/docs/reference/manual/hcloud_placement-group.md
@@ -11,13 +11,14 @@ Manage Placement Groups
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_add-label.md
+++ b/docs/reference/manual/hcloud_placement-group_add-label.md
@@ -16,13 +16,14 @@ hcloud placement-group add-label [--overwrite] <placement-group> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_create.md
+++ b/docs/reference/manual/hcloud_placement-group_create.md
@@ -19,13 +19,14 @@ hcloud placement-group create [options] --name <name> --type <type>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_delete.md
+++ b/docs/reference/manual/hcloud_placement-group_delete.md
@@ -15,13 +15,14 @@ hcloud placement-group delete <placement-group>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_describe.md
+++ b/docs/reference/manual/hcloud_placement-group_describe.md
@@ -16,13 +16,14 @@ hcloud placement-group describe [options] <placement-group>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_list.md
+++ b/docs/reference/manual/hcloud_placement-group_list.md
@@ -34,13 +34,14 @@ hcloud placement-group list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_remove-label.md
+++ b/docs/reference/manual/hcloud_placement-group_remove-label.md
@@ -16,13 +16,14 @@ hcloud placement-group remove-label <placement-group> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_placement-group_update.md
+++ b/docs/reference/manual/hcloud_placement-group_update.md
@@ -16,13 +16,14 @@ hcloud placement-group update [options] <placement-group>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip.md
+++ b/docs/reference/manual/hcloud_primary-ip.md
@@ -11,13 +11,14 @@ Manage Primary IPs
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_add-label.md
+++ b/docs/reference/manual/hcloud_primary-ip_add-label.md
@@ -16,13 +16,14 @@ hcloud primary-ip add-label [--overwrite] <primary-ip> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_assign.md
+++ b/docs/reference/manual/hcloud_primary-ip_assign.md
@@ -16,13 +16,14 @@ hcloud primary-ip assign --server <server> <primary-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_create.md
+++ b/docs/reference/manual/hcloud_primary-ip_create.md
@@ -23,13 +23,14 @@ hcloud primary-ip create [options] --type <ipv4|ipv6> --name <name>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_delete.md
+++ b/docs/reference/manual/hcloud_primary-ip_delete.md
@@ -15,13 +15,14 @@ hcloud primary-ip delete <primary-ip>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_describe.md
+++ b/docs/reference/manual/hcloud_primary-ip_describe.md
@@ -16,13 +16,14 @@ hcloud primary-ip describe [options] <primary-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_disable-protection.md
+++ b/docs/reference/manual/hcloud_primary-ip_disable-protection.md
@@ -15,13 +15,14 @@ hcloud primary-ip disable-protection <primary-ip> [delete]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_enable-protection.md
+++ b/docs/reference/manual/hcloud_primary-ip_enable-protection.md
@@ -15,13 +15,14 @@ hcloud primary-ip enable-protection <primary-ip> [delete]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_list.md
+++ b/docs/reference/manual/hcloud_primary-ip_list.md
@@ -42,13 +42,14 @@ hcloud primary-ip list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_remove-label.md
+++ b/docs/reference/manual/hcloud_primary-ip_remove-label.md
@@ -16,13 +16,14 @@ hcloud primary-ip remove-label <primary-ip> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_set-rdns.md
+++ b/docs/reference/manual/hcloud_primary-ip_set-rdns.md
@@ -18,13 +18,14 @@ hcloud primary-ip set-rdns [--ip <ip>] (--hostname <hostname> | --reset) <primar
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_unassign.md
+++ b/docs/reference/manual/hcloud_primary-ip_unassign.md
@@ -15,13 +15,14 @@ hcloud primary-ip unassign <primary-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_primary-ip_update.md
+++ b/docs/reference/manual/hcloud_primary-ip_update.md
@@ -17,13 +17,14 @@ hcloud primary-ip update [options] <primary-ip>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server-type.md
+++ b/docs/reference/manual/hcloud_server-type.md
@@ -11,13 +11,14 @@ View Server Types
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server-type_describe.md
+++ b/docs/reference/manual/hcloud_server-type_describe.md
@@ -16,13 +16,14 @@ hcloud server-type describe [options] <server-type>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server-type_list.md
+++ b/docs/reference/manual/hcloud_server-type_list.md
@@ -40,13 +40,14 @@ hcloud server-type list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server.md
+++ b/docs/reference/manual/hcloud_server.md
@@ -11,13 +11,14 @@ Manage Servers
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_add-label.md
+++ b/docs/reference/manual/hcloud_server_add-label.md
@@ -16,13 +16,14 @@ hcloud server add-label [--overwrite] <server> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_add-to-placement-group.md
+++ b/docs/reference/manual/hcloud_server_add-to-placement-group.md
@@ -16,13 +16,14 @@ hcloud server add-to-placement-group --placement-group <placement-group> <server
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_attach-iso.md
+++ b/docs/reference/manual/hcloud_server_attach-iso.md
@@ -15,13 +15,14 @@ hcloud server attach-iso <server> <iso>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_attach-to-network.md
+++ b/docs/reference/manual/hcloud_server_attach-to-network.md
@@ -18,13 +18,14 @@ hcloud server attach-to-network [options] --network <network> <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_change-alias-ips.md
+++ b/docs/reference/manual/hcloud_server_change-alias-ips.md
@@ -18,13 +18,14 @@ hcloud server change-alias-ips [options] --network <network> <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_change-type.md
+++ b/docs/reference/manual/hcloud_server_change-type.md
@@ -16,13 +16,14 @@ hcloud server change-type [--keep-disk] <server> <server-type>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_create-image.md
+++ b/docs/reference/manual/hcloud_server_create-image.md
@@ -18,13 +18,14 @@ hcloud server create-image [options] --type <snapshot|backup> <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_create.md
+++ b/docs/reference/manual/hcloud_server_create.md
@@ -37,13 +37,14 @@ hcloud server create [options] --name <name> --type <server-type> --image <image
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_delete.md
+++ b/docs/reference/manual/hcloud_server_delete.md
@@ -15,13 +15,14 @@ hcloud server delete <server>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_describe.md
+++ b/docs/reference/manual/hcloud_server_describe.md
@@ -16,13 +16,14 @@ hcloud server describe [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_detach-from-network.md
+++ b/docs/reference/manual/hcloud_server_detach-from-network.md
@@ -16,13 +16,14 @@ hcloud server detach-from-network --network <network> <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_detach-iso.md
+++ b/docs/reference/manual/hcloud_server_detach-iso.md
@@ -15,13 +15,14 @@ hcloud server detach-iso <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_disable-backup.md
+++ b/docs/reference/manual/hcloud_server_disable-backup.md
@@ -15,13 +15,14 @@ hcloud server disable-backup <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_disable-protection.md
+++ b/docs/reference/manual/hcloud_server_disable-protection.md
@@ -15,13 +15,14 @@ hcloud server disable-protection <server> (rebuild|delete)...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_disable-rescue.md
+++ b/docs/reference/manual/hcloud_server_disable-rescue.md
@@ -15,13 +15,14 @@ hcloud server disable-rescue <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_enable-backup.md
+++ b/docs/reference/manual/hcloud_server_enable-backup.md
@@ -16,13 +16,14 @@ hcloud server enable-backup <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_enable-protection.md
+++ b/docs/reference/manual/hcloud_server_enable-protection.md
@@ -15,13 +15,14 @@ hcloud server enable-protection <server> (rebuild|delete)...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_enable-rescue.md
+++ b/docs/reference/manual/hcloud_server_enable-rescue.md
@@ -17,13 +17,14 @@ hcloud server enable-rescue [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_ip.md
+++ b/docs/reference/manual/hcloud_server_ip.md
@@ -16,13 +16,14 @@ hcloud server ip [--ipv6] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_list.md
+++ b/docs/reference/manual/hcloud_server_list.md
@@ -51,13 +51,14 @@ hcloud server list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_metrics.md
+++ b/docs/reference/manual/hcloud_server_metrics.md
@@ -19,13 +19,14 @@ hcloud server metrics [options] (--type <cpu|disk|network>)... <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_poweroff.md
+++ b/docs/reference/manual/hcloud_server_poweroff.md
@@ -15,13 +15,14 @@ hcloud server poweroff <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_poweron.md
+++ b/docs/reference/manual/hcloud_server_poweron.md
@@ -15,13 +15,14 @@ hcloud server poweron <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_reboot.md
+++ b/docs/reference/manual/hcloud_server_reboot.md
@@ -15,13 +15,14 @@ hcloud server reboot <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_rebuild.md
+++ b/docs/reference/manual/hcloud_server_rebuild.md
@@ -17,13 +17,14 @@ hcloud server rebuild [--allow-deprecated-image] --image <image> <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_remove-from-placement-group.md
+++ b/docs/reference/manual/hcloud_server_remove-from-placement-group.md
@@ -15,13 +15,14 @@ hcloud server remove-from-placement-group <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_remove-label.md
+++ b/docs/reference/manual/hcloud_server_remove-label.md
@@ -16,13 +16,14 @@ hcloud server remove-label <server> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_request-console.md
+++ b/docs/reference/manual/hcloud_server_request-console.md
@@ -16,13 +16,14 @@ hcloud server request-console [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_reset-password.md
+++ b/docs/reference/manual/hcloud_server_reset-password.md
@@ -16,13 +16,14 @@ hcloud server reset-password [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_reset.md
+++ b/docs/reference/manual/hcloud_server_reset.md
@@ -15,13 +15,14 @@ hcloud server reset [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_set-rdns.md
+++ b/docs/reference/manual/hcloud_server_set-rdns.md
@@ -18,13 +18,14 @@ hcloud server set-rdns [--ip <ip>] (--hostname <hostname> | --reset) <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_shutdown.md
+++ b/docs/reference/manual/hcloud_server_shutdown.md
@@ -21,13 +21,14 @@ hcloud server shutdown [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_ssh.md
+++ b/docs/reference/manual/hcloud_server_ssh.md
@@ -18,13 +18,14 @@ hcloud server ssh [options] <server> [--] [ssh options] [command [argument...]]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_server_update.md
+++ b/docs/reference/manual/hcloud_server_update.md
@@ -16,13 +16,14 @@ hcloud server update [options] <server>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key.md
+++ b/docs/reference/manual/hcloud_ssh-key.md
@@ -11,13 +11,14 @@ Manage SSH Keys
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_add-label.md
+++ b/docs/reference/manual/hcloud_ssh-key_add-label.md
@@ -16,13 +16,14 @@ hcloud ssh-key add-label [--overwrite] <ssh-key> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_create.md
+++ b/docs/reference/manual/hcloud_ssh-key_create.md
@@ -20,13 +20,14 @@ hcloud ssh-key create [options] --name <name> (--public-key <key> | --public-key
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_delete.md
+++ b/docs/reference/manual/hcloud_ssh-key_delete.md
@@ -15,13 +15,14 @@ hcloud ssh-key delete <ssh-key>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_describe.md
+++ b/docs/reference/manual/hcloud_ssh-key_describe.md
@@ -16,13 +16,14 @@ hcloud ssh-key describe [options] <ssh-key>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_list.md
+++ b/docs/reference/manual/hcloud_ssh-key_list.md
@@ -35,13 +35,14 @@ hcloud ssh-key list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_remove-label.md
+++ b/docs/reference/manual/hcloud_ssh-key_remove-label.md
@@ -16,13 +16,14 @@ hcloud ssh-key remove-label <ssh-key> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_ssh-key_update.md
+++ b/docs/reference/manual/hcloud_ssh-key_update.md
@@ -16,13 +16,14 @@ hcloud ssh-key update [options] <ssh-key>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_version.md
+++ b/docs/reference/manual/hcloud_version.md
@@ -15,13 +15,14 @@ hcloud version
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume.md
+++ b/docs/reference/manual/hcloud_volume.md
@@ -11,13 +11,14 @@ Manage Volumes
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_add-label.md
+++ b/docs/reference/manual/hcloud_volume_add-label.md
@@ -16,13 +16,14 @@ hcloud volume add-label [--overwrite] <volume> <label>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_attach.md
+++ b/docs/reference/manual/hcloud_volume_attach.md
@@ -17,13 +17,14 @@ hcloud volume attach [--automount] --server <server> <volume>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_create.md
+++ b/docs/reference/manual/hcloud_volume_create.md
@@ -24,13 +24,14 @@ hcloud volume create [options] --name <name> --size <size>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_delete.md
+++ b/docs/reference/manual/hcloud_volume_delete.md
@@ -15,13 +15,14 @@ hcloud volume delete <volume>...
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_describe.md
+++ b/docs/reference/manual/hcloud_volume_describe.md
@@ -16,13 +16,14 @@ hcloud volume describe [options] <volume>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_detach.md
+++ b/docs/reference/manual/hcloud_volume_detach.md
@@ -15,13 +15,14 @@ hcloud volume detach <volume>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_disable-protection.md
+++ b/docs/reference/manual/hcloud_volume_disable-protection.md
@@ -15,13 +15,14 @@ hcloud volume disable-protection <volume> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_enable-protection.md
+++ b/docs/reference/manual/hcloud_volume_enable-protection.md
@@ -15,13 +15,14 @@ hcloud volume enable-protection <volume> delete
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_list.md
+++ b/docs/reference/manual/hcloud_volume_list.md
@@ -39,13 +39,14 @@ hcloud volume list [options]
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_remove-label.md
+++ b/docs/reference/manual/hcloud_volume_remove-label.md
@@ -16,13 +16,14 @@ hcloud volume remove-label <volume> (--all | <label>...)
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_resize.md
+++ b/docs/reference/manual/hcloud_volume_resize.md
@@ -16,13 +16,14 @@ hcloud volume resize --size <size> <volume>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/docs/reference/manual/hcloud_volume_update.md
+++ b/docs/reference/manual/hcloud_volume_update.md
@@ -16,13 +16,14 @@ hcloud volume update [options] <volume>
 ### Options inherited from parent commands
 
 ```
-      --config string            Config file path (default "~/.config/hcloud/cli.toml")
-      --context string           Currently active context
-      --debug                    Enable debug output
-      --debug-file string        File to write debug output to
-      --endpoint string          Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
-      --poll-interval duration   Interval at which to poll information, for example action progress (default 500ms)
-      --quiet                    If true, only print error messages
+      --config string             Config file path (default "~/.config/hcloud/cli.toml")
+      --context string            Currently active context
+      --debug                     Enable debug output
+      --debug-file string         File to write debug output to
+      --endpoint string           Hetzner Cloud API endpoint (default "https://api.hetzner.cloud/v1")
+      --hetzner-endpoint string   Hetzner API endpoint (default "https://api.hetzner.com/v1")
+      --poll-interval duration    Interval at which to poll information, for example action progress (default 500ms)
+      --quiet                     If true, only print error messages
 ```
 
 ### SEE ALSO

--- a/internal/cmd/config/helptext/preferences.txt
+++ b/internal/cmd/config/helptext/preferences.txt
@@ -1,25 +1,27 @@
-┌──────────────────┬──────────────────────┬─────────────┬──────────────────┬─────────────────────────┬─────────────────┐
-│ OPTION           │ DESCRIPTION          │ TYPE        │ CONFIG KEY       │ ENVIRONMENT VARIABLE    │ FLAG            │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ debug            │ Enable debug output  │ boolean     │ debug            │ HCLOUD_DEBUG            │ --debug         │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ debug-file       │ File to write debug  │ string      │ debug_file       │ HCLOUD_DEBUG_FILE       │ --debug-file    │
-│                  │ output to            │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ default-ssh-keys │ Default SSH Keys for │ string list │ default_ssh_keys │ HCLOUD_DEFAULT_SSH_KEYS │                 │
-│                  │ new Servers          │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ endpoint         │ Hetzner Cloud API    │ string      │ endpoint         │ HCLOUD_ENDPOINT         │ --endpoint      │
-│                  │ endpoint             │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ poll-interval    │ Interval at which to │ duration    │ poll_interval    │ HCLOUD_POLL_INTERVAL    │ --poll-interval │
-│                  │ poll information,    │             │                  │                         │                 │
-│                  │ for example action   │             │                  │                         │                 │
-│                  │ progress             │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ quiet            │ If true, only print  │ boolean     │ quiet            │ HCLOUD_QUIET            │ --quiet         │
-│                  │ error messages       │             │                  │                         │                 │
-├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼─────────────────┤
-│ sort.<resource>  │ Default sorting for  │ string list │ sort.<resource>  │ HCLOUD_SORT_<RESOURCE>  │                 │
-│                  │ resource             │             │                  │                         │                 │
-└──────────────────┴──────────────────────┴─────────────┴──────────────────┴─────────────────────────┴─────────────────┘
+┌──────────────────┬──────────────────────┬─────────────┬──────────────────┬─────────────────────────┬────────────────────┐
+│ OPTION           │ DESCRIPTION          │ TYPE        │ CONFIG KEY       │ ENVIRONMENT VARIABLE    │ FLAG               │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ debug            │ Enable debug output  │ boolean     │ debug            │ HCLOUD_DEBUG            │ --debug            │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ debug-file       │ File to write debug  │ string      │ debug_file       │ HCLOUD_DEBUG_FILE       │ --debug-file       │
+│                  │ output to            │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ default-ssh-keys │ Default SSH Keys for │ string list │ default_ssh_keys │ HCLOUD_DEFAULT_SSH_KEYS │                    │
+│                  │ new Servers          │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ endpoint         │ Hetzner Cloud API    │ string      │ endpoint         │ HCLOUD_ENDPOINT         │ --endpoint         │
+│                  │ endpoint             │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ hetzner-endpoint │ Hetzner API endpoint │ string      │ hetzner_endpoint │ HETZNER_ENDPOINT        │ --hetzner-endpoint │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ poll-interval    │ Interval at which to │ duration    │ poll_interval    │ HCLOUD_POLL_INTERVAL    │ --poll-interval    │
+│                  │ poll information,    │             │                  │                         │                    │
+│                  │ for example action   │             │                  │                         │                    │
+│                  │ progress             │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ quiet            │ If true, only print  │ boolean     │ quiet            │ HCLOUD_QUIET            │ --quiet            │
+│                  │ error messages       │             │                  │                         │                    │
+├──────────────────┼──────────────────────┼─────────────┼──────────────────┼─────────────────────────┼────────────────────┤
+│ sort.<resource>  │ Default sorting for  │ string list │ sort.<resource>  │ HCLOUD_SORT_<RESOURCE>  │                    │
+│                  │ resource             │             │                  │                         │                    │
+└──────────────────┴──────────────────────┴─────────────┴──────────────────┴─────────────────────────┴────────────────────┘

--- a/internal/state/config/config.go
+++ b/internal/state/config/config.go
@@ -90,6 +90,7 @@ func (cfg *config) reset() {
 	cfg.fs.Usage = func() {} // disable usage output
 	for _, o := range Options {
 		o.addToFlagSet(cfg.fs)
+		_ = cfg.v.BindEnv(o.GetName(), o.EnvVar())
 	}
 	if err := cfg.v.BindPFlags(cfg.fs); err != nil {
 		panic(err)
@@ -104,9 +105,6 @@ func (cfg *config) Read(f any) error {
 	if err != nil && !errors.Is(err, pflag.ErrHelp) {
 		return err
 	}
-
-	// load env already so we can determine the active context
-	cfg.v.AutomaticEnv()
 
 	cfg.path, err = OptionConfig.Get(cfg)
 	if err != nil {

--- a/internal/state/config/options.go
+++ b/internal/state/config/options.go
@@ -124,6 +124,15 @@ var (
 		nil,
 	)
 
+	OptionHetznerEndpoint = newOpt(
+		"hetzner-endpoint",
+		"Hetzner API endpoint",
+		hcloud.HetznerEndpoint,
+		DefaultPreferenceFlags,
+		nil,
+		&overrides{envVar: "HETZNER_ENDPOINT"},
+	)
+
 	OptionDebug = newOpt(
 		"debug",
 		"Enable debug output",

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -77,6 +77,12 @@ func (c *state) newClient() (hcapi2.Client, error) {
 		return nil, err
 	}
 
+	if ep, err := config.OptionHetznerEndpoint.Get(c.config); err == nil && ep != "" {
+		opts = append(opts, hcloud.WithHetznerEndpoint(ep))
+	} else if err != nil {
+		return nil, err
+	}
+
 	debug, err := config.OptionDebug.Get(c.config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds support for the Hetzner API (`https://api.hetzner.com`) with a new option to configure the API endpoint:

- Config Key: `hetzner-endpoint`
- Flag: `--hetzner-endpoint`
- Environment Variable: `HETZNER_ENDPOINT`