### PR TITLE
ci(mise): go backend no longer experimental

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,3 @@ go = "1.25.5"
 "github:goreleaser/goreleaser" = "v2.13.1"
 "github:anchore/quill" = "v0.5.1"
 "github:jstemmer/go-junit-report" = "v2.1.0"
-
-[settings]
-# Experimental features are needed for the Go backend
-experimental = true


### PR DESCRIPTION
The `go` backend is no longer experimental: https://github.com/jdx/mise/releases/tag/v2025.10.11