### PR TITLE
fix: list commands print `null` instead of `[]` in JSON mode

### DIFF
--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -146,7 +146,7 @@ func (lc *ListCmd[T, S]) Run(s state.State, cmd *cobra.Command, args []string) e
 
 	isSchema := outOpts.IsSet("json") || outOpts.IsSet("yaml")
 	if isSchema {
-		var schema []any
+		schema := make([]S, 0, len(resources))
 		for _, resource := range resources {
 			schema = append(schema, lc.Schema(resource))
 		}


### PR DESCRIPTION
The slice containing the JSON schemas was not initialized, leading to it being serialized to `null` when empty.

Fixes #1173