### PR TITLE
refactor(base): allow positional argument override in update

### DIFF
--- a/internal/cmd/base/update.go
+++ b/internal/cmd/base/update.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -20,8 +21,25 @@ type UpdateCmd struct {
 	ShortDescription     string
 	NameSuggestions      func(client hcapi2.Client) func() []string
 	DefineFlags          func(*cobra.Command)
-	Fetch                func(s state.State, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error)
-	Update               func(s state.State, cmd *cobra.Command, resource interface{}, flags map[string]pflag.Value) error
+
+	Fetch func(s state.State, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error)
+	// Can be set in case the resource has more than a single identifier that is used in the positional arguments.
+	// See [UpdateCmd.PositionalArgumentOverride].
+	FetchWithArgs func(s state.State, cmd *cobra.Command, args []string) (any, *hcloud.Response, error)
+
+	Update func(s state.State, cmd *cobra.Command, resource interface{}, flags map[string]pflag.Value) error
+
+	// In case the resource does not have a single identifier that matches [UpdateCmd.ResourceNameSingular], this field
+	// can be set to define the list of positional arguments.
+	// For example, passing:
+	//     []string{"a", "b", "c"}
+	// Would result in the usage string:
+	//     <a> <b> <c>
+	PositionalArgumentOverride []string
+
+	// Can be set if the default [UpdateCmd.NameSuggestions] is not enough. This is usually the case when
+	// [UpdateCmd.FetchWithArgs] and [UpdateCmd.PositionalArgumentOverride] is being used.
+	ValidArgsFunction func(client hcapi2.Client) []cobra.CompletionFunc
 
 	// Experimental is a function that will be used to mark the command as experimental.
 	Experimental func(state.State, *cobra.Command) *cobra.Command
@@ -29,11 +47,23 @@ type UpdateCmd struct {
 
 // CobraCommand creates a command that can be registered with cobra.
 func (uc *UpdateCmd) CobraCommand(s state.State) *cobra.Command {
+	var suggestArgs []cobra.CompletionFunc
+	switch {
+	case uc.NameSuggestions != nil:
+		suggestArgs = append(suggestArgs,
+			cmpl.SuggestCandidatesF(uc.NameSuggestions(s.Client())),
+		)
+	case uc.ValidArgsFunction != nil:
+		suggestArgs = append(suggestArgs, uc.ValidArgsFunction(s.Client())...)
+	default:
+		log.Fatalf("update command %s is missing ValidArgsFunction or NameSuggestions", uc.ResourceNameSingular)
+	}
+
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("update [options] <%s>", util.ToKebabCase(uc.ResourceNameSingular)),
+		Use:                   fmt.Sprintf("update [options] %s", positionalArguments(uc.ResourceNameSingular, uc.PositionalArgumentOverride)),
 		Short:                 uc.ShortDescription,
 		Args:                  util.Validate,
-		ValidArgsFunction:     cmpl.SuggestArgs(cmpl.SuggestCandidatesF(uc.NameSuggestions(s.Client()))),
+		ValidArgsFunction:     cmpl.SuggestArgs(suggestArgs...),
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
 		PreRunE:               util.ChainRunE(s.EnsureToken),
@@ -50,11 +80,20 @@ func (uc *UpdateCmd) CobraCommand(s state.State) *cobra.Command {
 
 // Run executes a update command.
 func (uc *UpdateCmd) Run(s state.State, cmd *cobra.Command, args []string) error {
-	idOrName := args[0]
-	resource, _, err := uc.Fetch(s, cmd, idOrName)
+	var (
+		resource any
+		err      error
+	)
+	if uc.FetchWithArgs != nil {
+		resource, _, err = uc.FetchWithArgs(s, cmd, args)
+	} else {
+		resource, _, err = uc.Fetch(s, cmd, args[0])
+	}
 	if err != nil {
 		return err
 	}
+
+	idOrName := args[len(args)-1]
 
 	// resource is an interface that always has a type, so the interface is never nil
 	// (i.e. == nil) is always false.


### PR DESCRIPTION
This refactor allows positional argument overrides in update commands. This allows us to update subresources (e.g. Storage Box Snapshots).