### PR TITLE
test: failure when certificate age is 'just now'

### DIFF
--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -108,7 +108,7 @@ func runCertificateTestSuite(t *testing.T, certName string, certID int64, certTy
 				SeparatedByWhitespace(
 					"ID", "NAME", "LABELS", "TYPE", "CREATED", "NOT VALID BEFORE", "NOT VALID AFTER",
 					"DOMAIN NAMES", "FINGERPRINT", "ISSUANCE STATUS", "RENEWAL STATUS", "AGE",
-				).Newline().
+				).OptionalWhitespace().Newline().
 				Lit(strconv.FormatInt(certID, 10)).Whitespace().
 				Lit(certName).Whitespace().
 				Lit(strings.Join(labels, ", ")).Whitespace().


### PR DESCRIPTION
The regex was missing some whitespace which was required when the age column shows 'just now'. Not sure why this never happend before.