### PR TITLE
refactor(base): make list command generic

### DIFF
--- a/internal/cmd/base/list_test.go
+++ b/internal/cmd/base/list_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
-	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/cli/internal/state/config"
@@ -18,11 +17,11 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var fakeListCmd = &base.ListCmd{
+var fakeListCmd = &base.ListCmd[*fakeResource, *fakeResource]{
 	ResourceNamePlural: "Fake resources",
 
-	Schema: func(i []interface{}) interface{} {
-		return i
+	Schema: func(resource *fakeResource) *fakeResource {
+		return resource
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -40,7 +39,7 @@ var fakeListCmd = &base.ListCmd{
 
 	DefaultColumns: []string{"id", "name"},
 
-	Fetch: func(_ state.State, _ *pflag.FlagSet, _ hcloud.ListOpts, sort []string) ([]interface{}, error) {
+	Fetch: func(_ state.State, _ *pflag.FlagSet, _ hcloud.ListOpts, sort []string) ([]*fakeResource, error) {
 		resources := []*fakeResource{
 			{
 				ID:   456,
@@ -75,7 +74,7 @@ var fakeListCmd = &base.ListCmd{
 				})
 			}
 		}
-		return util.ToAnySlice(resources), nil
+		return resources, nil
 	},
 }
 

--- a/internal/cmd/certificate/list.go
+++ b/internal/cmd/certificate/list.go
@@ -16,24 +16,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.Certificate, schema.Certificate]{
 	ResourceNamePlural: "Certificates",
 	JSONKeyGetByName:   "certificates",
 	DefaultColumns:     []string{"id", "name", "type", "domain_names", "not_valid_after", "age"},
 	SortOption:         config.OptionSortCertificate,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.Certificate, error) {
 		opts := hcloud.CertificateListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		certificates, err := s.Client().Certificate().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range certificates {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().Certificate().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -81,13 +75,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		certSchemas := make([]schema.Certificate, 0, len(resources))
-		for _, resource := range resources {
-			cert := resource.(*hcloud.Certificate)
-			certSchemas = append(certSchemas, hcloud.SchemaFromCertificate(cert))
-		}
-
-		return certSchemas
-	},
+	Schema: hcloud.SchemaFromCertificate,
 }

--- a/internal/cmd/datacenter/list.go
+++ b/internal/cmd/datacenter/list.go
@@ -12,23 +12,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.Datacenter, schema.Datacenter]{
 	ResourceNamePlural: "Datacenters",
 	JSONKeyGetByName:   "datacenters",
 	DefaultColumns:     []string{"id", "name", "description", "location"},
 	SortOption:         config.OptionSortDatacenter,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.Datacenter, error) {
 		opts := hcloud.DatacenterListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		datacenters, err := s.Client().Datacenter().AllWithOpts(s, opts)
-		var resources []interface{}
-		for _, n := range datacenters {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().Datacenter().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -40,13 +35,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		dcSchemas := make([]schema.Datacenter, 0, len(resources))
-		for _, resource := range resources {
-			dc := resource.(*hcloud.Datacenter)
-			dcSchemas = append(dcSchemas, hcloud.SchemaFromDatacenter(dc))
-		}
-
-		return dcSchemas
-	},
+	Schema: hcloud.SchemaFromDatacenter,
 }

--- a/internal/cmd/firewall/list.go
+++ b/internal/cmd/firewall/list.go
@@ -14,24 +14,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.Firewall, schema.Firewall]{
 	ResourceNamePlural: "Firewalls",
 	JSONKeyGetByName:   "firewalls",
 	DefaultColumns:     []string{"id", "name", "rules_count", "applied_to_count"},
 	SortOption:         config.OptionSortFirewall,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.Firewall, error) {
 		opts := hcloud.FirewallListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		firewalls, err := s.Client().Firewall().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range firewalls {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().Firewall().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -68,12 +62,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		firewallSchemas := make([]schema.Firewall, 0, len(resources))
-		for _, resource := range resources {
-			fw := resource.(*hcloud.Firewall)
-			firewallSchemas = append(firewallSchemas, hcloud.SchemaFromFirewall(fw))
-		}
-		return firewallSchemas
-	},
+	Schema: hcloud.SchemaFromFirewall,
 }

--- a/internal/cmd/floatingip/list.go
+++ b/internal/cmd/floatingip/list.go
@@ -17,24 +17,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.FloatingIP, schema.FloatingIP]{
 	ResourceNamePlural: "Floating IPs",
 	JSONKeyGetByName:   "floating_ips",
 	DefaultColumns:     []string{"id", "type", "name", "description", "ip", "home", "server", "dns", "age"},
 	SortOption:         config.OptionSortFloatingIP,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.FloatingIP, error) {
 		opts := hcloud.FloatingIPListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		floatingIPs, err := s.Client().FloatingIP().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range floatingIPs {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().FloatingIP().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, client hcapi2.Client) {
@@ -95,12 +89,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		floatingIPSchemas := make([]schema.FloatingIP, 0, len(resources))
-		for _, resource := range resources {
-			floatingIP := resource.(*hcloud.FloatingIP)
-			floatingIPSchemas = append(floatingIPSchemas, hcloud.SchemaFromFloatingIP(floatingIP))
-		}
-		return floatingIPSchemas
-	},
+	Schema: hcloud.SchemaFromFloatingIP,
 }

