### PR TITLE
refactor: move experimental warning to constant for use in testing

### DIFF
--- a/internal/cmd/base/experimental.go
+++ b/internal/cmd/base/experimental.go
@@ -11,8 +11,10 @@ import (
 	"github.com/hetznercloud/cli/internal/state/config"
 )
 
+const ExperimentalStderrWarning = "Warning: This command is experimental and may change in the future. Use --no-experimental-warnings to suppress this warning.\n"
+
 // ExperimentalWrapper create a command wrapper that appends a notice to the command
-// descriptions and logs a warning when the it is used.
+// descriptions and logs a warning when it is used.
 //
 // Usage:
 //
@@ -53,7 +55,7 @@ See %s for more details.
 				return err
 			}
 			if !hideWarning {
-				cmd.PrintErrln("Warning: This command is experimental and may change in the future. Use --no-experimental-warnings to suppress this warning.")
+				cmd.PrintErr(ExperimentalStderrWarning)
 			}
 			return nil
 		})


### PR DESCRIPTION
This way one can `assert.Equal(t, base.ExperimentalStderrWarning, stderr)` in test code.