### PR TITLE
fix: filepaths not correctly resolved on Windows

### DIFF
--- a/internal/scripts/generate_docs.go
+++ b/internal/scripts/generate_docs.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -56,18 +56,18 @@ func run() error {
 		if f.IsDir() {
 			continue
 		}
-		filepath := path.Join(dir, f.Name())
-		bytes, err := os.ReadFile(filepath)
+		path := filepath.Join(dir, f.Name())
+		bytes, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("could not read file at %q: %w", filepath, err)
+			return fmt.Errorf("could not read file at %q: %w", path, err)
 		}
 		bytes = generatedOnRegex.ReplaceAll(bytes, nil)
 		// We do this to wrap tables in a code block. Otherwise, they won't be displayed properly in markdown viewers.
 		bytes = []byte(strings.ReplaceAll(string(bytes), "┌", "```\n┌"))
 		bytes = []byte(strings.ReplaceAll(string(bytes), "┘", "┘\n```"))
-		err = os.WriteFile(filepath, bytes, f.Type())
+		err = os.WriteFile(path, bytes, f.Type())
 		if err != nil {
-			return fmt.Errorf("could not write file at %q: %w", filepath, err)
+			return fmt.Errorf("could not write file at %q: %w", path, err)
 		}
 	}
 

--- a/internal/state/config/config.go
+++ b/internal/state/config/config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -201,7 +201,7 @@ func (cfg *config) Read(f any) error {
 
 func (cfg *config) Write(w io.Writer) (err error) {
 	if w == nil {
-		dir := path.Dir(cfg.path)
+		dir := filepath.Dir(cfg.path)
 		if err = os.MkdirAll(dir, 0750); err != nil {
 			return err
 		}


### PR DESCRIPTION
The [path](https://pkg.go.dev/path) package only supports slash-separated paths. We should use [filepath](https://pkg.go.dev/path/filepath) for platform-specific path handling instead.

Fixes #1225