### PR TITLE
fix: outdated JSON output after creating resources

### DIFF
--- a/internal/cmd/floatingip/create.go
+++ b/internal/cmd/floatingip/create.go
@@ -105,7 +105,15 @@ var CreateCmd = base.CreateCmd[*hcloud.FloatingIP]{
 			return nil, nil, err
 		}
 
-		return result.FloatingIP, util.Wrap("floating_ip", hcloud.SchemaFromFloatingIP(result.FloatingIP)), nil
+		floatingIP, _, err := s.Client().FloatingIP().GetByID(s, result.FloatingIP.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if floatingIP == nil {
+			return nil, nil, fmt.Errorf("Floating IP not found: %d", result.FloatingIP.ID)
+		}
+
+		return floatingIP, util.Wrap("floating_ip", hcloud.SchemaFromFloatingIP(floatingIP)), nil
 	},
 
 	PrintResource: func(_ state.State, cmd *cobra.Command, floatingIP *hcloud.FloatingIP) {

--- a/internal/cmd/loadbalancer/create.go
+++ b/internal/cmd/loadbalancer/create.go
@@ -99,17 +99,18 @@ var CreateCmd = base.CreateCmd[*hcloud.LoadBalancer]{
 		if err := s.WaitForActions(s, cmd, result.Action); err != nil {
 			return nil, nil, err
 		}
+		cmd.Printf("Load Balancer %d created\n", result.LoadBalancer.ID)
+
+		if err := changeProtection(s, cmd, result.LoadBalancer, true, protectionOpts); err != nil {
+			return nil, nil, err
+		}
+
 		loadBalancer, _, err := s.Client().LoadBalancer().GetByID(s, result.LoadBalancer.ID)
 		if err != nil {
 			return nil, nil, err
 		}
 		if loadBalancer == nil {
 			return nil, nil, fmt.Errorf("Load Balancer not found: %d", result.LoadBalancer.ID)
-		}
-		cmd.Printf("Load Balancer %d created\n", loadBalancer.ID)
-
-		if err := changeProtection(s, cmd, loadBalancer, true, protectionOpts); err != nil {
-			return nil, nil, err
 		}
 
 		return loadBalancer, util.Wrap("load_balancer", hcloud.SchemaFromLoadBalancer(loadBalancer)), nil

--- a/internal/cmd/loadbalancer/create_test.go
+++ b/internal/cmd/loadbalancer/create_test.go
@@ -140,7 +140,7 @@ func TestCreateProtection(t *testing.T) {
 			Labels:           make(map[string]string),
 		}).
 		Return(hcloud.LoadBalancerCreateResult{
-			LoadBalancer: &hcloud.LoadBalancer{ID: 123},
+			LoadBalancer: loadBalancer,
 			Action:       &hcloud.Action{ID: 321},
 		}, nil, nil)
 	fx.ActionWaiter.EXPECT().WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 321}).Return(nil)

