### PR TITLE
test(e2e): fix panic

### DIFF
--- a/test/e2e/combined_test.go
+++ b/test/e2e/combined_test.go
@@ -85,6 +85,7 @@ func TestCombined(t *testing.T) {
 			t.Run("label-selector", func(t *testing.T) {
 				t.Run("public-ip", func(t *testing.T) {
 					out, err := runCommand(t, "load-balancer", "add-target", strconv.FormatInt(loadBalancerID, 10), "--label-selector", "foo=bar")
+					require.Error(t, err)
 					assert.Regexp(t, `^load balancer public interface is disabled, cannot add target using public IP \(load_balancer_public_interface_disabled, [0-9a-f]+\)$`, err.Error())
 					assert.Empty(t, out)
 				})
@@ -99,6 +100,7 @@ func TestCombined(t *testing.T) {
 			t.Run("server", func(t *testing.T) {
 				t.Run("public-ip", func(t *testing.T) {
 					out, err := runCommand(t, "load-balancer", "add-target", strconv.FormatInt(loadBalancerID, 10), "--server", strconv.FormatInt(serverID, 10))
+					require.Error(t, err)
 					assert.Regexp(t, `^load balancer public interface is disabled, cannot add target using public IP \(load_balancer_public_interface_disabled, [0-9a-f]+\)$`, err.Error())
 					assert.Empty(t, out)
 				})
@@ -159,6 +161,7 @@ func TestCombined(t *testing.T) {
 
 		t.Run("delete-in-use", func(t *testing.T) {
 			out, err := runCommand(t, "firewall", "delete", strconv.FormatInt(firewallID, 10))
+			require.Error(t, err)
 			assert.Regexp(t, `^firewall with ID [0-9]+ is still in use \(resource_in_use, [0-9a-f]+\)$`, err.Error())
 			assert.Empty(t, out)
 		})

--- a/test/e2e/floatingip_test.go
+++ b/test/e2e/floatingip_test.go
@@ -207,6 +207,7 @@ func TestFloatingIP(t *testing.T) {
 
 		t.Run("delete-protected", func(t *testing.T) {
 			out, err := runCommand(t, "floating-ip", "delete", strconv.FormatInt(floatingIPId, 10))
+			require.Error(t, err)
 			assert.Regexp(t, `^Floating IP deletion is protected \(protected, [0-9a-f]+\)$`, err.Error())
 			assert.Empty(t, out)
 		})

--- a/test/e2e/load_balancer_test.go
+++ b/test/e2e/load_balancer_test.go
@@ -97,6 +97,7 @@ func TestLoadBalancer(t *testing.T) {
 
 		t.Run("non-existing-algorithm", func(t *testing.T) {
 			out, err := runCommand(t, "load-balancer", "change-algorithm", strconv.FormatInt(lbID, 10), "--algorithm-type", "non-existing-algorithm")
+			require.Error(t, err)
 			assert.Regexp(t, `^invalid input in field 'type' \(invalid_input, [0-9a-f]+\)$`, err.Error())
 			assert.Empty(t, out)
 		})

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -119,6 +119,7 @@ func TestNetwork(t *testing.T) {
 	t.Run("delete-protected", func(t *testing.T) {
 		out, err := runCommand(t, "network", "delete", strconv.FormatInt(networkID, 10))
 		assert.Empty(t, out)
+		require.Error(t, err)
 		assert.Regexp(t, `^network is delete protected \(protected, [0-9a-f]+\)$`, err.Error())
 	})
 
@@ -132,6 +133,7 @@ func TestNetwork(t *testing.T) {
 		t.Run("non-existing-vswitch", func(t *testing.T) {
 			out, err := runCommand(t, "network", "add-subnet", "--type", "vswitch", "--vswitch-id", "42", "--network-zone", "eu-central", "--ip-range", "10.0.17.0/24", strconv.FormatInt(networkID, 10))
 			assert.Empty(t, out)
+			require.Error(t, err)
 			assert.Regexp(t, `^vswitch not found \(service_error, [0-9a-f]+\)$`, err.Error())
 		})
 


### PR DESCRIPTION
When `err` was unexpectedly `nil` and `err.Error()` was called, the test would panic. This PR fixes this by requiring there to be an error for the test to continue.