### PR TITLE
fix: segmentation fault possible when creating servers or load balancers

### DIFF
--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -103,6 +103,9 @@ var CreateCmd = base.CreateCmd{
 		if err != nil {
 			return nil, nil, err
 		}
+		if loadBalancer == nil {
+			return nil, nil, fmt.Errorf("Load Balancer not found: %d", result.LoadBalancer.ID)
+		}
 		cmd.Printf("Load Balancer %d created\n", loadBalancer.ID)
 
 		if err := changeProtection(s, cmd, loadBalancer, true, protectionOpts); err != nil {

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -118,6 +118,9 @@ var CreateCmd = base.CreateCmd{
 		if err != nil {
 			return nil, nil, err
 		}
+		if server == nil {
+			return nil, nil, fmt.Errorf("server not found: %d", result.Server.ID)
+		}
 
 		cmd.Printf("Server %d created\n", result.Server.ID)
 


### PR DESCRIPTION
There was a nil check missing leading to a segmentation fault being possible in rare cases. Fixes #1134