### PR TITLE
fix: report apple sign-and-notarize error after the release is complete

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,6 @@ jobs:
         with:
           name: Preview Binaries
           path: dist/hcloud-*/hcloud
+
+      - name: Check for release errors
+        run: scripts/check-release-error.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,6 @@ jobs:
           QUILL_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+
+      - name: Check for release errors
+        run: scripts/check-release-error.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,11 +28,10 @@ builds:
     goarch: [amd64, arm64]
     hooks:
       post:
-        - cmd: >
-            quill
-                sign-and-notarize "{{ .Path }}"
-                --dry-run={{ .IsSnapshot }}
-                --ad-hoc={{ .IsSnapshot }}
+        # sign-and-notarize might fails if the Apple license agreement is not signed.
+        # This ensures that the release process continues instead of stopping and having
+        # a release without assets. The error is reported at the end of the CI job.
+        - cmd: bash -c 'quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} || touch sign-and-notarize.error'
           output: true
 
 kos:

--- a/scripts/check-release-error.sh
+++ b/scripts/check-release-error.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ls -1 ./*.error || true
+
+if [[ -f sign-and-notarize.error ]]; then exit 1; fi


### PR DESCRIPTION
If the sign-and-notarize hook fails, we still continue with the release process to publish the different assets, and only fail after the assets where published.

```rp-commits
ci: report apple sign-and-notarize error after the release is complete (#1231)
```