### PR TITLE
feat(firewall): add list columns for labels, created and age

### DIFF
--- a/docs/reference/manual/hcloud_firewall_list.md
+++ b/docs/reference/manual/hcloud_firewall_list.md
@@ -8,11 +8,14 @@ Displays a list of Firewalls.
 
 Output can be controlled with the -o flag. Use -o noheader to suppress the
 table header. Displayed columns and their order can be set with
--o columns=applied_to_count,id (see available columns below).
+-o columns=age,applied_to_count (see available columns below).
 
 Columns:
+ - age
  - applied_to_count
+ - created
  - id
+ - labels
  - name
  - rules_count
 

--- a/internal/cmd/all/list_test.go
+++ b/internal/cmd/all/list_test.go
@@ -282,8 +282,8 @@ ID    NAME       IP RANGE       SERVERS    AGE
 
 FIREWALLS
 ---
-ID    NAME   RULES COUNT   APPLIED TO COUNT             
-123   test   5 Rules       2 Servers | 0 Label Selectors
+ID    NAME   RULES COUNT   APPLIED TO COUNT                AGE
+123   test   5 Rules       2 Servers | 0 Label Selectors   7m 
 
 CERTIFICATES
 ---

--- a/internal/cmd/firewall/list.go
+++ b/internal/cmd/firewall/list.go
@@ -2,11 +2,13 @@ package firewall
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/pflag"
 
 	"github.com/hetznercloud/cli/internal/cmd/base"
 	"github.com/hetznercloud/cli/internal/cmd/output"
+	"github.com/hetznercloud/cli/internal/cmd/util"
 	"github.com/hetznercloud/cli/internal/hcapi2"
 	"github.com/hetznercloud/cli/internal/state"
 	"github.com/hetznercloud/cli/internal/state/config"
@@ -17,7 +19,7 @@ import (
 var ListCmd = &base.ListCmd[*hcloud.Firewall, schema.Firewall]{
 	ResourceNamePlural: "Firewalls",
 	JSONKeyGetByName:   "firewalls",
-	DefaultColumns:     []string{"id", "name", "rules_count", "applied_to_count"},
+	DefaultColumns:     []string{"id", "name", "rules_count", "applied_to_count", "age"},
 	SortOption:         config.OptionSortFirewall,
 
 	Fetch: func(s state.State, _ *pflag.FlagSet, listOpts hcloud.ListOpts, sorts []string) ([]*hcloud.Firewall, error) {
@@ -57,6 +59,15 @@ var ListCmd = &base.ListCmd[*hcloud.Firewall, schema.Firewall]{
 					labelSelectorsText = "Label Selector"
 				}
 				return fmt.Sprintf("%d %s | %d %s", servers, serversText, labelSelectors, labelSelectorsText)
+			}).
+			AddFieldFn("labels", func(firewall *hcloud.Firewall) string {
+				return util.LabelsToString(firewall.Labels)
+			}).
+			AddFieldFn("created", func(firewall *hcloud.Firewall) string {
+				return util.Datetime(firewall.Created)
+			}).
+			AddFieldFn("age", func(firewall *hcloud.Firewall) string {
+				return util.Age(firewall.Created, time.Now())
 			})
 	},
 

--- a/internal/cmd/firewall/list_test.go
+++ b/internal/cmd/firewall/list_test.go
@@ -38,13 +38,14 @@ func TestList(t *testing.T) {
 				Rules:     make([]hcloud.FirewallRule, 5),
 				AppliedTo: make([]hcloud.FirewallResource, 2),
 				Labels:    make(map[string]string),
+				Created:   time.Now().Add(-20 * time.Second),
 			},
 		}, nil)
 
 	out, errOut, err := fx.Run(cmd, []string{})
 
-	expOut := `ID    NAME   RULES COUNT   APPLIED TO COUNT             
-123   test   5 Rules       2 Servers | 0 Label Selectors
+	expOut := `ID    NAME   RULES COUNT   APPLIED TO COUNT                AGE
+123   test   5 Rules       2 Servers | 0 Label Selectors   20s
 `
 
 	require.NoError(t, err)

--- a/test/e2e/firewall_test.go
+++ b/test/e2e/firewall_test.go
@@ -213,6 +213,26 @@ func TestFirewall(t *testing.T) {
 		)
 	})
 
+	t.Run("list", func(t *testing.T) {
+		t.Run("table", func(t *testing.T) {
+			out, err := runCommand(t, "firewall", "list", "--output", "columns=id,name,rules_count,applied_to_count,labels,created,age")
+			require.NoError(t, err)
+			assert.Regexp(t,
+				NewRegex().Start().
+					SeparatedByWhitespace("ID", "NAME", "RULES COUNT", "APPLIED TO COUNT", "LABELS", "CREATED", "AGE").Newline().
+					Int().Whitespace().
+					Raw(`new-test-firewall-[0-9a-f]{8}`).Whitespace().
+					Lit("5 Rules").Whitespace().
+					Lit("0 Servers | 1 Label Selector").Whitespace().
+					Lit("foo=bar").Whitespace().
+					Datetime().Whitespace().
+					Age().OptionalWhitespace().Newline().
+					End(),
+				out,
+			)
+		})
+	})
+
 	t.Run("remove-from-resource", func(t *testing.T) {
 		t.Run("unknown-type", func(t *testing.T) {
 			out, err := runCommand(t, "firewall", "remove-from-resource", "--type", "non-existing-type", strconv.FormatInt(firewallID, 10))


### PR DESCRIPTION
Nearly all other resources have the columns `labels`,`created` and `age` available. This adds these columns for the `hcloud firewall list` command. 