### PR TITLE
fix(cmd): Change tense for deletion of active context

### DIFF
--- a/internal/cmd/context/delete.go
+++ b/internal/cmd/context/delete.go
@@ -34,7 +34,7 @@ func runDelete(s state.State, _ *cobra.Command, args []string) error {
 		return fmt.Errorf("context not found: %v", name)
 	}
 	if cfg.ActiveContext() == context {
-		_, _ = fmt.Fprintln(os.Stderr, "Warning: You are deleting the currently active context. Please select a new active context.")
+		_, _ = fmt.Fprintln(os.Stderr, "Warning: You deleted the currently active context. Please select a new active context.")
 		cfg.SetActiveContext(nil)
 	}
 	config.RemoveContext(cfg, context)

--- a/internal/cmd/context/delete_test.go
+++ b/internal/cmd/context/delete_test.go
@@ -37,7 +37,7 @@ token = "super secret token"
 			name:   "delete active context",
 			args:   []string{"my-context"},
 			config: testConfig,
-			expErr: "Warning: You are deleting the currently active context. Please select a new active context.\n",
+			expErr: "Warning: You deleted the currently active context. Please select a new active context.\n",
 			expOut: `active_context = ""
 
 [[contexts]]


### PR DESCRIPTION
"You are deleting" implies that I can abort the action somehow. In other user interfaces, it's common to end sentences like this with "Are you sure?". Given that the hcloud CLI doesn't do this and happily deletes the context, I changed the wording to indicate that the action was executed.