--- a/internal/cmd/network/create.go
+++ b/internal/cmd/network/create.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/spf13/cobra"
@@ -62,6 +63,14 @@ var CreateCmd = base.CreateCmd[*hcloud.Network]{
 
 		if err := changeProtection(s, cmd, network, true, protectionOpts); err != nil {
 			return nil, nil, err
+		}
+
+		network, _, err = s.Client().Network().GetByID(s, network.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if network == nil {
+			return nil, nil, fmt.Errorf("Network not found: %d", network.ID)
 		}
 
 		return network, util.Wrap("network", hcloud.SchemaFromNetwork(network)), nil

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -1,6 +1,8 @@
 package primaryip
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
@@ -87,7 +89,15 @@ var CreateCmd = base.CreateCmd[*hcloud.PrimaryIP]{
 			}
 		}
 
-		return result.PrimaryIP, util.Wrap("primary_ip", hcloud.SchemaFromPrimaryIP(result.PrimaryIP)), nil
+		primaryIP, _, err := s.Client().PrimaryIP().GetByID(s, result.PrimaryIP.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if primaryIP == nil {
+			return nil, nil, fmt.Errorf("Primary IP not found: %d", result.PrimaryIP.ID)
+		}
+
+		return primaryIP, util.Wrap("primary_ip", hcloud.SchemaFromPrimaryIP(primaryIP)), nil
 	},
 	PrintResource: func(_ state.State, cmd *cobra.Command, primaryIP *hcloud.PrimaryIP) {
 		cmd.Printf("IP%s: %s\n", primaryIP.Type[2:], primaryIP.IP)

--- a/internal/cmd/server/create.go
+++ b/internal/cmd/server/create.go
@@ -124,23 +124,15 @@ var CreateCmd = base.CreateCmd[*createResult]{
 			return nil, nil, err
 		}
 
-		server, _, err := s.Client().Server().GetByID(s, result.Server.ID)
-		if err != nil {
-			return nil, nil, err
-		}
-		if server == nil {
-			return nil, nil, fmt.Errorf("server not found: %d", result.Server.ID)
-		}
-
 		cmd.Printf("Server %d created\n", result.Server.ID)
 
-		if err := changeProtection(s, cmd, server, true, protectionOpts); err != nil {
+		if err := changeProtection(s, cmd, result.Server, true, protectionOpts); err != nil {
 			return nil, nil, err
 		}
 
 		enableBackup, _ := cmd.Flags().GetBool("enable-backup")
 		if enableBackup {
-			action, _, err := s.Client().Server().EnableBackup(s, server, "")
+			action, _, err := s.Client().Server().EnableBackup(s, result.Server, "")
 			if err != nil {
 				return nil, nil, err
 			}
@@ -149,7 +141,15 @@ var CreateCmd = base.CreateCmd[*createResult]{
 				return nil, nil, err
 			}
 
-			cmd.Printf("Backups enabled for Server %d\n", server.ID)
+			cmd.Printf("Backups enabled for Server %d\n", result.Server.ID)
+		}
+
+		server, _, err := s.Client().Server().GetByID(s, result.Server.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if server == nil {
+			return nil, nil, fmt.Errorf("Server not found: %d", result.Server.ID)
 		}
 
 		return &createResult{Server: server, RootPassword: result.RootPassword},

--- a/internal/cmd/server/create_test.go
+++ b/internal/cmd/server/create_test.go
@@ -234,30 +234,6 @@ func TestCreateProtectionBackup(t *testing.T) {
 
 	fx.ExpectEnsureToken()
 
-	fx.Client.ServerTypeClient.EXPECT().
-		Get(gomock.Any(), "cx22").
-		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86, Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}, nil, nil)
-	fx.Client.ImageClient.EXPECT().
-		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
-		Return(&hcloud.Image{}, nil, nil)
-	fx.Client.ServerClient.EXPECT().
-		Create(gomock.Any(), gomock.Any()).
-		Do(func(_ context.Context, opts hcloud.ServerCreateOpts) {
-			assert.Equal(t, "cli-test", opts.Name)
-		}).
-		Return(hcloud.ServerCreateResult{
-			Server: &hcloud.Server{
-				ID: 1234,
-				PublicNet: hcloud.ServerPublicNet{
-					IPv4: hcloud.ServerPublicNetIPv4{
-						IP: net.ParseIP("192.0.2.1"),
-					},
-				},
-			},
-			Action:      &hcloud.Action{ID: 123},
-			NextActions: []*hcloud.Action{{ID: 234}},
-		}, nil, nil)
-
 	srv := &hcloud.Server{
 		ID: 1234,
 		PublicNet: hcloud.ServerPublicNet{
@@ -270,6 +246,23 @@ func TestCreateProtectionBackup(t *testing.T) {
 			Rebuild: true,
 		},
 	}
+
+	fx.Client.ServerTypeClient.EXPECT().
+		Get(gomock.Any(), "cx22").
+		Return(&hcloud.ServerType{Architecture: hcloud.ArchitectureX86, Locations: []hcloud.ServerTypeLocation{{Location: &hcloud.Location{Name: "fsn1"}}}}, nil, nil)
+	fx.Client.ImageClient.EXPECT().
+		GetForArchitecture(gomock.Any(), "ubuntu-20.04", hcloud.ArchitectureX86).
+		Return(&hcloud.Image{}, nil, nil)
+	fx.Client.ServerClient.EXPECT().
+		Create(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, opts hcloud.ServerCreateOpts) {
+			assert.Equal(t, "cli-test", opts.Name)
+		}).
+		Return(hcloud.ServerCreateResult{
+			Server:      srv,
+			Action:      &hcloud.Action{ID: 123},
+			NextActions: []*hcloud.Action{{ID: 234}},
+		}, nil, nil)
 
 	fx.Client.ServerClient.EXPECT().
 		GetByID(gomock.Any(), int64(1234)).

--- a/internal/cmd/volume/create.go
+++ b/internal/cmd/volume/create.go
@@ -107,6 +107,14 @@ var CreateCmd = base.CreateCmd[*hcloud.Volume]{
 			return nil, nil, err
 		}
 
-		return result.Volume, util.Wrap("volume", hcloud.SchemaFromVolume(result.Volume)), nil
+		volume, _, err := s.Client().Volume().GetByID(s, result.Volume.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if volume == nil {
+			return nil, nil, fmt.Errorf("Volume not found: %d", result.Volume.ID)
+		}
+
+		return volume, util.Wrap("volume", hcloud.SchemaFromVolume(volume)), nil
 	},
 }


### PR DESCRIPTION
Sometimes the JSON output after creating a resource was outdated, because the resource needed to be fetched again. This could happen for example after protection was enabled or the state of a resource changed after waiting for the create action.

Fixes #1167
