### PR TITLE
test: fix conflicts from new date format

### DIFF
--- a/internal/cmd/storagebox/describe_test.go
+++ b/internal/cmd/storagebox/describe_test.go
@@ -111,7 +111,7 @@ func TestDescribe(t *testing.T) {
 
 	expOut := fmt.Sprintf(`ID:				123
 Name:				test
-Created:			Sat Jan 30 23:55:00 UTC 2016 (%s)
+Created:			2016-01-30 23:55:00 UTC (%s)
 Status:				active
 Username:			u12345
 Server:				u1337.your-storagebox.de

--- a/internal/cmd/storagebox/snapshot/describe_test.go
+++ b/internal/cmd/storagebox/snapshot/describe_test.go
@@ -59,7 +59,7 @@ func TestDescribe(t *testing.T) {
 	expOut := fmt.Sprintf(`ID:			456
 Name:			snapshot-1
 Description:		some-description
-Created:		Tue Jan  2 15:04:05 UTC 2024 (%s)
+Created:		2024-01-02 15:04:05 UTC (%s)
 Is automatic:		no
 Stats:
   Size:			50 GiB

--- a/internal/cmd/storagebox/subaccount/describe_test.go
+++ b/internal/cmd/storagebox/subaccount/describe_test.go
@@ -61,7 +61,7 @@ func TestDescribe(t *testing.T) {
 
 	expOut := fmt.Sprintf(`ID:			42
 Description:		host01 backup
-Created:		Sat Jan 30 23:55:00 UTC 2016 (%s)
+Created:		2016-01-30 23:55:00 UTC (%s)
 Username:		u1337-sub1
 Home Directory:		my_backups/host01.my.company
 Server:			u1337-sub1.your-storagebox.de

--- a/internal/cmd/storageboxtype/list_test.go
+++ b/internal/cmd/storageboxtype/list_test.go
@@ -88,9 +88,9 @@ func TestListColumnDeprecated(t *testing.T) {
 
 	out, errOut, err := fx.Run(cmd, []string{"-o=columns=id,name,deprecated"})
 
-	expOut := `ID    NAME         DEPRECATED                  
-123   deprecated   Thu Aug 20 12:00:00 UTC 2037
-124   current      -                           
+	expOut := `ID    NAME         DEPRECATED             
+123   deprecated   2037-08-20 12:00:00 UTC
+124   current      -                      
 `
 
 	require.NoError(t, err)


### PR DESCRIPTION
The PR for the new date format (#1197) was not rebased before merging, and the tests new storage box commands that were added in the meantime still verified the old date format.