### PR TITLE
feat: format user provided TXT records when not quoted

### DIFF
--- a/docs/reference/manual/hcloud_zone_rrset.md
+++ b/docs/reference/manual/hcloud_zone_rrset.md
@@ -4,7 +4,11 @@
 
 ### Synopsis
 
-For more details, see the documentation for Zones https://docs.hetzner.cloud/reference/cloud#zones or Zone RRSets https://docs.hetzner.cloud/reference/cloud#zone-rrsets.
+For more details, see the documentation for Zones https://docs.hetzner.cloud/reference/cloud#zones
+or Zone RRSets https://docs.hetzner.cloud/reference/cloud#zone-rrsets.
+
+TXT records format must consist of one or many quoted strings of 255 characters. If the
+user provider TXT records are not quoted, they will be formatted for you.
 
 Experimental: DNS API is in beta, breaking changes may occur within minor releases.
 See https://docs.hetzner.cloud/changelog#2025-10-07-dns-beta for more details.

--- a/internal/cmd/zone/rrset/add_records.go
+++ b/internal/cmd/zone/rrset/add_records.go
@@ -66,6 +66,11 @@ If the Zone RRSet doesn't exist, it will automatically be created.
 			return err
 		}
 
+		// TXT: Format record values to simplify its usage
+		if rrset.Type == hcloud.ZoneRRSetTypeTXT {
+			FormatTXTRecords(cmd, opts.Records)
+		}
+
 		if ttl, _ := cmd.Flags().GetInt("ttl"); ttl != 0 {
 			opts.TTL = &ttl
 		}

--- a/internal/cmd/zone/rrset/create.go
+++ b/internal/cmd/zone/rrset/create.go
@@ -83,6 +83,11 @@ var CreateCmd = base.CreateCmd[*hcloud.ZoneRRSet]{
 			return nil, nil, err
 		}
 
+		// TXT: Format record values to simplify its usage
+		if createOpts.Type == hcloud.ZoneRRSetTypeTXT {
+			FormatTXTRecords(cmd, createOpts.Records)
+		}
+
 		if cmd.Flags().Changed("ttl") {
 			ttl, _ := cmd.Flags().GetInt("ttl")
 			createOpts.TTL = &ttl

--- a/internal/cmd/zone/rrset/remove_records.go
+++ b/internal/cmd/zone/rrset/remove_records.go
@@ -58,6 +58,11 @@ If the Zone RRSet doesn't contain any records, it will automatically be deleted.
 			return err
 		}
 
+		// TXT: Format record values to simplify its usage
+		if rrset.Type == hcloud.ZoneRRSetTypeTXT {
+			FormatTXTRecords(cmd, opts.Records)
+		}
+
 		action, _, err := s.Client().Zone().RemoveRRSetRecords(s, rrset, opts)
 		if err != nil {
 			return err

--- a/internal/cmd/zone/rrset/set_records.go
+++ b/internal/cmd/zone/rrset/set_records.go
@@ -62,6 +62,11 @@ var SetRecordsCmd = base.Cmd{
 			return err
 		}
 
+		// TXT: Format record values to simplify its usage
+		if hcloud.ZoneRRSetType(rrsetType) == hcloud.ZoneRRSetTypeTXT {
+			FormatTXTRecords(cmd, records)
+		}
+
 		zoneIDOrName, err = util.ParseZoneIDOrName(zoneIDOrName)
 		if err != nil {
 			return fmt.Errorf("failed to convert Zone name to ascii: %w", err)


### PR DESCRIPTION
If the given TXT records are not already quoted, the CLI will split the records into chunks of 255 chars and quote them:
    
```diff
-hcloud zone rrset add-records example-1948294840.com @ TXT --record "\"v=spf1 include:_spf.example.net ~all\""
+hcloud zone rrset add-records example-1948294840.com @ TXT --record "v=spf1 include:_spf.example.net ~all"
```