--- a/internal/cmd/loadbalancertype/list.go
+++ b/internal/cmd/loadbalancertype/list.go
@@ -11,24 +11,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = base.ListCmd[*hcloud.LoadBalancerType, schema.LoadBalancerType]{
 	ResourceNamePlural: "Load Balancer Types",
 	JSONKeyGetByName:   "load_balancer_types",
 	DefaultColumns:     []string{"id", "name", "description", "max_services", "max_connections", "max_targets"},
 	SortOption:         nil, // Load Balancer Types do not support sorting
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.LoadBalancerType, error) {
 		opts := hcloud.LoadBalancerTypeListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		loadBalancerTypes, err := s.Client().LoadBalancerType().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, r := range loadBalancerTypes {
-			resources = append(resources, r)
-		}
-		return resources, err
+		return s.Client().LoadBalancerType().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -36,12 +30,5 @@ var ListCmd = base.ListCmd{
 			AddAllowedFields(hcloud.LoadBalancerType{})
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		loadBalancerTypeSchemas := make([]schema.LoadBalancerType, 0, len(resources))
-		for _, resource := range resources {
-			loadBalancerType := resource.(*hcloud.LoadBalancerType)
-			loadBalancerTypeSchemas = append(loadBalancerTypeSchemas, hcloud.SchemaFromLoadBalancerType(loadBalancerType))
-		}
-		return loadBalancerTypeSchemas
-	},
+	Schema: hcloud.SchemaFromLoadBalancerType,
 }

--- a/internal/cmd/location/list.go
+++ b/internal/cmd/location/list.go
@@ -12,24 +12,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = base.ListCmd[*hcloud.Location, schema.Location]{
 	ResourceNamePlural: "Locations",
 	JSONKeyGetByName:   "locations",
 	DefaultColumns:     []string{"id", "name", "description", "network_zone", "country", "city"},
 	SortOption:         config.OptionSortLocation,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.Location, error) {
 		opts := hcloud.LocationListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		locations, err := s.Client().Location().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range locations {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().Location().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -37,12 +31,5 @@ var ListCmd = base.ListCmd{
 			AddAllowedFields(hcloud.Location{})
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		locationSchemas := make([]schema.Location, 0, len(resources))
-		for _, resource := range resources {
-			location := resource.(*hcloud.Location)
-			locationSchemas = append(locationSchemas, hcloud.SchemaFromLocation(location))
-		}
-		return locationSchemas
-	},
+	Schema: hcloud.SchemaFromLocation,
 }

--- a/internal/cmd/placementgroup/list.go
+++ b/internal/cmd/placementgroup/list.go
@@ -16,24 +16,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.PlacementGroup, schema.PlacementGroup]{
 	ResourceNamePlural: "Placement Groups",
 	JSONKeyGetByName:   "placement_groups",
 	DefaultColumns:     []string{"id", "name", "servers", "type", "age"},
 	SortOption:         config.OptionSortPlacementGroup,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.PlacementGroup, error) {
 		opts := hcloud.PlacementGroupListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		placementGroups, err := s.Client().PlacementGroup().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range placementGroups {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().PlacementGroup().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -57,12 +51,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		placementGroupSchemas := make([]schema.PlacementGroup, 0, len(resources))
-		for _, resource := range resources {
-			placementGroup := resource.(*hcloud.PlacementGroup)
-			placementGroupSchemas = append(placementGroupSchemas, hcloud.SchemaFromPlacementGroup(placementGroup))
-		}
-		return placementGroupSchemas
-	},
+	Schema: hcloud.SchemaFromPlacementGroup,
 }

