### PR TITLE
fix: formatting of server-type describe output

### DIFF
--- a/internal/cmd/servertype/describe.go
+++ b/internal/cmd/servertype/describe.go
@@ -43,16 +43,16 @@ var DescribeCmd = base.DescribeCmd[*hcloud.ServerType]{
 		cmd.Printf("Locations:\n")
 		for _, info := range locations {
 
-			cmd.Printf("  - Location:\t\t%s\n", info.Location.Name)
+			cmd.Printf("  - Location:\t\t\t%s\n", info.Location.Name)
 
 			if deprecationText := util.DescribeDeprecation(info); deprecationText != "" {
 				cmd.Print(util.PrefixLines(deprecationText, "    "))
 			}
 
 			cmd.Printf("    Pricing:\n")
-			cmd.Printf("      Hourly:\t\t%s\n", util.GrossPrice(info.Pricing.Hourly))
-			cmd.Printf("      Monthly:\t\t%s\n", util.GrossPrice(info.Pricing.Monthly))
-			cmd.Printf("      Included Traffic:\t%s\n", humanize.IBytes(info.Pricing.IncludedTraffic))
+			cmd.Printf("      Hourly:\t\t\t%s\n", util.GrossPrice(info.Pricing.Hourly))
+			cmd.Printf("      Monthly:\t\t\t%s\n", util.GrossPrice(info.Pricing.Monthly))
+			cmd.Printf("      Included Traffic:\t\t%s\n", humanize.IBytes(info.Pricing.IncludedTraffic))
 			cmd.Printf("      Additional Traffic:\t%s per TB\n", util.GrossPrice(info.Pricing.PerTBTraffic))
 			cmd.Printf("\n")
 		}

--- a/internal/cmd/servertype/describe_test.go
+++ b/internal/cmd/servertype/describe_test.go
@@ -111,14 +111,14 @@ Memory:			4.0 GB
 Disk:			40 GB
 Storage Type:		local
 Locations:
-  - Location:		fsn1
+  - Location:			fsn1
     Deprecation:
       Announced:		%s (%s)
       Unavailable After:	%s (%s)
     Pricing:
-      Hourly:		€ 1.0000
-      Monthly:		€ 2.0000
-      Included Traffic:	639 KiB
+      Hourly:			€ 1.0000
+      Monthly:			€ 2.0000
+      Included Traffic:		639 KiB
       Additional Traffic:	€ 3.0000 per TB
 
 `,


### PR DESCRIPTION
The indentation was completely off, now all fields under `Locations` are aligned.