### PR TITLE
fix(iso): broken `--type` flag in list command

### DIFF
--- a/internal/cmd/iso/list.go
+++ b/internal/cmd/iso/list.go
@@ -2,6 +2,7 @@ package iso
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -65,7 +66,18 @@ var ListCmd = &base.ListCmd[*hcloud.ISO, schema.ISO]{
 			opts.Sort = sorts
 		}
 
-		return s.Client().ISO().AllWithOpts(s, opts)
+		isos, err := s.Client().ISO().AllWithOpts(s, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		var filtered []*hcloud.ISO
+		for _, iso := range isos {
+			if slices.Contains(types, string(iso.Type)) {
+				filtered = append(filtered, iso)
+			}
+		}
+		return filtered, nil
 	},
 
 	OutputTable: func(t *output.Table[*hcloud.ISO], _ hcapi2.Client) {

--- a/internal/cmd/iso/list_test.go
+++ b/internal/cmd/iso/list_test.go
@@ -50,3 +50,56 @@ func TestList(t *testing.T) {
 	assert.Empty(t, errOut)
 	assert.Equal(t, expOut, out)
 }
+
+func TestListPrivate(t *testing.T) {
+	fx := testutil.NewFixture(t)
+	defer fx.Finish()
+
+	time.Local = time.UTC
+
+	cmd := iso.ListCmd.CobraCommand(fx.State())
+
+	fx.ExpectEnsureToken()
+	fx.Client.ISOClient.EXPECT().
+		AllWithOpts(
+			gomock.Any(),
+			hcloud.ISOListOpts{
+				ListOpts: hcloud.ListOpts{PerPage: 50},
+				Sort:     nil, // ISOs do not support sorting
+			},
+		).
+		Return([]*hcloud.ISO{
+			{
+				ID:           123,
+				Name:         "public1",
+				Description:  "Test Public ISO",
+				Type:         hcloud.ISOTypePublic,
+				Architecture: hcloud.Ptr(hcloud.ArchitectureX86),
+			},
+			{
+				ID:           456,
+				Name:         "private1",
+				Description:  "Test Private ISO 1",
+				Type:         hcloud.ISOTypePrivate,
+				Architecture: hcloud.Ptr(hcloud.ArchitectureX86),
+			},
+			{
+				ID:           789,
+				Name:         "private2",
+				Description:  "Test Private ISO 2",
+				Type:         hcloud.ISOTypePrivate,
+				Architecture: hcloud.Ptr(hcloud.ArchitectureX86),
+			},
+		}, nil)
+
+	out, errOut, err := fx.Run(cmd, []string{"--type=private"})
+
+	expOut := `ID    NAME       DESCRIPTION          TYPE      ARCHITECTURE
+456   private1   Test Private ISO 1   private   x86         
+789   private2   Test Private ISO 2   private   x86         
+`
+
+	require.NoError(t, err)
+	assert.Empty(t, errOut)
+	assert.Equal(t, expOut, out)
+}


### PR DESCRIPTION
This PR fixes #1217 and adds a test case to make sure it doesn't break again.