### PR TITLE
ci: automatically update mise version in GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - name: Run GoReleaser
         run: goreleaser release --clean --snapshot --skip=sign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - name: Run gofmt
         run: diff -u <(echo -n) <(gofmt -d -s .)
@@ -38,7 +38,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - name: Run tests
         run: go test -coverpkg=./internal/... -coverprofile=coverage.txt -v -race ./...
@@ -63,7 +63,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - uses: hetznercloud/tps-action@main
 
@@ -92,7 +92,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - name: Delete old generated files
         run: find . -name 'zz_*.go' -delete
@@ -115,7 +115,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - name: Run go mod tidy
         run: go mod tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@v3
         with:
-          version: 2025.5.9
+          version: 2025.5.9 # renovate: datasource=github-releases depName=jdx/mise
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
We accidentally pinned an old version of mise by not including a comment for renovate to update the version.