### PR TITLE
feat(load-balancer): support --http-timeout-idle flag

### DIFF
--- a/docs/reference/manual/hcloud_load-balancer_add-service.md
+++ b/docs/reference/manual/hcloud_load-balancer_add-service.md
@@ -26,6 +26,7 @@ hcloud load-balancer add-service [options] (--protocol http | --protocol tcp --l
       --http-cookie-name string                  Sticky Sessions: Cookie Name we set
       --http-redirect-http                       Redirect all traffic on port 80 to port 443 (true, false)
       --http-sticky-sessions                     Enable Sticky Sessions (true, false)
+      --http-timeout-idle duration               Idle timeout for HTTP connections (30s-300s)
       --listen-port int                          Listen port of the service
       --protocol string                          Protocol of the service (required)
       --proxy-protocol                           Enable proxyprotocol (true, false)

--- a/docs/reference/manual/hcloud_load-balancer_update-service.md
+++ b/docs/reference/manual/hcloud_load-balancer_update-service.md
@@ -26,6 +26,7 @@ hcloud load-balancer update-service [options] --listen-port <1-65535> <load-bala
       --http-cookie-name string                  Sticky Sessions: Cookie Name which will be set
       --http-redirect-http                       Enable or disable redirect all traffic on port 80 to port 443 (true, false)
       --http-sticky-sessions                     Enable or disable (with --http-sticky-sessions=false) Sticky Sessions (true, false)
+      --http-timeout-idle duration               Idle timeout for HTTP connections (30s-300s)
       --listen-port int                          The listen port of the service that you want to update (required)
       --protocol string                          The protocol to use for load balancing traffic
       --proxy-protocol                           Enable or disable (with --proxy-protocol=false) Proxy Protocol (true, false)

--- a/internal/cmd/loadbalancer/add_service.go
+++ b/internal/cmd/loadbalancer/add_service.go
@@ -34,6 +34,7 @@ var AddServiceCmd = base.Cmd{
 		cmd.Flags().Duration("http-cookie-lifetime", 0, "Sticky Sessions: Lifetime of the cookie")
 		cmd.Flags().StringSlice("http-certificates", []string{}, "IDs or names of Certificates which should be attached to this Load Balancer")
 		cmd.Flags().Bool("http-redirect-http", false, "Redirect all traffic on port 80 to port 443 (true, false)")
+		cmd.Flags().Duration("http-timeout-idle", 0, "Idle timeout for HTTP connections (30s-300s)")
 
 		cmd.Flags().String("health-check-protocol", "", "The protocol the health check is performed over")
 		cmd.Flags().Int("health-check-port", 0, "The port the health check is performed over")
@@ -91,6 +92,7 @@ var AddServiceCmd = base.Cmd{
 		httpCookieName, _ := cmd.Flags().GetString("http-cookie-name")
 		httpCookieLifetime, _ := cmd.Flags().GetDuration("http-cookie-lifetime")
 		httpRedirect, _ := cmd.Flags().GetBool("http-redirect-http")
+		httpTimeoutIdle, _ := cmd.Flags().GetDuration("http-timeout-idle")
 
 		loadBalancer, _, err := s.Client().LoadBalancer().Get(s, idOrName)
 		if err != nil {
@@ -123,6 +125,10 @@ var AddServiceCmd = base.Cmd{
 			if httpCookieLifetime != 0 {
 				opts.HTTP.CookieLifetime = &httpCookieLifetime
 			}
+			if httpTimeoutIdle != 0 {
+				opts.HTTP.TimeoutIdle = &httpTimeoutIdle
+			}
+
 			for _, idOrName := range httpCertificates {
 				cert, _, err := s.Client().Certificate().Get(s, idOrName)
 				if err != nil {

--- a/internal/cmd/loadbalancer/add_service_test.go
+++ b/internal/cmd/loadbalancer/add_service_test.go
@@ -31,6 +31,7 @@ func TestAddService(t *testing.T) {
 			HTTP: &hcloud.LoadBalancerAddServiceOptsHTTP{
 				StickySessions: hcloud.Ptr(false),
 				RedirectHTTP:   hcloud.Ptr(false),
+				TimeoutIdle:    hcloud.Ptr(60 * time.Second),
 			},
 			Proxyprotocol: hcloud.Ptr(false),
 		}).
@@ -39,7 +40,7 @@ func TestAddService(t *testing.T) {
 		WaitForActions(gomock.Any(), gomock.Any(), &hcloud.Action{ID: 123}).
 		Return(nil)
 
-	out, errOut, err := fx.Run(cmd, []string{"123", "--protocol", "http", "--listen-port", "80", "--destination-port", "8080"})
+	out, errOut, err := fx.Run(cmd, []string{"123", "--protocol", "http", "--listen-port", "80", "--destination-port", "8080", "--http-timeout-idle", "60s"})
 
 	expOut := "Service was added to Load Balancer 123\n"
 

--- a/internal/cmd/loadbalancer/describe.go
+++ b/internal/cmd/loadbalancer/describe.go
@@ -76,6 +76,7 @@ var DescribeCmd = base.DescribeCmd[*hcloud.LoadBalancer]{
 				fmt.Fprintf(out, "    Destination Port:\t%d\n", service.DestinationPort)
 				fmt.Fprintf(out, "    Proxy Protocol:\t%s\n", util.YesNo(service.Proxyprotocol))
 				if service.Protocol != hcloud.LoadBalancerServiceProtocolTCP {
+					fmt.Fprintf(out, "    Timeout Idle:\t%vs\n", service.HTTP.TimeoutIdle.Seconds())
 					fmt.Fprintf(out, "    Sticky Sessions:\t%s\n", util.YesNo(service.HTTP.StickySessions))
 					if service.HTTP.StickySessions {
 						fmt.Fprintf(out, "    Sticky Cookie Name:\t%s\n", service.HTTP.CookieName)

--- a/internal/cmd/loadbalancer/describe_test.go
+++ b/internal/cmd/loadbalancer/describe_test.go
@@ -51,6 +51,35 @@ func TestDescribe(t *testing.T) {
 		Algorithm: hcloud.LoadBalancerAlgorithm{
 			Type: hcloud.LoadBalancerAlgorithmTypeLeastConnections,
 		},
+		Services: []hcloud.LoadBalancerService{
+			{
+				Protocol:        hcloud.LoadBalancerServiceProtocolHTTP,
+				ListenPort:      80,
+				DestinationPort: 8080,
+				Proxyprotocol:   true,
+				HTTP: hcloud.LoadBalancerServiceHTTP{
+					TimeoutIdle:    60 * time.Second,
+					StickySessions: true,
+					CookieName:     "my-cookie",
+					CookieLifetime: 5 * time.Minute,
+					RedirectHTTP:   true,
+				},
+				HealthCheck: hcloud.LoadBalancerServiceHealthCheck{
+					Protocol: hcloud.LoadBalancerServiceProtocolHTTP,
+					Port:     8080,
+					Timeout:  10 * time.Second,
+					Interval: 15 * time.Second,
+					Retries:  3,
+					HTTP: &hcloud.LoadBalancerServiceHealthCheckHTTP{
+						Domain:      "example.com",
+						Path:        "/health",
+						Response:    "OK",
+						StatusCodes: []string{"200", "201"},
+						TLS:         true,
+					},
+				},
+			},
+		},
 		IncludedTraffic: 20 * util.Tebibyte,
 		IngoingTraffic:  10 * util.Tebibyte,
 		OutgoingTraffic: 10 * util.Tebibyte,
@@ -87,7 +116,24 @@ Load Balancer Type:
   Max assigned Certificates:  10
 
 Services:
-  No services
+  - Protocol:                http
+    Listen Port:             80
+    Destination Port:        8080
+    Proxy Protocol:          yes
+    Timeout Idle:            60s
+    Sticky Sessions:         yes
+    Sticky Cookie Name:      my-cookie
+    Sticky Cookie Lifetime:  300s
+    Health Check:
+      Protocol:      http
+      Timeout:       10s
+      Interval:      every 15s
+      Retries:       3
+      HTTP Domain:   example.com
+      HTTP Path:     /health
+      Response:      OK
+      TLS:           yes
+      Status Codes:  [200 201]
 
 Targets:
   No targets

--- a/internal/cmd/loadbalancer/update_service.go
+++ b/internal/cmd/loadbalancer/update_service.go
@@ -36,6 +36,7 @@ var UpdateServiceCmd = base.Cmd{
 		cmd.Flags().String("http-cookie-name", "", "Sticky Sessions: Cookie Name which will be set")
 		cmd.Flags().Duration("http-cookie-lifetime", 0, "Sticky Sessions: Lifetime of the cookie")
 		cmd.Flags().StringSlice("http-certificates", []string{}, "IDs or names of Certificates which should be attached to this Load Balancer")
+		cmd.Flags().Duration("http-timeout-idle", 0, "Idle timeout for HTTP connections (30s-300s)")
 
 		cmd.Flags().String("health-check-protocol", "", "The protocol the health check is performed over")
 		cmd.Flags().Int("health-check-port", 0, "The port the health check is performed over")
@@ -102,6 +103,10 @@ var UpdateServiceCmd = base.Cmd{
 		if cmd.Flag("http-cookie-lifetime").Changed {
 			cookieLifetime, _ := cmd.Flags().GetDuration("http-cookie-lifetime")
 			opts.HTTP.CookieLifetime = &cookieLifetime
+		}
+		if cmd.Flag("http-timeout-idle").Changed {
+			timeoutIdle, _ := cmd.Flags().GetDuration("http-timeout-idle")
+			opts.HTTP.TimeoutIdle = &timeoutIdle
 		}
 		if cmd.Flag("http-certificates").Changed {
 			certificates, _ := cmd.Flags().GetStringSlice("http-certificates")

--- a/internal/cmd/loadbalancer/update_service_test.go
+++ b/internal/cmd/loadbalancer/update_service_test.go
@@ -37,6 +37,7 @@ func TestUpdateService(t *testing.T) {
 				CookieName:     hcloud.Ptr("test"),
 				CookieLifetime: hcloud.Ptr(10 * time.Minute),
 				Certificates:   []*hcloud.Certificate{{ID: 1}},
+				TimeoutIdle:    hcloud.Ptr(60 * time.Second),
 			},
 			HealthCheck: &hcloud.LoadBalancerUpdateServiceOptsHealthCheck{
 				Protocol: hcloud.LoadBalancerServiceProtocolTCP,
@@ -69,6 +70,7 @@ func TestUpdateService(t *testing.T) {
 		"--http-cookie-name", "test",
 		"--http-cookie-lifetime", "10m",
 		"--http-certificates", "1",
+		"--http-timeout-idle", "60s",
 		"--health-check-protocol", "tcp",
 		"--health-check-port", "8080",
 		"--health-check-interval", "10s",


### PR DESCRIPTION
Add `--http-timeout-idle` flag to load balancer service commands; adapt `describe` to display `TimeoutIdle` for HTTP services.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-30-load-balancers-http-idle-timeout-can-now-be-configured) for more information.