--- a/internal/cmd/primaryip/list.go
+++ b/internal/cmd/primaryip/list.go
@@ -17,24 +17,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.PrimaryIP, schema.PrimaryIP]{
 	ResourceNamePlural: "Primary IPs",
 	JSONKeyGetByName:   "primary_ips",
 	DefaultColumns:     []string{"id", "type", "name", "ip", "assignee", "dns", "auto_delete", "age"},
 	SortOption:         config.OptionSortPrimaryIP,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.PrimaryIP, error) {
 		opts := hcloud.PrimaryIPListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		primaryips, err := s.Client().PrimaryIP().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range primaryips {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().PrimaryIP().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, client hcapi2.Client) {
@@ -98,12 +92,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		primaryIPsSchema := make([]schema.PrimaryIP, 0, len(resources))
-		for _, resource := range resources {
-			primaryIP := resource.(*hcloud.PrimaryIP)
-			primaryIPsSchema = append(primaryIPsSchema, hcloud.SchemaFromPrimaryIP(primaryIP))
-		}
-		return primaryIPsSchema
-	},
+	Schema: hcloud.SchemaFromPrimaryIP,
 }

--- a/internal/cmd/servertype/list.go
+++ b/internal/cmd/servertype/list.go
@@ -14,24 +14,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.ServerType, schema.ServerType]{
 	ResourceNamePlural: "Server Types",
 	JSONKeyGetByName:   "server_types",
 	DefaultColumns:     []string{"id", "name", "cores", "cpu_type", "architecture", "memory", "disk", "storage_type"},
 	SortOption:         nil, // Server Types do not support sorting
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.ServerType, error) {
 		opts := hcloud.ServerTypeListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		servers, err := s.Client().ServerType().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, r := range servers {
-			resources = append(resources, r)
-		}
-		return resources, err
+		return s.Client().ServerType().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -60,12 +54,5 @@ var ListCmd = base.ListCmd{
 			})
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		serverTypeSchemas := make([]schema.ServerType, 0, len(resources))
-		for _, resource := range resources {
-			serverType := resource.(*hcloud.ServerType)
-			serverTypeSchemas = append(serverTypeSchemas, hcloud.SchemaFromServerType(serverType))
-		}
-		return serverTypeSchemas
-	},
+	Schema: hcloud.SchemaFromServerType,
 }

--- a/internal/cmd/sshkey/list.go
+++ b/internal/cmd/sshkey/list.go
@@ -15,24 +15,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.SSHKey, schema.SSHKey]{
 	ResourceNamePlural: "SSH Keys",
 	JSONKeyGetByName:   "ssh_keys",
 	DefaultColumns:     []string{"id", "name", "fingerprint", "age"},
 	SortOption:         config.OptionSortSSHKey,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.SSHKey, error) {
 		opts := hcloud.SSHKeyListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		sshKeys, err := s.Client().SSHKey().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range sshKeys {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().SSHKey().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, _ hcapi2.Client) {
@@ -52,12 +46,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		sshKeySchemas := make([]schema.SSHKey, 0, len(resources))
-		for _, resource := range resources {
-			sshKey := resource.(*hcloud.SSHKey)
-			sshKeySchemas = append(sshKeySchemas, hcloud.SchemaFromSSHKey(sshKey))
-		}
-		return sshKeySchemas
-	},
+	Schema: hcloud.SchemaFromSSHKey,
 }

--- a/internal/cmd/volume/list.go
+++ b/internal/cmd/volume/list.go
@@ -17,24 +17,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
-var ListCmd = base.ListCmd{
+var ListCmd = &base.ListCmd[*hcloud.Volume, schema.Volume]{
 	ResourceNamePlural: "Volumes",
 	JSONKeyGetByName:   "volumes",
 	DefaultColumns:     []string{"id", "name", "size", "server", "location", "age"},
 	SortOption:         config.OptionSortVolume,
 
-	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]interface{}, error) {
+	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.Volume, error) {
 		opts := hcloud.VolumeListOpts{ListOpts: listOpts}
 		if len(sorts) > 0 {
 			opts.Sort = sorts
 		}
-		volumes, err := s.Client().Volume().AllWithOpts(s, opts)
-
-		var resources []interface{}
-		for _, n := range volumes {
-			resources = append(resources, n)
-		}
-		return resources, err
+		return s.Client().Volume().AllWithOpts(s, opts)
 	},
 
 	OutputTable: func(t *output.Table, client hcapi2.Client) {
@@ -78,12 +72,5 @@ var ListCmd = base.ListCmd{
 			}))
 	},
 
-	Schema: func(resources []interface{}) interface{} {
-		volumesSchema := make([]schema.Volume, 0, len(resources))
-		for _, resource := range resources {
-			volume := resource.(*hcloud.Volume)
-			volumesSchema = append(volumesSchema, hcloud.SchemaFromVolume(volume))
-		}
-		return volumesSchema
-	},
+	Schema: hcloud.SchemaFromVolume,
 }


### PR DESCRIPTION
Making list commands generic allows to remove a lot of code duplication and makes it easier to use the base command.