### PR TITLE
feat(server): deprecate datacenter column

### DIFF
--- a/internal/cmd/server/list.go
+++ b/internal/cmd/server/list.go
@@ -93,7 +93,6 @@ var ListCmd = &base.ListCmd[*hcloud.Server, schema.Server]{
 					return server.Datacenter.Name
 				}
 				return "-"
-
 			}).
 			AddFieldFn("location", func(server *hcloud.Server) string {
 				return server.Location.Name
@@ -140,7 +139,8 @@ var ListCmd = &base.ListCmd[*hcloud.Server, schema.Server]{
 					return "-"
 				}
 				return server.PlacementGroup.Name
-			})
+			}).
+			MarkFieldAsDeprecated("datacenter", "The datacenter column is deprecated. Use location column instead.")
 	},
 
 	Schema: hcloud.SchemaFromServer,


### PR DESCRIPTION
This marks the `datacenter` column for `hcloud server list` as deprecated and outputs a warning if it is used.
Note: Even though Primary IPs have the datacenter property as well, the column is entirely missing in `hcloud primary-ip list`.