### PR TITLE
feat(primary-ip): `--assignee-type` is optional when creating a Primary IP

### DIFF
--- a/docs/reference/manual/hcloud_primary-ip_create.md
+++ b/docs/reference/manual/hcloud_primary-ip_create.md
@@ -9,6 +9,14 @@ Create a Primary IP.
 The --datacenter flag is deprecated. Use --location or --assignee-id instead.
 See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
 
+The --assignee-type flag will be required together with the --assignee-id flag. Using 
+the default value (server) for the --assignee-type flag is deprecated. Consider 
+explicitly setting the --assignee-type flag.
+
+See https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned
+and https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional.
+
+
 ```
 hcloud primary-ip create [options] --type <ipv4|ipv6> --name <name>
 ```

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -71,13 +71,21 @@ See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.`,
 		}
 
 		createOpts := hcloud.PrimaryIPCreateOpts{
-			Type:         hcloud.PrimaryIPType(typ),
-			Name:         name,
-			AssigneeType: assigneeType,
-			Labels:       labels,
+			Type:   hcloud.PrimaryIPType(typ),
+			Name:   name,
+			Labels: labels,
 		}
 		if assigneeID != 0 {
 			createOpts.AssigneeID = &assigneeID
+			if !cmd.Flags().Changed("assignee-type") {
+				cmd.PrintErrln(
+					"Warning: " +
+						"The --assignee-type flag will soon be required together" +
+						"with the --assignee-id flag. Consider explicitly setting " +
+						"the --assignee-type flag.",
+				)
+			}
+			createOpts.AssigneeType = assigneeType
 		}
 		if cmd.Flags().Changed("auto-delete") {
 			createOpts.AutoDelete = &autoDelete

--- a/internal/cmd/primaryip/create.go
+++ b/internal/cmd/primaryip/create.go
@@ -22,7 +22,15 @@ var CreateCmd = base.CreateCmd[*hcloud.PrimaryIP]{
 			Long: `Create a Primary IP.
 
 The --datacenter flag is deprecated. Use --location or --assignee-id instead.
-See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.`,
+See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.
+
+The --assignee-type flag will be required together with the --assignee-id flag. Using 
+the default value (server) for the --assignee-type flag is deprecated. Consider 
+explicitly setting the --assignee-type flag.
+
+See https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned
+and https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional.
+`,
 			TraverseChildren:      true,
 			DisableFlagsInUseLine: true,
 		}
@@ -80,9 +88,10 @@ See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.`,
 			if !cmd.Flags().Changed("assignee-type") {
 				cmd.PrintErrln(
 					"Warning: " +
-						"The --assignee-type flag will soon be required together" +
-						"with the --assignee-id flag. Consider explicitly setting " +
-						"the --assignee-type flag.",
+						"The --assignee-type flag will be required together " +
+						"with the --assignee-id flag and will no longer default " +
+						"to 'server'. Consider explicitly setting the " +
+						"--assignee-type flag.",
 				)
 			}
 			createOpts.AssigneeType = assigneeType

--- a/internal/cmd/primaryip/create_test.go
+++ b/internal/cmd/primaryip/create_test.go
@@ -37,12 +37,11 @@ func TestCreate(t *testing.T) {
 		Create(
 			gomock.Any(),
 			hcloud.PrimaryIPCreateOpts{
-				Name:         "my-ip",
-				Type:         "ipv4",
-				Location:     "fsn1",
-				Labels:       map[string]string{"foo": "bar"},
-				AssigneeType: "server",
-				AutoDelete:   hcloud.Ptr(true),
+				Name:       "my-ip",
+				Type:       "ipv4",
+				Location:   "fsn1",
+				Labels:     map[string]string{"foo": "bar"},
+				AutoDelete: hcloud.Ptr(true),
 			},
 		).
 		Return(
@@ -107,12 +106,11 @@ func TestCreateJSON(t *testing.T) {
 		Create(
 			gomock.Any(),
 			hcloud.PrimaryIPCreateOpts{
-				Name:         "my-ip",
-				Type:         "ipv4",
-				Location:     "fsn1",
-				Labels:       map[string]string{"foo": "bar"},
-				AssigneeType: "server",
-				AutoDelete:   hcloud.Ptr(true),
+				Name:       "my-ip",
+				Type:       "ipv4",
+				Location:   "fsn1",
+				Labels:     map[string]string{"foo": "bar"},
+				AutoDelete: hcloud.Ptr(true),
 			},
 		).
 		Return(


### PR DESCRIPTION
#### Primary IPs `assignee_type` behavior change

As of 1 August 2026, the behavior of the Primary IP `assignee_type` property will change, and will return `unassigned` when the Primary IP is not assigned (when `assignee_id` is `null`). The goal is to eventually assign Primary IPs to other resource types, not only to `server`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned) for more details.

In addition, the Primary IP request body `assignee_type` property of the operation [`POST /v1/primary_ips`](https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip) is now optional. Primary IPs created without `assignee_type` return `server` until 1 August 2026, after this date, its value will be `unassigned`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional) for more details.

