### PR TITLE
Add option to use proxy

### DIFF
--- a/internal/state/config/options.go
+++ b/internal/state/config/options.go
@@ -169,6 +169,15 @@ var (
 		nil,
 	)
 
+	OptionProxy = newOpt(
+		"proxy",
+		"A proxy url to use",
+		"",
+		DefaultPreferenceFlags,
+		nil,
+		nil,
+	)
+
 	OptionQuiet = newOpt(
 		"quiet",
 		"If true, only print error messages",

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -133,6 +134,18 @@ func (c *state) newClient() (hcapi2.Client, error) {
 		opts = append(opts, hcloud.WithPollOpts(hcloud.PollOpts{
 			BackoffFunc: customPollBackoffFunc(),
 		}))
+	}
+
+	proxyUrlStr, err := config.OptionProxy.Get(c.config)
+	if err != nil {
+		return nil, err
+	}
+	if len(proxyUrlStr) > 0 {
+		proxyUrl, err := url.Parse(proxyUrlStr)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, hcloud.WithProxy(proxyUrl))
 	}
 
 	return hcapi2.NewClient(opts...), nil


### PR DESCRIPTION
Adds an option to the CLI that allows specifying a proxy to use; Requires https://github.com/hetznercloud/hcloud-go/pull/838