### PR TITLE
refactor(base): rename Experimental to Configure

### DIFF
--- a/internal/cmd/base/change_protection.go
+++ b/internal/cmd/base/change_protection.go
@@ -53,8 +53,8 @@ type ChangeProtectionCmds[T, Opts any] struct {
 	// IDOrName is used to retrieve a string representation of the resource
 	IDOrName func(resource T) string
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 func (cpc *ChangeProtectionCmds[T, Opts]) newChangeProtectionCmd(s state.State, enable bool) *cobra.Command {
@@ -133,8 +133,8 @@ func (cpc *ChangeProtectionCmds[T, Opts]) newChangeProtectionCmd(s state.State, 
 		cpc.AdditionalFlags(cmd)
 	}
 
-	if cpc.Experimental != nil {
-		cmd = cpc.Experimental(s, cmd)
+	if cpc.Configure != nil {
+		cmd = cpc.Configure(s, cmd)
 	}
 
 	return cmd

--- a/internal/cmd/base/create.go
+++ b/internal/cmd/base/create.go
@@ -19,8 +19,8 @@ type CreateCmd[T any] struct {
 	// It should return the created resource, the schema of the resource and an error.
 	Run           func(state.State, *cobra.Command, []string) (T, any, error)
 	PrintResource func(state.State, *cobra.Command, T)
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 // CobraCommand creates a command that can be registered with cobra.
@@ -78,8 +78,8 @@ func (cc *CreateCmd[T]) CobraCommand(s state.State) *cobra.Command {
 		return nil
 	}
 
-	if cc.Experimental != nil {
-		cmd = cc.Experimental(s, cmd)
+	if cc.Configure != nil {
+		cmd = cc.Configure(s, cmd)
 	}
 	return cmd
 }

--- a/internal/cmd/base/delete.go
+++ b/internal/cmd/base/delete.go
@@ -44,8 +44,8 @@ type DeleteCmd[T any] struct {
 	// [DeleteCmd.FetchWithArgs] and [DeleteCmd.PositionalArgumentOverride] is being used.
 	ValidArgsFunction func(client hcapi2.Client) []cobra.CompletionFunc
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 type FetchFunc[T any] func(s state.State, cmd *cobra.Command, idOrName string) (T, *hcloud.Response, error)
@@ -84,8 +84,8 @@ func (dc *DeleteCmd[T]) CobraCommand(s state.State) *cobra.Command {
 	if dc.AdditionalFlags != nil {
 		dc.AdditionalFlags(cmd)
 	}
-	if dc.Experimental != nil {
-		cmd = dc.Experimental(s, cmd)
+	if dc.Configure != nil {
+		cmd = dc.Configure(s, cmd)
 	}
 	return cmd
 }

--- a/internal/cmd/base/describe.go
+++ b/internal/cmd/base/describe.go
@@ -47,8 +47,8 @@ type DescribeCmd[T any] struct {
 	// [DescribeCmd.FetchWithArgs] and [DescribeCmd.PositionalArgumentOverride] is being used.
 	ValidArgsFunction func(client hcapi2.Client) []cobra.CompletionFunc
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 // CobraCommand creates a command that can be registered with cobra.
@@ -84,8 +84,8 @@ func (dc *DescribeCmd[T]) CobraCommand(s state.State) *cobra.Command {
 		dc.AdditionalFlags(cmd)
 	}
 
-	if dc.Experimental != nil {
-		cmd = dc.Experimental(s, cmd)
+	if dc.Configure != nil {
+		cmd = dc.Configure(s, cmd)
 	}
 
 	return cmd

--- a/internal/cmd/base/labels.go
+++ b/internal/cmd/base/labels.go
@@ -46,8 +46,8 @@ type LabelCmds[T any] struct {
 	// provided as part of the [LabelCmds.ValidArgsFunction].
 	ValidArgsFunction func(client hcapi2.Client) []cobra.CompletionFunc
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 // AddCobraCommand creates a command that can be registered with cobra.
@@ -79,8 +79,8 @@ func (lc *LabelCmds[T]) AddCobraCommand(s state.State) *cobra.Command {
 
 	cmd.Flags().BoolP("overwrite", "o", false, "Overwrite label if it exists already (true, false)")
 
-	if lc.Experimental != nil {
-		cmd = lc.Experimental(s, cmd)
+	if lc.Configure != nil {
+		cmd = lc.Configure(s, cmd)
 	}
 
 	return cmd
@@ -177,8 +177,8 @@ func (lc *LabelCmds[T]) RemoveCobraCommand(s state.State) *cobra.Command {
 
 	cmd.Flags().BoolP("all", "a", false, "Remove all labels")
 
-	if lc.Experimental != nil {
-		cmd = lc.Experimental(s, cmd)
+	if lc.Configure != nil {
+		cmd = lc.Configure(s, cmd)
 	}
 
 	return cmd

--- a/internal/cmd/base/list.go
+++ b/internal/cmd/base/list.go
@@ -56,8 +56,8 @@ type ListCmd[T any, S any] struct {
 	// Can be set if auto-completion is needed (usually if [ListCmd.FetchWithArgs] is used)
 	ValidArgsFunction func(client hcapi2.Client) cobra.CompletionFunc
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 // CobraCommand creates a command that can be registered with cobra.
@@ -92,8 +92,8 @@ func (lc *ListCmd[T, S]) CobraCommand(s state.State) *cobra.Command {
 		lc.AdditionalFlags(cmd)
 	}
 	cmd.Flags().StringSliceP("sort", "s", []string{}, "Determine the sorting of the result")
-	if lc.Experimental != nil {
-		cmd = lc.Experimental(s, cmd)
+	if lc.Configure != nil {
+		cmd = lc.Configure(s, cmd)
 	}
 	return cmd
 }

--- a/internal/cmd/base/set_rdns.go
+++ b/internal/cmd/base/set_rdns.go
@@ -22,8 +22,8 @@ type SetRdnsCmd[T hcloud.RDNSSupporter] struct {
 	Fetch                func(s state.State, cmd *cobra.Command, idOrName string) (T, *hcloud.Response, error)
 	GetDefaultIP         func(resource T) net.IP
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 // CobraCommand creates a command that can be registered with cobra.
@@ -45,8 +45,8 @@ func (rc *SetRdnsCmd[T]) CobraCommand(s state.State) *cobra.Command {
 
 	cmd.Flags().IPP("ip", "i", net.IP{}, "IP address for which the reverse DNS entry should be set")
 
-	if rc.Experimental != nil {
-		cmd = rc.Experimental(s, cmd)
+	if rc.Configure != nil {
+		cmd = rc.Configure(s, cmd)
 	}
 	return cmd
 }

--- a/internal/cmd/base/update.go
+++ b/internal/cmd/base/update.go
@@ -41,8 +41,8 @@ type UpdateCmd[T any] struct {
 	// [UpdateCmd.FetchWithArgs] and [UpdateCmd.PositionalArgumentOverride] is being used.
 	ValidArgsFunction func(client hcapi2.Client) []cobra.CompletionFunc
 
-	// Experimental is a function that will be used to mark the command as experimental.
-	Experimental func(state.State, *cobra.Command) *cobra.Command
+	// Configure is a function that can be used to configure the command directly.
+	Configure func(state.State, *cobra.Command) *cobra.Command
 }
 
 // CobraCommand creates a command that can be registered with cobra.
@@ -72,8 +72,8 @@ func (uc *UpdateCmd[T]) CobraCommand(s state.State) *cobra.Command {
 		},
 	}
 	uc.DefineFlags(cmd)
-	if uc.Experimental != nil {
-		cmd = uc.Experimental(s, cmd)
+	if uc.Configure != nil {
+		cmd = uc.Configure(s, cmd)
 	}
 	return cmd
 }


### PR DESCRIPTION
For some commands we might want to do more than just mark them as experimental, e.g. change their generated description. This PR renames `Experimental` to `Configure` to make it clear that the function can be used to configure all aspects of the command, not only to mark it as experimental.