### PR TITLE
feat: per location server types

### DIFF
--- a/internal/cmd/server/change_type.go
+++ b/internal/cmd/server/change_type.go
@@ -47,9 +47,7 @@ var ChangeTypeCmd = base.Cmd{
 			return fmt.Errorf("Server Type not found: %s", serverTypeIDOrName)
 		}
 
-		if serverType.IsDeprecated() {
-			cmd.Print(warningDeprecatedServerType(serverType))
-		}
+		cmd.Print(deprecatedServerTypeWarning(serverType, server.Datacenter.Location.Name))
 
 		keepDisk, _ := cmd.Flags().GetBool("keep-disk")
 		opts := hcloud.ServerChangeTypeOpts{

--- a/internal/cmd/server/change_type_test.go
+++ b/internal/cmd/server/change_type_test.go
@@ -19,8 +19,8 @@ func TestChangeType(t *testing.T) {
 	cmd := server.ChangeTypeCmd.CobraCommand(fx.State())
 	fx.ExpectEnsureToken()
 
-	srv := &hcloud.Server{ID: 123, Name: "my-server"}
-	st := &hcloud.ServerType{ID: 456, Name: "cax21"}
+	srv := &hcloud.Server{ID: 123, Name: "my-server", Datacenter: &hcloud.Datacenter{Location: &hcloud.Location{Name: "fsn1"}}}
+	st := &hcloud.ServerType{ID: 456, Name: "cax21", Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}
 
 	fx.Client.ServerClient.EXPECT().
 		Get(gomock.Any(), "my-server").
@@ -53,8 +53,8 @@ func TestChangeTypeKeepDisk(t *testing.T) {
 	cmd := server.ChangeTypeCmd.CobraCommand(fx.State())
 	fx.ExpectEnsureToken()
 
-	srv := &hcloud.Server{ID: 123, Name: "my-server"}
-	st := &hcloud.ServerType{ID: 456, Name: "cax21"}
+	srv := &hcloud.Server{ID: 123, Name: "my-server", Datacenter: &hcloud.Datacenter{Location: &hcloud.Location{Name: "fsn1"}}}
+	st := &hcloud.ServerType{ID: 456, Name: "cax21", Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}
 
 	fx.Client.ServerClient.EXPECT().
 		Get(gomock.Any(), "my-server").

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -30,7 +30,7 @@ func TestCreate(t *testing.T) {
 
 	fx.Client.ServerTypeClient.EXPECT().
 		Get(gomock.Any(), "cx22").
-		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86}, nil, nil)
+		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86, Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
 		Return(&hcloud.Image{}, nil, nil)
@@ -193,7 +193,7 @@ func TestCreateJSON(t *testing.T) {
 
 	fx.Client.ServerTypeClient.EXPECT().
 		Get(gomock.Any(), "cx22").
-		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86}, nil, nil)
+		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86, Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
 		Return(&hcloud.Image{}, nil, nil)
@@ -236,7 +236,7 @@ func TestCreateProtectionBackup(t *testing.T) {
 
 	fx.Client.ServerTypeClient.EXPECT().
 		Get(gomock.Any(), "cx22").
-		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86}, nil, nil)
+		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86, Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}, nil, nil)
 	fx.Client.ImageClient.EXPECT().
 		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
 		Return(&hcloud.Image{}, nil, nil)

