### PR TITLE
deps: fix renovate picking up mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,10 @@
 [tools]
 go = "1.25.4"
-"go:go.uber.org/mock/mockgen" = "v0.6.0"  # renovate: datasource=github-releases depName=uber-go/mock
-golangci-lint = "2.6.1"
-goreleaser = "v2.9.0"
-"ubi:anchore/quill" = "v0.5.1"            # renovate: datasource=github-releases depName=anchore/quill
-"ubi:jstemmer/go-junit-report" = "v2.1.0" # renovate: datasource=github-releases depName=jstemmer/go-junit-report
+"go:go.uber.org/mock/mockgen" = "v0.6.0"
+"ubi:golangci/golangci-lint" = "2.6.1"
+"ubi:goreleaser/goreleaser" = "v2.9.0"
+"ubi:anchore/quill" = "v0.5.1"
+"ubi:jstemmer/go-junit-report" = "v2.1.0"
 
 [settings]
 # Experimental features are needed for the Go backend


### PR DESCRIPTION
Currently, `goreleaser` is not supported as a default registry tool short name by renovate, so we have to annotate it manually. See https://docs.renovatebot.com/modules/manager/mise/#supported-default-registry-tool-short-names