### PR TITLE
feat: drop builds for windows armv6 and armv7 (32 bit)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,9 @@ builds:
     goos: [freebsd, windows, linux]
     goarch: [amd64, arm, arm64, "386"]
     goarm: ["6", "7"]
+    ignore:
+      - goos: windows
+        goarch: arm
 
   - <<: *build_defaults
     id: hcloud-build-darwin


### PR DESCRIPTION
Stop building binaries for windows arm32.

Those targets are marked as broken in go 1.24: https://github.com/golang/go/blob/release-branch.go1.24/src/cmd/dist/build.go#L1826-L1830

And will be removed in go 1.26: https://github.com/golang/go/issues/71671