--- a/internal/cmd/server/describe_test.go
+++ b/internal/cmd/server/describe_test.go
@@ -25,6 +25,11 @@ func TestDescribe(t *testing.T) {
 	cmd := server.DescribeCmd.CobraCommand(fx.State())
 	fx.ExpectEnsureToken()
 
+	serverTypeDeprecation := hcloud.DeprecatableResource{Deprecation: &hcloud.DeprecationInfo{
+		Announced:        time.Date(2036, 1, 1, 0, 0, 0, 0, time.UTC),
+		UnavailableAfter: time.Date(2036, 4, 1, 0, 0, 0, 0, time.UTC),
+	}}
+
 	srv := &hcloud.Server{
 		ID:   123,
 		Name: "test",
@@ -37,6 +42,15 @@ func TestDescribe(t *testing.T) {
 			Memory:      4.0,
 			Disk:        40,
 			StorageType: hcloud.StorageTypeLocal,
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location: &hcloud.Location{Name: "fsn1"},
+				},
+				{
+					Location:             &hcloud.Location{Name: "hel1"},
+					DeprecatableResource: serverTypeDeprecation,
+				},
+			},
 		},
 		Image: &hcloud.Image{
 			ID:           123,
@@ -91,6 +105,9 @@ Server Type:	cax11 (ID: 45)
   Memory:	4 GB
   Disk:		0 GB
   Storage Type:	local
+  Deprecation:
+    Announced:		%s (%s)
+    Unavailable After:	%s (%s)
 Public Net:
   IPv4:
     No Primary IPv4
@@ -142,7 +159,10 @@ Placement Group:
   No Placement Group set
 `,
 		util.Datetime(srv.Created), humanize.Time(srv.Created),
-		util.Datetime(srv.Image.Created), humanize.Time(srv.Image.Created))
+		util.Datetime(serverTypeDeprecation.DeprecationAnnounced()), humanize.Time(serverTypeDeprecation.DeprecationAnnounced()),
+		util.Datetime(serverTypeDeprecation.UnavailableAfter()), humanize.Time(serverTypeDeprecation.UnavailableAfter()),
+		util.Datetime(srv.Image.Created), humanize.Time(srv.Image.Created),
+	)
 
 	require.NoError(t, err)
 	assert.Empty(t, errOut)

--- a/internal/cmd/server/texts.go
+++ b/internal/cmd/server/texts.go
@@ -2,19 +2,21 @@ package server
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/deprecationutil"
 )
 
-func warningDeprecatedServerType(serverType *hcloud.ServerType) string {
-	if !serverType.IsDeprecated() {
+const ChangeDeprecatedServerTypeMessage = (`Existing servers of that plan will ` +
+	`continue to work as before and no action is required on your part. ` +
+	`It is possible to migrate this Server to another Server Type by using ` +
+	`the "hcloud server change-type" command.`)
+
+func deprecatedServerTypeWarning(serverType *hcloud.ServerType, locationName string) string {
+	warnText, _ := deprecationutil.ServerTypeWarning(serverType, locationName)
+	if warnText == "" {
 		return ""
 	}
 
-	if time.Now().After(serverType.UnavailableAfter()) {
-		return fmt.Sprintf("Attention: The Server Type %q is deprecated and can no longer be ordered. Existing servers of that plan will continue to work as before and no action is required on your part. It is possible to migrate this Server to another Server Type by using the \"hcloud server change-type\" command.\n\n", serverType.Name)
-	}
-
-	return fmt.Sprintf("Attention: The Server Type %q is deprecated and will no longer be available for order as of %s. Existing servers of that plan will continue to work as before and no action is required on your part. It is possible to migrate this Server to another Server Type by using the \"hcloud server change-type\" command.\n\n", serverType.Name, serverType.UnavailableAfter().Format(time.DateOnly))
+	return fmt.Sprintf("Attention: %s %s\n\n", warnText, ChangeDeprecatedServerTypeMessage)
 }

--- a/internal/cmd/servertype/list_test.go
+++ b/internal/cmd/servertype/list_test.go
@@ -75,10 +75,20 @@ func TestListColumnDeprecated(t *testing.T) {
 			{
 				ID:   123,
 				Name: "deprecated",
-				DeprecatableResource: hcloud.DeprecatableResource{
-					Deprecation: &hcloud.DeprecationInfo{
-						Announced:        time.Date(2036, 8, 20, 12, 0, 0, 0, time.UTC),
-						UnavailableAfter: time.Date(2037, 8, 20, 12, 0, 0, 0, time.UTC),
+				Locations: []hcloud.ServerTypeLocation{
+					{
+						Location: &hcloud.Location{Name: "fsn1"},
+						DeprecatableResource: hcloud.DeprecatableResource{Deprecation: &hcloud.DeprecationInfo{
+							Announced:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+							UnavailableAfter: time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+						}},
+					},
+					{
+						Location: &hcloud.Location{Name: "nbg1"},
+						DeprecatableResource: hcloud.DeprecatableResource{Deprecation: &hcloud.DeprecationInfo{
+							Announced:        time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+							UnavailableAfter: time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC),
+						}},
 					},
 				},
 			},
@@ -90,9 +100,9 @@ func TestListColumnDeprecated(t *testing.T) {
 
 	out, errOut, err := fx.Run(cmd, []string{"-o=columns=id,name,deprecated"})
 
-	expOut := `ID    NAME         DEPRECATED                  
-123   deprecated   Thu Aug 20 12:00:00 UTC 2037
-124   current      -                           
+	expOut := `ID    NAME         DEPRECATED                     
+123   deprecated   fsn1=2025-04-01,nbg1=2025-05-01
+124   current      -                              
 `
 
 	require.NoError(t, err)


### PR DESCRIPTION
[Server Types](https://docs.hetzner.cloud/reference/cloud#server-types) now depend on [Locations](https://docs.hetzner.cloud/reference/cloud#locations).

- We added a new `locations` property to the [Server Types](https://docs.hetzner.cloud/reference/cloud#server-types) resource. The new property defines a list of supported [Locations](https://docs.hetzner.cloud/reference/cloud#locations) and additional per [Locations](https://docs.hetzner.cloud/reference/cloud#locations) details such as deprecations information.

- We deprecated the `deprecation` property from the [Server Types](https://docs.hetzner.cloud/reference/cloud#server-types) resource. The property will gradually be phased out as per [Locations](https://docs.hetzner.cloud/reference/cloud#locations) deprecations are being announced. Please use the new per [Locations](https://docs.hetzner.cloud/reference/cloud#locations) deprecation information instead.

See our [changelog](https://docs.hetzner.cloud/changelog#2025-09-24-per-location-server-types) for more details.