### PR TITLE
docs: fix snapshot -> subaccount

### DIFF
--- a/docs/reference/manual/hcloud_storage-box_subaccount_update.md
+++ b/docs/reference/manual/hcloud_storage-box_subaccount_update.md
@@ -17,7 +17,7 @@ hcloud storage-box subaccount update [options] <storage-box> <subaccount>
 ### Options
 
 ```
-      --description string   Description of the Storage Box Snapshot
+      --description string   Description of the Storage Box Subaccount
   -h, --help                 help for update
 ```
 

--- a/internal/cmd/storagebox/subaccount/update.go
+++ b/internal/cmd/storagebox/subaccount/update.go
@@ -37,7 +37,7 @@ var UpdateCmd = base.UpdateCmd[*hcloud.StorageBoxSubaccount]{
 		return s.Client().StorageBox().GetSubaccount(s, storageBox, subaccountIDOrName)
 	},
 	DefineFlags: func(cmd *cobra.Command) {
-		cmd.Flags().String("description", "", "Description of the Storage Box Snapshot")
+		cmd.Flags().String("description", "", "Description of the Storage Box Subaccount")
 		cmd.MarkFlagsOneRequired("description")
 	},
 	Update: func(s state.State, cmd *cobra.Command, subaccount *hcloud.StorageBoxSubaccount, _ map[string]pflag.Value) error {


### PR DESCRIPTION
Flag description had "Snapshot" instead of "Subaccount" in `hcloud storage-box subaccount update`