### PR TITLE
fix: remove old checks for storage box delete protection

### DIFF
--- a/internal/cmd/storagebox/create.go
+++ b/internal/cmd/storagebox/create.go
@@ -131,11 +131,8 @@ var CreateCmd = base.CreateCmd[*hcloud.StorageBox]{
 			return nil, nil, fmt.Errorf("Storage Box not found: %d", result.StorageBox.ID)
 		}
 
-		if len(protection) > 0 {
-			// TODO this check can be removed once delete protection is made nullable
-			if err := changeProtection(s, cmd, storageBox, true, protectionOpts); err != nil {
-				return nil, nil, err
-			}
+		if err := changeProtection(s, cmd, storageBox, true, protectionOpts); err != nil {
+			return nil, nil, err
 		}
 
 		return storageBox, util.Wrap("storage_box", hcloud.SchemaFromStorageBox(result.StorageBox)), nil

--- a/internal/cmd/storagebox/enable_protection.go
+++ b/internal/cmd/storagebox/enable_protection.go
@@ -36,12 +36,9 @@ func getChangeProtectionOpts(enable bool, flags []string) (hcloud.StorageBoxChan
 func changeProtection(s state.State, cmd *cobra.Command,
 	storageBox *hcloud.StorageBox, enable bool, opts hcloud.StorageBoxChangeProtectionOpts) error {
 
-	/*
-		// TODO this needs to be fixed in the hcloud-go library first
-		if opts.Delete == nil {
-			return nil
-		}
-	*/
+	if opts.Delete == nil {
+		return nil
+	}
 
 	action, _, err := s.Client().StorageBox().ChangeProtection(s, storageBox, opts)
 	if err != nil {


### PR DESCRIPTION
These checks are no longer necessary as the protection level is now a pointer.