### PR TITLE
chore: reduce diff by hiding generated documentation by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/reference/manual/*.md linguist-generated=true


### PR DESCRIPTION
I would like to reduce the amount of files shown in PRs, this hides the generated manuals by default.

Github was complaining for the Storage Boxes PR being too big.

