### PR TITLE
ci: fix failing link check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -31,6 +31,7 @@ jobs:
             --include-fragments
             --exclude 'api.hetzner.cloud'
             --exclude 'api.hetzner.com'
+            --exclude 'asciinema.org'
             --exclude 'codecov.io'
             --exclude 'github.com'
             --exclude '169.254.169.254'


### PR DESCRIPTION
Requests to `asciinema.org` started timing out even though the link is still reachable. Maybe GitHub runners got blocked. This PR adds it to the ignore list so that the CI stops failing.