### PR TITLE
refactor(base): make update, delete, set-rdns generic

### DIFF
--- a/internal/cmd/base/delete_test.go
+++ b/internal/cmd/base/delete_test.go
@@ -16,16 +16,16 @@ import (
 
 var mu = sync.Mutex{}
 
-var fakeDeleteCmd = &base.DeleteCmd{
+var fakeDeleteCmd = &base.DeleteCmd[*fakeResource]{
 	ResourceNameSingular: "Fake resource",
 	ResourceNamePlural:   "Fake resources",
-	Delete: func(_ state.State, cmd *cobra.Command, _ interface{}) (*hcloud.Action, error) {
+	Delete: func(_ state.State, cmd *cobra.Command, _ *fakeResource) (*hcloud.Action, error) {
 		defer mu.Unlock()
 		cmd.Println("Deleting fake resource")
 		return nil, nil
 	},
 
-	Fetch: func(_ state.State, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(_ state.State, cmd *cobra.Command, idOrName string) (*fakeResource, *hcloud.Response, error) {
 		mu.Lock()
 		cmd.Println("Fetching fake resource")
 

--- a/internal/cmd/base/update.go
+++ b/internal/cmd/base/update.go
@@ -16,18 +16,18 @@ import (
 )
 
 // UpdateCmd allows defining commands for updating a resource.
-type UpdateCmd struct {
+type UpdateCmd[T any] struct {
 	ResourceNameSingular string // e.g. "Server"
 	ShortDescription     string
 	NameSuggestions      func(client hcapi2.Client) func() []string
 	DefineFlags          func(*cobra.Command)
 
-	Fetch func(s state.State, cmd *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error)
+	Fetch func(s state.State, cmd *cobra.Command, idOrName string) (T, *hcloud.Response, error)
 	// Can be set in case the resource has more than a single identifier that is used in the positional arguments.
 	// See [UpdateCmd.PositionalArgumentOverride].
-	FetchWithArgs func(s state.State, cmd *cobra.Command, args []string) (any, *hcloud.Response, error)
+	FetchWithArgs func(s state.State, cmd *cobra.Command, args []string) (T, *hcloud.Response, error)
 
-	Update func(s state.State, cmd *cobra.Command, resource interface{}, flags map[string]pflag.Value) error
+	Update func(s state.State, cmd *cobra.Command, resource T, flags map[string]pflag.Value) error
 
 	// In case the resource does not have a single identifier that matches [UpdateCmd.ResourceNameSingular], this field
 	// can be set to define the list of positional arguments.
@@ -46,7 +46,7 @@ type UpdateCmd struct {
 }
 
 // CobraCommand creates a command that can be registered with cobra.
-func (uc *UpdateCmd) CobraCommand(s state.State) *cobra.Command {
+func (uc *UpdateCmd[T]) CobraCommand(s state.State) *cobra.Command {
 	var suggestArgs []cobra.CompletionFunc
 	switch {
 	case uc.NameSuggestions != nil:
@@ -79,9 +79,9 @@ func (uc *UpdateCmd) CobraCommand(s state.State) *cobra.Command {
 }
 
 // Run executes a update command.
-func (uc *UpdateCmd) Run(s state.State, cmd *cobra.Command, args []string) error {
+func (uc *UpdateCmd[T]) Run(s state.State, cmd *cobra.Command, args []string) error {
 	var (
-		resource any
+		resource T
 		err      error
 	)
 	if uc.FetchWithArgs != nil {

--- a/internal/cmd/certificate/delete.go
+++ b/internal/cmd/certificate/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Certificate]{
 	ResourceNameSingular: "Certificate",
 	ResourceNamePlural:   "Certificates",
 	ShortDescription:     "Delete a Certificate",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Firewall().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Certificate, *hcloud.Response, error) {
 		return s.Client().Certificate().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		certificate := resource.(*hcloud.Certificate)
+	Delete: func(s state.State, _ *cobra.Command, certificate *hcloud.Certificate) (*hcloud.Action, error) {
 		_, err := s.Client().Certificate().Delete(s, certificate)
 		return nil, err
 	},

--- a/internal/cmd/certificate/update.go
+++ b/internal/cmd/certificate/update.go
@@ -10,18 +10,17 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.Certificate]{
 	ResourceNameSingular: "Certificate",
 	ShortDescription:     "Update a Certificate",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Firewall().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Certificate, *hcloud.Response, error) {
 		return s.Client().Certificate().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Certificate Name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		certificate := resource.(*hcloud.Certificate)
+	Update: func(s state.State, _ *cobra.Command, certificate *hcloud.Certificate, flags map[string]pflag.Value) error {
 		updOpts := hcloud.CertificateUpdateOpts{
 			Name: flags["name"].String(),
 		}

--- a/internal/cmd/firewall/delete.go
+++ b/internal/cmd/firewall/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Firewall]{
 	ResourceNameSingular: "Firewall",
 	ResourceNamePlural:   "Firewalls",
 	ShortDescription:     "Delete a Firewall",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Firewall().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Firewall, *hcloud.Response, error) {
 		return s.Client().Firewall().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		firewall := resource.(*hcloud.Firewall)
+	Delete: func(s state.State, _ *cobra.Command, firewall *hcloud.Firewall) (*hcloud.Action, error) {
 		_, err := s.Client().Firewall().Delete(s, firewall)
 		return nil, err
 	},

--- a/internal/cmd/firewall/update.go
+++ b/internal/cmd/firewall/update.go
@@ -10,18 +10,17 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.Firewall]{
 	ResourceNameSingular: "Firewall",
 	ShortDescription:     "Update a Firewall",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Firewall().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Firewall, *hcloud.Response, error) {
 		return s.Client().Firewall().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Firewall name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		firewall := resource.(*hcloud.Firewall)
+	Update: func(s state.State, _ *cobra.Command, firewall *hcloud.Firewall, flags map[string]pflag.Value) error {
 		updOpts := hcloud.FirewallUpdateOpts{
 			Name: flags["name"].String(),
 		}

--- a/internal/cmd/floatingip/delete.go
+++ b/internal/cmd/floatingip/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.FloatingIP]{
 	ResourceNameSingular: "Floating IP",
 	ResourceNamePlural:   "Floating IPs",
 	ShortDescription:     "Delete a Floating IP",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.FloatingIP().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.FloatingIP, *hcloud.Response, error) {
 		return s.Client().FloatingIP().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		floatingIP := resource.(*hcloud.FloatingIP)
+	Delete: func(s state.State, _ *cobra.Command, floatingIP *hcloud.FloatingIP) (*hcloud.Action, error) {
 		_, err := s.Client().FloatingIP().Delete(s, floatingIP)
 		return nil, err
 	},

--- a/internal/cmd/floatingip/set_rdns.go
+++ b/internal/cmd/floatingip/set_rdns.go
@@ -11,15 +11,14 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var SetRDNSCmd = base.SetRdnsCmd{
+var SetRDNSCmd = base.SetRdnsCmd[*hcloud.FloatingIP]{
 	ResourceNameSingular: "Floating IP",
 	ShortDescription:     "Change reverse DNS of a Floating IP",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.FloatingIP().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.FloatingIP, *hcloud.Response, error) {
 		return s.Client().FloatingIP().Get(s, idOrName)
 	},
-	GetDefaultIP: func(resource interface{}) net.IP {
-		floatingIP := resource.(*hcloud.FloatingIP)
+	GetDefaultIP: func(floatingIP *hcloud.FloatingIP) net.IP {
 		return floatingIP.IP
 	},
 }

--- a/internal/cmd/floatingip/update.go
+++ b/internal/cmd/floatingip/update.go
@@ -10,19 +10,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.FloatingIP]{
 	ResourceNameSingular: "Floating IP",
 	ShortDescription:     "Update a Floating IP",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.FloatingIP().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.FloatingIP, *hcloud.Response, error) {
 		return s.Client().FloatingIP().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Floating IP name")
 		cmd.Flags().String("description", "", "Floating IP description")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		floatingIP := resource.(*hcloud.FloatingIP)
+	Update: func(s state.State, _ *cobra.Command, floatingIP *hcloud.FloatingIP, flags map[string]pflag.Value) error {
 		updOpts := hcloud.FloatingIPUpdateOpts{
 			Name:        flags["name"].String(),
 			Description: flags["description"].String(),

--- a/internal/cmd/image/delete.go
+++ b/internal/cmd/image/delete.go
@@ -12,20 +12,19 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Image]{
 	ResourceNameSingular: "Image",
 	ResourceNamePlural:   "Images",
 	ShortDescription:     "Delete an Image",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Image().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Image, *hcloud.Response, error) {
 		id, err := strconv.ParseInt(idOrName, 10, 64)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid snapshot or backup ID %q", idOrName)
 		}
 		return s.Client().Image().GetByID(s, id)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		image := resource.(*hcloud.Image)
+	Delete: func(s state.State, _ *cobra.Command, image *hcloud.Image) (*hcloud.Action, error) {
 		_, err := s.Client().Image().Delete(s, image)
 		return nil, err
 	},

--- a/internal/cmd/image/update.go
+++ b/internal/cmd/image/update.go
@@ -14,11 +14,11 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.Image]{
 	ResourceNameSingular: "Image",
 	ShortDescription:     "Update an Image",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Image().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Image, *hcloud.Response, error) {
 		id, err := strconv.ParseInt(idOrName, 10, 64)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid snapshot or backup ID %q", idOrName)
@@ -30,8 +30,7 @@ var UpdateCmd = base.UpdateCmd{
 		cmd.Flags().String("type", "", "Image type")
 		_ = cmd.RegisterFlagCompletionFunc("type", cmpl.SuggestCandidates("snapshot"))
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		image := resource.(*hcloud.Image)
+	Update: func(s state.State, _ *cobra.Command, image *hcloud.Image, flags map[string]pflag.Value) error {
 		updOpts := hcloud.ImageUpdateOpts{
 			Description: hcloud.Ptr(flags["description"].String()),
 			Type:        hcloud.ImageType(flags["type"].String()),

--- a/internal/cmd/loadbalancer/delete.go
+++ b/internal/cmd/loadbalancer/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.LoadBalancer]{
 	ResourceNameSingular: "Load Balancer",
 	ResourceNamePlural:   "Load Balancers",
 	ShortDescription:     "Delete a Load Balancer",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.LoadBalancer().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.LoadBalancer, *hcloud.Response, error) {
 		return s.Client().LoadBalancer().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		loadBalancer := resource.(*hcloud.LoadBalancer)
+	Delete: func(s state.State, _ *cobra.Command, loadBalancer *hcloud.LoadBalancer) (*hcloud.Action, error) {
 		_, err := s.Client().LoadBalancer().Delete(s, loadBalancer)
 		return nil, err
 	},

--- a/internal/cmd/loadbalancer/set_rdns.go
+++ b/internal/cmd/loadbalancer/set_rdns.go
@@ -11,15 +11,14 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var SetRDNSCmd = base.SetRdnsCmd{
+var SetRDNSCmd = base.SetRdnsCmd[*hcloud.LoadBalancer]{
 	ResourceNameSingular: "Load Balancer",
 	ShortDescription:     "Change reverse DNS of a Load Balancer",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.LoadBalancer().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.LoadBalancer, *hcloud.Response, error) {
 		return s.Client().LoadBalancer().Get(s, idOrName)
 	},
-	GetDefaultIP: func(resource interface{}) net.IP {
-		loadBalancer := resource.(*hcloud.LoadBalancer)
+	GetDefaultIP: func(loadBalancer *hcloud.LoadBalancer) net.IP {
 		return loadBalancer.PublicNet.IPv4.IP
 	},
 }

--- a/internal/cmd/loadbalancer/update.go
+++ b/internal/cmd/loadbalancer/update.go
@@ -10,22 +10,21 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.LoadBalancer]{
 	ResourceNameSingular: "Load Balancer",
 	ShortDescription:     "Update a Load Balancer",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.LoadBalancer().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.LoadBalancer, *hcloud.Response, error) {
 		return s.Client().LoadBalancer().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Load Balancer name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		floatingIP := resource.(*hcloud.LoadBalancer)
+	Update: func(s state.State, _ *cobra.Command, loadBalancer *hcloud.LoadBalancer, flags map[string]pflag.Value) error {
 		updOpts := hcloud.LoadBalancerUpdateOpts{
 			Name: flags["name"].String(),
 		}
-		_, _, err := s.Client().LoadBalancer().Update(s, floatingIP, updOpts)
+		_, _, err := s.Client().LoadBalancer().Update(s, loadBalancer, updOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/network/delete.go
+++ b/internal/cmd/network/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Network]{
 	ResourceNameSingular: "Network",
 	ResourceNamePlural:   "Networks",
 	ShortDescription:     "Delete a network",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Network().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Network, *hcloud.Response, error) {
 		return s.Client().Network().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		network := resource.(*hcloud.Network)
+	Delete: func(s state.State, _ *cobra.Command, network *hcloud.Network) (*hcloud.Action, error) {
 		_, err := s.Client().Network().Delete(s, network)
 		return nil, err
 	},

--- a/internal/cmd/network/update.go
+++ b/internal/cmd/network/update.go
@@ -10,22 +10,21 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.Network]{
 	ResourceNameSingular: "Network",
 	ShortDescription:     "Update a Network.\n\nTo enable or disable exposing routes to the vSwitch connection you can use the subcommand \"hcloud network expose-routes-to-vswitch\".",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Network().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Network, *hcloud.Response, error) {
 		return s.Client().Network().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Network name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		floatingIP := resource.(*hcloud.Network)
+	Update: func(s state.State, _ *cobra.Command, network *hcloud.Network, flags map[string]pflag.Value) error {
 		updOpts := hcloud.NetworkUpdateOpts{
 			Name: flags["name"].String(),
 		}
-		_, _, err := s.Client().Network().Update(s, floatingIP, updOpts)
+		_, _, err := s.Client().Network().Update(s, network, updOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/placementgroup/delete.go
+++ b/internal/cmd/placementgroup/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.PlacementGroup]{
 	ResourceNameSingular: "Placement Group",
 	ResourceNamePlural:   "Placement Groups",
 	ShortDescription:     "Delete a Placement Group",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.PlacementGroup().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.PlacementGroup, *hcloud.Response, error) {
 		return s.Client().PlacementGroup().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		placementGroup := resource.(*hcloud.PlacementGroup)
+	Delete: func(s state.State, _ *cobra.Command, placementGroup *hcloud.PlacementGroup) (*hcloud.Action, error) {
 		_, err := s.Client().PlacementGroup().Delete(s, placementGroup)
 		return nil, err
 	},

--- a/internal/cmd/placementgroup/update.go
+++ b/internal/cmd/placementgroup/update.go
@@ -10,18 +10,17 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.PlacementGroup]{
 	ResourceNameSingular: "Placement Group",
 	ShortDescription:     "Update a Placement Group",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.PlacementGroup().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.PlacementGroup, *hcloud.Response, error) {
 		return s.Client().PlacementGroup().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Placement Group name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		placementGroup := resource.(*hcloud.PlacementGroup)
+	Update: func(s state.State, _ *cobra.Command, placementGroup *hcloud.PlacementGroup, flags map[string]pflag.Value) error {
 		updOpts := hcloud.PlacementGroupUpdateOpts{
 			Name: flags["name"].String(),
 		}

--- a/internal/cmd/primaryip/delete.go
+++ b/internal/cmd/primaryip/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.PrimaryIP]{
 	ResourceNameSingular: "Primary IP",
 	ResourceNamePlural:   "Primary IPs",
 	ShortDescription:     "Delete a Primary IP",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.PrimaryIP().Names(false, false, nil) },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.PrimaryIP, *hcloud.Response, error) {
 		return s.Client().PrimaryIP().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		primaryIP := resource.(*hcloud.PrimaryIP)
+	Delete: func(s state.State, _ *cobra.Command, primaryIP *hcloud.PrimaryIP) (*hcloud.Action, error) {
 		_, err := s.Client().PrimaryIP().Delete(s, primaryIP)
 		return nil, err
 	},

--- a/internal/cmd/primaryip/set_rdns.go
+++ b/internal/cmd/primaryip/set_rdns.go
@@ -11,15 +11,14 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var SetRDNSCmd = base.SetRdnsCmd{
+var SetRDNSCmd = base.SetRdnsCmd[*hcloud.PrimaryIP]{
 	ResourceNameSingular: "Primary IP",
 	ShortDescription:     "Change reverse DNS of a Primary IP",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.PrimaryIP().Names(false, false, nil) },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.PrimaryIP, *hcloud.Response, error) {
 		return s.Client().PrimaryIP().Get(s, idOrName)
 	},
-	GetDefaultIP: func(resource interface{}) net.IP {
-		primaryIP := resource.(*hcloud.PrimaryIP)
+	GetDefaultIP: func(primaryIP *hcloud.PrimaryIP) net.IP {
 		return primaryIP.IP
 	},
 }

--- a/internal/cmd/primaryip/update.go
+++ b/internal/cmd/primaryip/update.go
@@ -10,19 +10,18 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.PrimaryIP]{
 	ResourceNameSingular: "Primary IP",
 	ShortDescription:     "Update a Primary IP",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.PrimaryIP().Names(false, false, nil) },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.PrimaryIP, *hcloud.Response, error) {
 		return s.Client().PrimaryIP().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Primary IP name")
 		cmd.Flags().Bool("auto-delete", false, "Delete this Primary IP when the resource it is assigned to is deleted (true, false)")
 	},
-	Update: func(s state.State, cmd *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		primaryIP := resource.(*hcloud.PrimaryIP)
+	Update: func(s state.State, cmd *cobra.Command, primaryIP *hcloud.PrimaryIP, flags map[string]pflag.Value) error {
 		updOpts := hcloud.PrimaryIPUpdateOpts{
 			Name: flags["name"].String(),
 		}

--- a/internal/cmd/server/delete.go
+++ b/internal/cmd/server/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Server]{
 	ResourceNameSingular: "Server",
 	ResourceNamePlural:   "Servers",
 	ShortDescription:     "Delete a server",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Server().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Server, *hcloud.Response, error) {
 		return s.Client().Server().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		server := resource.(*hcloud.Server)
+	Delete: func(s state.State, _ *cobra.Command, server *hcloud.Server) (*hcloud.Action, error) {
 		result, _, err := s.Client().Server().DeleteWithResult(s, server)
 		if err != nil {
 			return nil, err

--- a/internal/cmd/server/set_rdns.go
+++ b/internal/cmd/server/set_rdns.go
@@ -11,15 +11,14 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var SetRDNSCmd = base.SetRdnsCmd{
+var SetRDNSCmd = base.SetRdnsCmd[*hcloud.Server]{
 	ResourceNameSingular: "Server",
 	ShortDescription:     "Change reverse DNS of a Server",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Server().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Server, *hcloud.Response, error) {
 		return s.Client().Server().Get(s, idOrName)
 	},
-	GetDefaultIP: func(resource interface{}) net.IP {
-		server := resource.(*hcloud.Server)
+	GetDefaultIP: func(server *hcloud.Server) net.IP {
 		return server.PublicNet.IPv4.IP
 	},
 }

--- a/internal/cmd/server/update.go
+++ b/internal/cmd/server/update.go
@@ -10,22 +10,21 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.Server]{
 	ResourceNameSingular: "Server",
 	ShortDescription:     "Update a Server",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Server().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Server, *hcloud.Response, error) {
 		return s.Client().Server().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Server name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		floatingIP := resource.(*hcloud.Server)
+	Update: func(s state.State, _ *cobra.Command, server *hcloud.Server, flags map[string]pflag.Value) error {
 		updOpts := hcloud.ServerUpdateOpts{
 			Name: flags["name"].String(),
 		}
-		_, _, err := s.Client().Server().Update(s, floatingIP, updOpts)
+		_, _, err := s.Client().Server().Update(s, server, updOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/sshkey/delete.go
+++ b/internal/cmd/sshkey/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.SSHKey]{
 	ResourceNameSingular: "SSH Key",
 	ResourceNamePlural:   "SSH Keys",
 	ShortDescription:     "Delete an SSH Key",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.SSHKey().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.SSHKey, *hcloud.Response, error) {
 		return s.Client().SSHKey().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		sshKey := resource.(*hcloud.SSHKey)
+	Delete: func(s state.State, _ *cobra.Command, sshKey *hcloud.SSHKey) (*hcloud.Action, error) {
 		_, err := s.Client().SSHKey().Delete(s, sshKey)
 		return nil, err
 	},

--- a/internal/cmd/sshkey/update.go
+++ b/internal/cmd/sshkey/update.go
@@ -10,22 +10,21 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.SSHKey]{
 	ResourceNameSingular: "SSH Key",
 	ShortDescription:     "Update an SSH Key",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.SSHKey().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.SSHKey, *hcloud.Response, error) {
 		return s.Client().SSHKey().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "SSH Key name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		floatingIP := resource.(*hcloud.SSHKey)
+	Update: func(s state.State, _ *cobra.Command, sshKey *hcloud.SSHKey, flags map[string]pflag.Value) error {
 		updOpts := hcloud.SSHKeyUpdateOpts{
 			Name: flags["name"].String(),
 		}
-		_, _, err := s.Client().SSHKey().Update(s, floatingIP, updOpts)
+		_, _, err := s.Client().SSHKey().Update(s, sshKey, updOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/storagebox/delete.go
+++ b/internal/cmd/storagebox/delete.go
@@ -10,16 +10,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.StorageBox]{
 	ResourceNameSingular: "Storage Box",
 	ResourceNamePlural:   "Storage Boxes",
 	ShortDescription:     "Delete a Storage Box",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.StorageBox().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (any, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.StorageBox, *hcloud.Response, error) {
 		return s.Client().StorageBox().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource any) (*hcloud.Action, error) {
-		storageBox := resource.(*hcloud.StorageBox)
+	Delete: func(s state.State, _ *cobra.Command, storageBox *hcloud.StorageBox) (*hcloud.Action, error) {
 		result, _, err := s.Client().StorageBox().Delete(s, storageBox)
 		return result.Action, err
 	},

--- a/internal/cmd/storagebox/snapshot/delete.go
+++ b/internal/cmd/storagebox/snapshot/delete.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.StorageBoxSnapshot]{
 	ResourceNameSingular:       "Storage Box Snapshot",
 	ResourceNamePlural:         "Storage Box Snapshots",
 	ShortDescription:           "Delete a Storage Box Snapshot",
@@ -25,7 +25,7 @@ var DeleteCmd = base.DeleteCmd{
 		}
 	},
 
-	FetchFunc: func(s state.State, _ *cobra.Command, args []string) (base.FetchFunc, error) {
+	FetchFunc: func(s state.State, _ *cobra.Command, args []string) (base.FetchFunc[*hcloud.StorageBoxSnapshot], error) {
 		storageBox, _, err := s.Client().StorageBox().Get(s, args[0])
 		if err != nil {
 			return nil, err
@@ -33,13 +33,12 @@ var DeleteCmd = base.DeleteCmd{
 		if storageBox == nil {
 			return nil, fmt.Errorf("Storage Box not found: %s", args[0])
 		}
-		return func(s state.State, _ *cobra.Command, idOrName string) (any, *hcloud.Response, error) {
+		return func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.StorageBoxSnapshot, *hcloud.Response, error) {
 			return s.Client().StorageBox().GetSnapshot(s, storageBox, idOrName)
 		}, nil
 	},
 
-	Delete: func(s state.State, _ *cobra.Command, resource any) (*hcloud.Action, error) {
-		snapshot := resource.(*hcloud.StorageBoxSnapshot)
+	Delete: func(s state.State, _ *cobra.Command, snapshot *hcloud.StorageBoxSnapshot) (*hcloud.Action, error) {
 		result, _, err := s.Client().StorageBox().DeleteSnapshot(s, snapshot)
 		return result.Action, err
 	},

--- a/internal/cmd/storagebox/snapshot/update.go
+++ b/internal/cmd/storagebox/snapshot/update.go
@@ -13,12 +13,12 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.StorageBoxSnapshot]{
 	ResourceNameSingular:       "Storage Box Snapshot",
 	ShortDescription:           "Update a Storage Box Snapshot",
 	NameSuggestions:            func(c hcapi2.Client) func() []string { return c.StorageBox().Names },
 	PositionalArgumentOverride: []string{"storage-box", "snapshot"},
-	FetchWithArgs: func(s state.State, _ *cobra.Command, args []string) (any, *hcloud.Response, error) {
+	FetchWithArgs: func(s state.State, _ *cobra.Command, args []string) (*hcloud.StorageBoxSnapshot, *hcloud.Response, error) {
 		storageBox, _, err := s.Client().StorageBox().Get(s, args[0])
 		if err != nil {
 			return nil, nil, err
@@ -32,8 +32,7 @@ var UpdateCmd = base.UpdateCmd{
 		cmd.Flags().String("description", "", "Description of the Storage Box Snapshot")
 		cmd.MarkFlagsOneRequired("description")
 	},
-	Update: func(s state.State, cmd *cobra.Command, resource interface{}, _ map[string]pflag.Value) error {
-		snapshot := resource.(*hcloud.StorageBoxSnapshot)
+	Update: func(s state.State, cmd *cobra.Command, snapshot *hcloud.StorageBoxSnapshot, _ map[string]pflag.Value) error {
 		var opts hcloud.StorageBoxSnapshotUpdateOpts
 		if cmd.Flags().Changed("description") {
 			description, _ := cmd.Flags().GetString("description")

--- a/internal/cmd/storagebox/subaccount/delete.go
+++ b/internal/cmd/storagebox/subaccount/delete.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.StorageBoxSubaccount]{
 	ResourceNameSingular:       "Storage Box Subaccount",
 	ResourceNamePlural:         "Storage Box Subaccounts",
 	ShortDescription:           "Delete a Storage Box Subaccount",
@@ -25,7 +25,7 @@ var DeleteCmd = base.DeleteCmd{
 		}
 	},
 
-	FetchFunc: func(s state.State, _ *cobra.Command, args []string) (base.FetchFunc, error) {
+	FetchFunc: func(s state.State, _ *cobra.Command, args []string) (base.FetchFunc[*hcloud.StorageBoxSubaccount], error) {
 		storageBox, _, err := s.Client().StorageBox().Get(s, args[0])
 		if err != nil {
 			return nil, err
@@ -33,13 +33,12 @@ var DeleteCmd = base.DeleteCmd{
 		if storageBox == nil {
 			return nil, fmt.Errorf("Storage Box not found: %s", args[0])
 		}
-		return func(s state.State, _ *cobra.Command, idOrName string) (any, *hcloud.Response, error) {
+		return func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.StorageBoxSubaccount, *hcloud.Response, error) {
 			return s.Client().StorageBox().GetSubaccount(s, storageBox, idOrName)
 		}, nil
 	},
 
-	Delete: func(s state.State, _ *cobra.Command, resource any) (*hcloud.Action, error) {
-		subaccount := resource.(*hcloud.StorageBoxSubaccount)
+	Delete: func(s state.State, _ *cobra.Command, subaccount *hcloud.StorageBoxSubaccount) (*hcloud.Action, error) {
 		result, _, err := s.Client().StorageBox().DeleteSubaccount(s, subaccount)
 		return result.Action, err
 	},

--- a/internal/cmd/storagebox/subaccount/update.go
+++ b/internal/cmd/storagebox/subaccount/update.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.StorageBoxSubaccount]{
 	ResourceNameSingular: "Storage Box Subaccount",
 	ShortDescription:     "Update a Storage Box Subaccount",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.StorageBox().Names },
@@ -25,7 +25,7 @@ var UpdateCmd = base.UpdateCmd{
 		}
 	},
 	PositionalArgumentOverride: []string{"storage-box", "subaccount"},
-	FetchWithArgs: func(s state.State, _ *cobra.Command, args []string) (any, *hcloud.Response, error) {
+	FetchWithArgs: func(s state.State, _ *cobra.Command, args []string) (*hcloud.StorageBoxSubaccount, *hcloud.Response, error) {
 		storageBoxIDOrName, subaccountIDOrName := args[0], args[1]
 		storageBox, _, err := s.Client().StorageBox().Get(s, storageBoxIDOrName)
 		if err != nil {
@@ -40,8 +40,7 @@ var UpdateCmd = base.UpdateCmd{
 		cmd.Flags().String("description", "", "Description of the Storage Box Snapshot")
 		cmd.MarkFlagsOneRequired("description")
 	},
-	Update: func(s state.State, cmd *cobra.Command, resource interface{}, _ map[string]pflag.Value) error {
-		subaccount := resource.(*hcloud.StorageBoxSubaccount)
+	Update: func(s state.State, cmd *cobra.Command, subaccount *hcloud.StorageBoxSubaccount, _ map[string]pflag.Value) error {
 		var opts hcloud.StorageBoxSubaccountUpdateOpts
 		if cmd.Flags().Changed("description") {
 			description, _ := cmd.Flags().GetString("description")

--- a/internal/cmd/storagebox/update.go
+++ b/internal/cmd/storagebox/update.go
@@ -11,18 +11,17 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.StorageBox]{
 	ResourceNameSingular: "Storage Box",
 	ShortDescription:     "Update a Storage Box",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.StorageBox().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (any, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.StorageBox, *hcloud.Response, error) {
 		return s.Client().StorageBox().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Storage Box name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		storageBox := resource.(*hcloud.StorageBox)
+	Update: func(s state.State, _ *cobra.Command, storageBox *hcloud.StorageBox, flags map[string]pflag.Value) error {
 		opts := hcloud.StorageBoxUpdateOpts{
 			Name: flags["name"].String(),
 		}

--- a/internal/cmd/volume/delete.go
+++ b/internal/cmd/volume/delete.go
@@ -9,16 +9,15 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Volume]{
 	ResourceNameSingular: "Volume",
 	ResourceNamePlural:   "Volumes",
 	ShortDescription:     "Delete a Volume",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Volume().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Volume, *hcloud.Response, error) {
 		return s.Client().Volume().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		volume := resource.(*hcloud.Volume)
+	Delete: func(s state.State, _ *cobra.Command, volume *hcloud.Volume) (*hcloud.Action, error) {
 		_, err := s.Client().Volume().Delete(s, volume)
 		return nil, err
 	},

--- a/internal/cmd/volume/update.go
+++ b/internal/cmd/volume/update.go
@@ -10,22 +10,21 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var UpdateCmd = base.UpdateCmd{
+var UpdateCmd = base.UpdateCmd[*hcloud.Volume]{
 	ResourceNameSingular: "Volume",
 	ShortDescription:     "Update a Volume",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Volume().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Volume, *hcloud.Response, error) {
 		return s.Client().Volume().Get(s, idOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
 		cmd.Flags().String("name", "", "Volume name")
 	},
-	Update: func(s state.State, _ *cobra.Command, resource interface{}, flags map[string]pflag.Value) error {
-		floatingIP := resource.(*hcloud.Volume)
+	Update: func(s state.State, _ *cobra.Command, volume *hcloud.Volume, flags map[string]pflag.Value) error {
 		updOpts := hcloud.VolumeUpdateOpts{
 			Name: flags["name"].String(),
 		}
-		_, _, err := s.Client().Volume().Update(s, floatingIP, updOpts)
+		_, _, err := s.Client().Volume().Update(s, volume, updOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/zone/delete.go
+++ b/internal/cmd/zone/delete.go
@@ -12,12 +12,12 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-var DeleteCmd = base.DeleteCmd{
+var DeleteCmd = base.DeleteCmd[*hcloud.Zone]{
 	ResourceNameSingular: "Zone",
 	ResourceNamePlural:   "Zones",
 	ShortDescription:     "Delete a Zone",
 	NameSuggestions:      func(c hcapi2.Client) func() []string { return c.Zone().Names },
-	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (interface{}, *hcloud.Response, error) {
+	Fetch: func(s state.State, _ *cobra.Command, idOrName string) (*hcloud.Zone, *hcloud.Response, error) {
 		idOrName, err := util.ParseZoneIDOrName(idOrName)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to convert Zone name to ascii: %w", err)
@@ -25,8 +25,7 @@ var DeleteCmd = base.DeleteCmd{
 
 		return s.Client().Zone().Get(s, idOrName)
 	},
-	Delete: func(s state.State, _ *cobra.Command, resource interface{}) (*hcloud.Action, error) {
-		zone := resource.(*hcloud.Zone)
+	Delete: func(s state.State, _ *cobra.Command, zone *hcloud.Zone) (*hcloud.Action, error) {
 		res, _, err := s.Client().Zone().Delete(s, zone)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR makes the remaining base commands generic, cleaning up the code and preventing casting errors.