### PR TITLE
ci: ignore spec reference links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -35,6 +35,8 @@ jobs:
             --exclude 'github.com'
             --exclude '169.254.169.254'
             --exclude 'https://docs.hetzner.cloud/changelog#new-product'
+            --exclude 'https://docs.hetzner.cloud/reference/cloud#'
+            --exclude 'https://docs.hetzner.cloud/reference/hetzner#'
             --exclude 'https://style-guide.europa.eu/en/content/-/isg/topic'
             --exclude 'https://www.hetzner.com/news/arm64-cloud'
             '**/*.md'


### PR DESCRIPTION
The spec reference anchors are no longer generated server side, lychee therefore cannot check them.

Ignore all the reference links until a better solution is found.